### PR TITLE
Handle the case in which the attribute value is not a map in derived format

### DIFF
--- a/formats/src/test/scala/com/gu/scanamo/DynamoFormatTest.scala
+++ b/formats/src/test/scala/com/gu/scanamo/DynamoFormatTest.scala
@@ -1,0 +1,21 @@
+package com.gu.scanamo
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.gu.scanamo.error.TypeCoercionError
+import org.scalatest.{EitherValues, FunSuite, Matchers}
+
+class DynamoFormatTest extends FunSuite with Matchers with EitherValues {
+
+  test("Handles trying to deserialize something that's not a map to a product") {
+    case class Product(foo: String, bar: Int)
+    DynamoFormat[Product].read(new AttributeValue().withS("bar")).left.value shouldBe a[TypeCoercionError]
+  }
+
+  test("Handles trying to deserialize something that's not a map to a coproduct") {
+    sealed trait CoProduct
+    case class Foo(f1: String) extends CoProduct
+    case class Bar(f2: Int) extends CoProduct
+    DynamoFormat[CoProduct].read(new AttributeValue().withS("bar")).left.value shouldBe a [TypeCoercionError]
+  }
+
+}


### PR DESCRIPTION
Currently this would fail with a null pointer exception:

```scala
case class Thing(foo: String, bar: Int)
DynamoFormat[Thing].read(new AttributeValue().withS("whatevs")) // throws NPE

sealed trait Base
case class Foo(f1: String) extends Base
case class Bar(f2: Int) extends Base
DynamoFormat[Base].read(new AttributeValue().withS("whatevs")) // throws NPE
```

This PR should fix it and return an error.

I can add tests if required.