### PR TITLE
Make space for back-off algorithm

### DIFF
--- a/alpakka/src/main/scala/com/gu/scanamo/ops/AlpakkaInterpreter.scala
+++ b/alpakka/src/main/scala/com/gu/scanamo/ops/AlpakkaInterpreter.scala
@@ -22,6 +22,7 @@ object AlpakkaInterpreter {
           case Query(req) => client.single(JavaRequests.query(req))
           case Update(req) => client.single(JavaRequests.update(req))
           case BatchWrite(req) => client.single(req)
+          case BatchWriteRetry(req) => client.single(req)
           case BatchGet(req) => client.single(req)
           case ConditionalDelete(req) =>
             client.single(JavaRequests.delete(req))

--- a/scanamo/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
@@ -49,6 +49,8 @@ object ScanamoInterpreters {
         client.query(JavaRequests.query(req))
       case BatchWrite(req) =>
         client.batchWriteItem(req)
+      case BatchWriteRetry(req) =>
+        client.batchWriteItem(req)
       case BatchGet(req) =>
         client.batchGetItem(req)
       case Update(req) =>
@@ -98,6 +100,8 @@ object ScanamoInterpreters {
         futureOf(client.queryAsync, JavaRequests.query(req))
       // Overloading means we need explicit parameter types here
       case BatchWrite(req) =>
+        futureOf(client.batchWriteItemAsync(_: BatchWriteItemRequest, _: AsyncHandler[BatchWriteItemRequest, BatchWriteItemResult]), req)
+      case BatchWriteRetry(req) =>
         futureOf(client.batchWriteItemAsync(_: BatchWriteItemRequest, _: AsyncHandler[BatchWriteItemRequest, BatchWriteItemResult]), req)
       case BatchGet(req) =>
         futureOf(client.batchGetItemAsync(_: BatchGetItemRequest, _: AsyncHandler[BatchGetItemRequest, BatchGetItemResult]), req)

--- a/scanamo/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
@@ -12,6 +12,7 @@ final case class ConditionalDelete(req: ScanamoDeleteRequest) extends ScanamoOps
 final case class Scan(req: ScanamoScanRequest) extends ScanamoOpsA[ScanResult]
 final case class Query(req: ScanamoQueryRequest) extends ScanamoOpsA[QueryResult]
 final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
+final case class BatchWriteRetry(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
 final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResult]
 final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResult]
 final case class ConditionalUpdate(req: ScanamoUpdateRequest) extends ScanamoOpsA[Either[ConditionalCheckFailedException, UpdateItemResult]]
@@ -31,6 +32,8 @@ object ScanamoOps {
   def query(req: ScanamoQueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](Query(req))
   def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
     liftF[ScanamoOpsA, BatchWriteItemResult](BatchWrite(req))
+  def batchWriteRetry(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
+    liftF[ScanamoOpsA, BatchWriteItemResult](BatchWriteRetry(req))
   def batchGet(req: BatchGetItemRequest): ScanamoOps[BatchGetItemResult] =
     liftF[ScanamoOpsA, BatchGetItemResult](BatchGet(req))
   def update(req: ScanamoUpdateRequest): ScanamoOps[UpdateItemResult] =


### PR DESCRIPTION
Thought I would try to add support for incomplete writes. Ultimately one will want to decide exactly how to handle unprocessed items at the interpreter level, as the behaviour will depend on the destination monad. 

The cleanest way I can think of is by introducing a new operation in the algebra (`BatchWriteRetry`) that can be treated separately. From there, it is not hard to add back-off with jitter and maximum retries.