### PR TITLE
Implement get all with consistent reads

### DIFF
--- a/alpakka/src/main/scala/com/gu/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/com/gu/scanamo/ScanamoAlpakka.scala
@@ -40,6 +40,10 @@ object ScanamoAlpakka {
                              (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.getAll[T](tableName)(keys))
 
+  def getAllWithConsistency[T: DynamoFormat](client: DynamoClient)(tableName: String)(keys: UniqueKeys[_])
+                             (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =
+    exec(client)(ScanamoFree.getAllWithConsistency[T](tableName)(keys))
+
   def delete[T](client: DynamoClient)(tableName: String)(key: UniqueKey[_])
                (implicit ec: ExecutionContext): Future[DeleteItemResult] =
     exec(client)(ScanamoFree.delete(tableName)(key))

--- a/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
@@ -427,6 +427,20 @@ class ScanamoAlpakkaSpec
     }
   }
 
+  it("should get multiple items consistently asynchronously (automatically handling batching)") {
+    LocalDynamoDB.usingTable(client)("asyncFarms")('id -> N) {
+
+      case class Farm(id: Int, name: String)
+      val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
+
+      Scanamo.putAll(client)("asyncFarms")(farms)
+
+      ScanamoAsync.getAllWithConsistency[Farm](client)("asyncFarms")(
+        UniqueKeys(KeyList('id, farms.map(_.id)))
+      ).futureValue should equal(farms.map(Right(_)))
+    }
+  }
+
   it("conditionally put asynchronously") {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)

--- a/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
@@ -152,7 +152,7 @@ class ScanamoAlpakkaSpec
     }
   }
 
-  it("should update asynchornously if a condition holds") {
+  it("should update asynchronously if a condition holds") {
     LocalDynamoDB.usingTable(client)("forecast")('location -> S) {
 
       case class Forecast(location: String, weather: String, equipment: Option[String])

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -162,6 +162,27 @@ object Scanamo {
     : Set[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.getAll(tableName)(keys))
 
+  /**
+    * {{{
+    * >>> case class Farm(animals: List[String])
+    * >>> case class Farmer(name: String, age: Long, farm: Farm)
+    *
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> val client = LocalDynamoDB.client()
+    *
+    * >>> import com.gu.scanamo.query._
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.putAll(client)("farmers")(Set(
+    * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
+    * ...   ))
+    * ...   Scanamo.getAllWithConsistency[Farmer](client)("farmers")(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
+    * ... }
+    * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
+    * }}}
+    */
+  def getAllWithConsistency[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(keys: UniqueKeys[_])
+  : Set[Either[DynamoReadError, T]] =
+    exec(client)(ScanamoFree.getAllWithConsistency(tableName)(keys))
 
   /**
     * Deletes a single item from a table by a unique key

--- a/scanamo/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -41,6 +41,10 @@ object ScanamoAsync {
     (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.getAll[T](tableName)(keys))
 
+  def getAllWithConsistency[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(keys: UniqueKeys[_])
+                             (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =
+    exec(client)(ScanamoFree.getAllWithConsistency[T](tableName)(keys))
+
   def delete[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
     (implicit ec: ExecutionContext): Future[DeleteItemResult] =
     exec(client)(ScanamoFree.delete(tableName)(key))

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -571,6 +571,8 @@ private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](tableName: St
 
   def get(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] =
     ScanamoFree.getWithConsistency[V](tableName)(key)
+  def getAll(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, V]]] =
+    ScanamoFree.getAllWithConsistency[V](tableName)(keys)
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] =
     ScanamoFree.scanConsistent[V](tableName)
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =

--- a/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -128,7 +128,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
     }
   }
 
-  it("should update asynchornously if a condition holds") {
+  it("should update asynchronously if a condition holds") {
     LocalDynamoDB.usingTable(client)("forecast")('location -> S) {
 
       case class Forecast(location: String, weather: String, equipment: Option[String])

--- a/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -403,6 +403,20 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
     }
   }
 
+  it("should get multiple items consistently asynchronously (automatically handling batching)") {
+    LocalDynamoDB.usingTable(client)("asyncFarms")('id -> N) {
+
+      case class Farm(id: Int, name: String)
+      val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
+
+      Scanamo.putAll(client)("asyncFarms")(farms)
+
+      ScanamoAsync.getAllWithConsistency[Farm](client)("asyncFarms")(
+        UniqueKeys(KeyList('id, farms.map(_.id)))
+      ).futureValue should equal(farms.map(Right(_)))
+    }
+  }
+
   it("should return old item after put asynchronously") {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)


### PR DESCRIPTION
Implements [consistent reads](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html) for the `getAll` operation (`getAllWithConistency`).

Note: the tests appear to only test that the `WithConsistency` methods function correctly, and don't directly test that the `KeysAndAttributes.consistentRead` field is set. This could be tested using a test interpreter which would capture the resultant `BatchGetItemRequest` and test that `consistentRead` is set.