### PR TITLE
Fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,5 +28,5 @@ The [website](http://www.scanamo.org) is built using
 [sbt-microsites](https://47deg.github.io/sbt-microsites/). To check 
 documentation changes: 
  * run `makeMicrosite` from the root of SBT
- * run `jekyll serve --incremental --baseurl /scanamo` from `docs/target/site` 
- * Load http://127.0.0.1:4000/scanamo/
+ * run `jekyll serve --incremental --baseurl /` from `docs/target/site`
+ * Load http://127.0.0.1:4000/

--- a/docs/src/main/tut/conditional-operations.md
+++ b/docs/src/main/tut/conditional-operations.md
@@ -44,4 +44,4 @@ LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
 }
 ```
 
-More examples can be found in the [Table ScalaDoc](/scanamo/latest/api/com/gu/scanamo/Table.html#given[T](condition:T)(implicitevidence$2:com.gu.scanamo.query.ConditionExpression[T]):com.gu.scanamo.query.ConditionalOperation[V,T]).
+More examples can be found in the [Table ScalaDoc](/latest/api/com/gu/scanamo/Table.html#given[T](condition:T)(implicitevidence$2:com.gu.scanamo.query.ConditionExpression[T]):com.gu.scanamo.query.ConditionalOperation[V,T]).

--- a/docs/src/main/tut/filters.md
+++ b/docs/src/main/tut/filters.md
@@ -43,4 +43,4 @@ LocalDynamoDB.withTable(client)("Station")('line -> S, 'name -> S) {
 }
 ```
 
-More examples can be found in the [Table ScalaDoc](/scanamo/latest/api/com/gu/scanamo/Table.html#filter[C](condition:C)(implicitevidence$3:com.gu.scanamo.query.ConditionExpression[C]):com.gu.scanamo.TableWithOptions[V]).
+More examples can be found in the [Table ScalaDoc](/latest/api/com/gu/scanamo/Table.html#filter[C](condition:C)(implicitevidence$3:com.gu.scanamo.query.ConditionExpression[C]):com.gu.scanamo.TableWithOptions[V]).

--- a/docs/src/main/tut/operations.md
+++ b/docs/src/main/tut/operations.md
@@ -141,7 +141,7 @@ Scanamo.exec(client)(
 ```
 
 Further examples, showcasing different types of update can be found in the 
-[scaladoc for the `update` method on `Table`](/scanamo/latest/api/com/gu/scanamo/Table.html#update(key:com.gu.scanamo.query.UniqueKey[_],expression:com.gu.scanamo.update.UpdateExpression):com.gu.scanamo.ops.ScanamoOps[Either[com.gu.scanamo.error.DynamoReadError,V]]) 
+[scaladoc for the `update` method on `Table`](/latest/api/com/gu/scanamo/Table.html#update(key:com.gu.scanamo.query.UniqueKey[_],expression:com.gu.scanamo.update.UpdateExpression):com.gu.scanamo.ops.ScanamoOps[Either[com.gu.scanamo.error.DynamoReadError,V]])
 
 ### Scan
 


### PR DESCRIPTION
Many links to the scaladocs were linking to a url with a /scanamo
prefix. However, the main documentation is just hosted at /, causing
broken links.

Ran `grep -r "/scanamo"` to ensure I picked up all the links and built the docs to make sure the links worked now.