### PR TITLE
Add a module to support refined types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,20 @@ lazy val formats = (project in file("formats"))
     doctestTestFramework := DoctestTestFramework.ScalaTest
   )
 
+lazy val refined = (project in file("refined"))
+  .settings(
+    commonSettings,
+    publishingSettings,
+    name := "scanamo-refined"
+  )
+  .settings(
+    libraryDependencies ++= Seq(
+      "eu.timepit" %% "refined" % "0.8.6",
+      "org.scalatest" %% "scalatest" % "3.0.4" % Test
+    )
+  )
+  .dependsOn(formats)
+
 lazy val scanamo = (project in file("scanamo"))
   .settings(
     commonSettings,
@@ -166,7 +180,7 @@ lazy val docs = (project in file("docs"))
   )
   .enablePlugins(MicrositesPlugin, SiteScaladocPlugin, GhpagesPlugin, ScalaUnidocPlugin)
   .disablePlugins(ReleasePlugin)
-  .dependsOn(scanamo % "compile->test", alpakka % "compile")
+  .dependsOn(scanamo % "compile->test", alpakka % "compile", refined % "compile")
 
 
 import ReleaseTransformations._

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -52,3 +52,44 @@ val operations = for {
  
 Scanamo.exec(client)(operations).toList
 ```
+
+### Formats for Refined Types
+
+Scanamo supports Scala refined types via the `scanamo-refined` module, helping you to define custom formats
+for types built using the predicates provided by the [refined](https://github.com/fthomas/refined) project.
+Refined types give an extra layer of type safety to our programs making the compilation fail when we try to
+assign wrong values to them.
+
+To use them in your project you will need to include the dependency in your project:
+
+```
+libraryDependencies += "com.gu.scanamo" %% "scanamo-refined" % "x.y.z"
+```
+
+And then import the support for refined types and define your model:
+
+```tut:silent
+import com.gu.scanamo.refined._
+import eu.timepit.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric._
+
+type PosInt = Int Refined Positive
+
+case class Customer(age: PosInt)
+
+LocalDynamoDB.createTable(client)("Customer")('age -> N)
+```
+
+You just now use it like if the type `PosInt` was natively supported by `scanamo`:
+
+```tut:book
+val customerTable = Table[Customer]("Customer")
+val operations = for {
+  _       <- customerTable.put(Customer(67))
+  results <- customerTable.scan()
+} yield results
+
+Scanamo.exec(client)(operations).toList
+```

--- a/refined/src/main/scala/com/gu/scanamo/refined/package.scala
+++ b/refined/src/main/scala/com/gu/scanamo/refined/package.scala
@@ -1,0 +1,34 @@
+package com.gu.scanamo
+
+import cats.syntax.either._
+
+import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+
+import eu.timepit.refined.api.{RefType, Validate}
+
+package object refined {
+
+  implicit def refTypeDynamoFormat[F[_, _], T, P](
+    implicit
+    baseFormat: DynamoFormat[T],
+    refType: RefType[F],
+    validate: Validate[T, P]
+  ): DynamoFormat[F[T, P]] = new DynamoFormat[F[T, P]] {
+
+    override def default: Option[F[T, P]] = {
+      baseFormat.default.flatMap(refType.refine[P](_).toOption)
+    }
+
+    def read(av: AttributeValue): Either[DynamoReadError, F[T, P]] = {
+      baseFormat.read(av).flatMap { v =>
+        refType.refine[P](v).leftMap(desc => TypeCoercionError(new Exception(desc)))
+      }
+    }
+
+    def write(v: F[T, P]): AttributeValue =
+      baseFormat.write(refType.unwrap(v))
+
+  }
+
+}

--- a/refined/src/test/scala/com/gu/scanamo/refined/RefinedDynamoFormatSpec.scala
+++ b/refined/src/test/scala/com/gu/scanamo/refined/RefinedDynamoFormatSpec.scala
@@ -1,0 +1,43 @@
+package com.gu.scanamo
+package refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.Positive
+
+import com.gu.scanamo.error.TypeCoercionError
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class RefinedDynamoFormatSpec extends FlatSpec with Matchers {
+
+  type PosInt = Int Refined Positive
+
+  "DynamoFormat[PosInt]" should "read a positive integer value" in {
+    val valueToRead = new AttributeValue().withN("10")
+
+    val valueRead = DynamoFormat[PosInt].read(valueToRead)
+    valueRead shouldBe Right(10: PosInt)
+  }
+
+  it should "fail to read non positive integers" in {
+    val valueToRead = new AttributeValue().withN("-234")
+
+    val expectedErrorMsg = "Predicate failed: (-234 > 0)."
+
+    val valueRead = DynamoFormat[PosInt].read(valueToRead)
+    valueRead should matchPattern {
+      case Left(e: TypeCoercionError) if e.t.getMessage == expectedErrorMsg =>
+    }
+  }
+
+  it should "write positive integers" in {
+    val expectedValue = new AttributeValue().withN("123")
+
+    val valueWritten = DynamoFormat[PosInt].write(123)
+
+    valueWritten shouldBe expectedValue
+  }
+
+}


### PR DESCRIPTION
Hi all, hope you find this interesting.

At work we use refined types in some projects so we end up writing wiring (integration?) with other libraries that do not support it. Most of the time the code is as trivial as in this case, so I took the liberty of adding a module to the project to support them so everyone else can also profit from it.