### PR TITLE
Allow append/prepend of list values

### DIFF
--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -170,6 +170,25 @@ case class Table[V: DynamoFormat](name: String) {
     * List(Right(Character(James Bond,List(Craig))))
     * }}}
     *
+    * To concatenate a list to the front or end of an existing list, use appendAll/prependAll:
+    *
+    * {{{
+    * >>> case class Fruit(kind: String, sources: List[String])
+    * >>> val fruits = Table[Fruit]("fruits")
+    *
+    * >>> LocalDynamoDB.withTable(client)("fruits")('kind -> S) {
+    * ...   import com.gu.scanamo.syntax._
+    * ...   val operations = for {
+    * ...     _ <- fruits.put(Fruit("watermelon", List("USA")))
+    * ...     _ <- fruits.update('kind -> "watermelon", appendAll('sources -> List("China", "Turkey")))
+    * ...     _ <- fruits.update('kind -> "watermelon", prependAll('sources -> List("Brazil")))
+    * ...     results <- fruits.query('kind -> "watermelon")
+    * ...   } yield results.toList
+    * ...   Scanamo.exec(client)(operations)
+    * ... }
+    * List(Right(Fruit(watermelon,List(Brazil, USA, China, Turkey))))
+    * }}}
+    *
     * Multiple operations can also be performed in one call:
     * {{{
     * >>> case class Foo(name: String, bar: Int, l: List[String])

--- a/scanamo/src/main/scala/com/gu/scanamo/package.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/package.scala
@@ -59,6 +59,10 @@ package object scanamo {
       UpdateExpression.append(fieldValue)
     def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
       UpdateExpression.prepend(fieldValue)
+    def appendAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
+      UpdateExpression.appendAll(fieldValue)
+    def prependAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
+      UpdateExpression.prependAll(fieldValue)
     def add[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
       UpdateExpression.add(fieldValue)
     def delete[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =

--- a/scanamo/src/main/scala/com/gu/scanamo/update/UpdateExpression.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/update/UpdateExpression.scala
@@ -45,6 +45,10 @@ object UpdateExpression {
     AppendExpression(fieldValue._1, fieldValue._2)
   def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
     PrependExpression(fieldValue._1, fieldValue._2)
+  def appendAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
+    AppendAllExpression(fieldValue._1, fieldValue._2)
+  def prependAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
+    PrependAllExpression(fieldValue._1, fieldValue._2)
   def add[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
     AddExpression(fieldValue._1, fieldValue._2)
   def delete[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
@@ -175,6 +179,30 @@ object PrependExpression {
       field.attributeNames(prefix),
       "update",
       DynamoFormat.listFormat[V].write(List(value))
+    ))
+  }
+}
+
+object AppendAllExpression {
+  private val prefix = "updateAppendAll"
+  def apply[V](field: AttributeName, value: List[V])(implicit format: DynamoFormat[V]): UpdateExpression =  {
+    SimpleUpdateExpression(LeafAppendExpression(
+      field.placeholder(prefix),
+      field.attributeNames(prefix),
+      "update",
+      DynamoFormat.listFormat[V].write(value)
+    ))
+  }
+}
+
+object PrependAllExpression {
+  private val prefix = "updatePrependAll"
+  def apply[V](field: AttributeName, value: List[V])(implicit format: DynamoFormat[V]): UpdateExpression = {
+    SimpleUpdateExpression(LeafPrependExpression(
+      field.placeholder(prefix),
+      field.attributeNames(prefix),
+      "update",
+      DynamoFormat.listFormat[V].write(value)
     ))
   }
 }

--- a/scanamo/src/test/scala/com/gu/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/update/UpdateExpressionTest.scala
@@ -3,6 +3,7 @@ package com.gu.scanamo.update
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 import com.gu.scanamo.syntax._
+import scala.collection.JavaConverters._
 
 class UpdateExpressionTest extends org.scalatest.FunSpec
   with org.scalatest.Matchers
@@ -16,7 +17,7 @@ class UpdateExpressionTest extends org.scalatest.FunSpec
       i <- arbitrary[Int]
       si <- arbitrary[Set[Int]]
       l <- arbitrary[List[String]]
-      u <- Gen.oneOf(List(set(s -> i), add(s -> i), remove(s), delete(s -> si), append(s -> l), prepend(s -> l)))
+      u <- Gen.oneOf(List(set(s -> i), add(s -> i), remove(s), delete(s -> si), append(s -> i), prepend(s -> i), appendAll(s -> l), prependAll(s -> l)))
     } yield u
 
   def genNode(level: Int): Gen[UpdateExpression] = for {
@@ -29,7 +30,6 @@ class UpdateExpressionTest extends org.scalatest.FunSpec
       Gen.oneOf(leaf, genNode(level + 1))
     }
   implicit lazy val update: Arbitrary[UpdateExpression] = Arbitrary(genTree(0))
-
 
   it("should have all value placeholders in the expression") {
     check {
@@ -49,4 +49,19 @@ class UpdateExpressionTest extends org.scalatest.FunSpec
     }
   }
 
+  it("append/prepend should wrap scalar values in a list") {
+    check {
+      (s: Symbol, v: String) =>
+        append(s -> v).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == List(v))
+        prepend(s -> v).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == List(v))
+    }
+  }
+
+  it("appendAll/prependAll should take the value as a list") {
+    check {
+      (s: Symbol, l: List[String]) =>
+        appendAll(s -> l).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == l)
+        prependAll(s -> l).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == l)
+    }
+  }
 }


### PR DESCRIPTION
Adds two new functions: `appendList` and `prependList`. Each takes
a list argument and appends or prepends it to an existing value at
the specified attribute name.

The previous methods, `append` and `prepend`, are unchanged: they
take a value, cast it to a list of a single element, and then
append/prepend it. This does not allow for list concatenation;
appending a list would result in a nested list, thus likely causing
any custom deserialization that expected a flat list for the updated
attribute to fail.

I messed around with ways to allow the existing `append` to take either a list or a single argument with varargs and things like that but couldn't get anything working. Since the argument is a tuple I wasn't able to do something clever like overload `def append[V: DynamoFormat](fieldValue: (AttributeName, V*)` or things like that.