### PR TITLE
Equals condition support for nested attributes

### DIFF
--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -446,17 +446,20 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * Conditions can also be placed on nested attributes
     *
+    * {{{
     * >>> val smallscaleFarmersTable = Table[Farmer]("smallscale-farmers")
     * >>> LocalDynamoDB.withTable(client)("smallscale-farmers")('name -> S) {
     * ...   val farmerOps = for {
     * ...     _ <- smallscaleFarmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
     * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares < 40L).put(Farmer("McDonald", 156L, Farm(List("gerbil", "hamster"), 20)))
     * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares > 40L).put(Farmer("McDonald", 156L, Farm(List("elephant"), 50)))
+    * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares -> 20L).update('name -> "McDonald", append('farm \ 'animals -> "squirrel"))
     * ...     farmerWithNewStock <- smallscaleFarmersTable.get('name -> "McDonald")
     * ...   } yield farmerWithNewStock
     * ...   Scanamo.exec(client)(farmerOps)
     * ... }
-    * Some(Right(Farmer(McDonald,156,Farm(List(gerbil, hamster),20))))
+    * Some(Right(Farmer(McDonald,156,Farm(List(gerbil, hamster, squirrel),20))))
+    * }}}
     */
   def given[T: ConditionExpression](condition: T) = ConditionalOperation[V,T](name, condition)
 

--- a/scanamo/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
@@ -41,9 +41,15 @@ case class ConditionalOperation[V, T](tableName: String, t: T)(
 
 object ConditionExpression {
   implicit def symbolValueEqualsCondition[V: DynamoFormat] = new ConditionExpression[(Symbol, V)] {
-    val prefix = "equalsCondition"
     override def apply(pair: (Symbol, V))(condition: Option[RequestCondition]): RequestCondition = {
-      val attributeName = AttributeName.of(pair._1)
+      attributeValueEqualsCondition.apply((AttributeName.of(pair._1), pair._2))(condition)
+    }
+  }
+
+  implicit def attributeValueEqualsCondition[V: DynamoFormat] = new ConditionExpression[(AttributeName, V)] {
+    val prefix = "equalsCondition"
+    override def apply(pair: (AttributeName, V))(condition: Option[RequestCondition]): RequestCondition = {
+      val attributeName = pair._1
       RequestCondition(
         s"#${attributeName.placeholder(prefix)} = :conditionAttributeValue",
         attributeName.attributeNames(s"#$prefix"),


### PR DESCRIPTION
Fixes remaining issue in #136. Slight addition to #156, which adds an implicit conversion from `(AttributeName, V)` to `ConditionExpression`, necessary to support nested fields. Not the prettiest code, but I could not find a solution to replace `Symbol, V)` conversion completely.