### PR TITLE
Use NonEmptySet for key conditions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,8 +166,6 @@ lazy val docs = (project in file("docs"))
     dynamoDBLocalDownloadDir := file(".dynamodb-local"),
     dynamoDBLocalPort := 8042,
 
-    libraryDependencies += "org.typelevel" %% "cats-core" % catsVersion,
-
     tut := tut.dependsOn(startDynamoDBLocal).value,
     stopDynamoDBLocal := stopDynamoDBLocal.triggeredBy(tut).value,
 

--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,8 @@ lazy val docs = (project in file("docs"))
     dynamoDBLocalDownloadDir := file(".dynamodb-local"),
     dynamoDBLocalPort := 8042,
 
+    libraryDependencies += "org.typelevel" %% "cats-core" % catsVersion,
+
     tut := tut.dependsOn(startDynamoDBLocal).value,
     stopDynamoDBLocal := stopDynamoDBLocal.triggeredBy(tut).value,
 

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -12,6 +12,8 @@ has support for putting, getting and deleting in batches
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import cats.data.NonEmptyList
+import cats.kernel.instances.string._
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,8 +31,8 @@ val ops = for {
   _ <- lemmingsTable.putAll(Set(
     Lemming("Walker", 99), Lemming("Blocker", 42), Lemming("Builder", 180)
   ))
-  bLemmings <- lemmingsTable.getAll('role -> Set("Blocker", "Builder"))
-  _ <- lemmingsTable.deleteAll('role -> Set("Walker", "Blocker"))
+  bLemmings <- lemmingsTable.getAll('role -> NonEmptySet.of("Blocker", "Builder"))
+  _ <- lemmingsTable.deleteAll('role -> NonEmptySet.of("Walker", "Blocker"))
   survivors <- lemmingsTable.scan()
 } yield (bLemmings, survivors)
 val (bLemmings, survivors) = Scanamo.exec(client)(ops)

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -12,7 +12,7 @@ has support for putting, getting and deleting in batches
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
-import cats.data.NonEmptyList
+import cats.data.NonEmptySet
 import cats.kernel.instances.string._
 
 import scala.concurrent.duration._

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -12,8 +12,6 @@ has support for putting, getting and deleting in batches
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
-import cats.data.NonEmptySet
-import cats.kernel.instances.string._
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,8 +29,8 @@ val ops = for {
   _ <- lemmingsTable.putAll(Set(
     Lemming("Walker", 99), Lemming("Blocker", 42), Lemming("Builder", 180)
   ))
-  bLemmings <- lemmingsTable.getAll('role -> NonEmptySet.of("Blocker", "Builder"))
-  _ <- lemmingsTable.deleteAll('role -> NonEmptySet.of("Walker", "Blocker"))
+  bLemmings <- lemmingsTable.getAll('role -> keySet("Blocker", "Builder"))
+  _ <- lemmingsTable.deleteAll('role -> keySet("Walker", "Blocker"))
   survivors <- lemmingsTable.scan()
 } yield (bLemmings, survivors)
 val (bLemmings, survivors) = Scanamo.exec(client)(ops)

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -139,11 +139,13 @@ object Scanamo {
     * or with some added syntactic sugar:
     * {{{
     * >>> import com.gu.scanamo.syntax._
+    * >>> import cats.data.NonEmptySet
+    * >>> import cats.kernel.instances.all._
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   Scanamo.putAll(client)("farmers")(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> Set("Boggis", "Bean"))
+    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> NonEmptySet.of("Boggis", "Bean"))
     * ... }
     * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
@@ -153,7 +155,7 @@ object Scanamo {
     * >>> LocalDynamoDB.withTable(client)("doctors")('actor -> S, 'regeneration -> N) {
     * ...   Scanamo.putAll(client)("doctors")(
     * ...     Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> NonEmptySet.of("McCoy" -> 9, "Ecclestone" -> 11))
     * ... }
     * Set(Right(Doctor(McCoy,9)), Right(Doctor(Ecclestone,11)))
     * }}}
@@ -194,16 +196,19 @@ object Scanamo {
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import cats.data.NonEmptySet
+    * >>> import cats.kernel.instances.string._
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> val dataSet = Set(
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
+    * >>> val keySet = NonEmptySet.of("Patty", "Ted", "Jack")
     *
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   Scanamo.putAll(client)("farmers")(dataSet)
-    * ...   Scanamo.deleteAll(client)("farmers")('name -> dataSet.map(_.name))
+    * ...   Scanamo.deleteAll(client)("farmers")('name -> keySet)
     * ...   Scanamo.scan[Farmer](client)("farmers").toList
     * ... }
     * List()

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -138,14 +138,13 @@ object Scanamo {
     * }}}
     * or with some added syntactic sugar:
     * {{{
+    * >>> import com.gu.scanamo._
     * >>> import com.gu.scanamo.syntax._
-    * >>> import cats.data.NonEmptySet
-    * >>> import cats.kernel.instances.all._
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   Scanamo.putAll(client)("farmers")(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> NonEmptySet.of("Boggis", "Bean"))
+    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> keySet("Boggis", "Bean"))
     * ... }
     * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
@@ -155,7 +154,7 @@ object Scanamo {
     * >>> LocalDynamoDB.withTable(client)("doctors")('actor -> S, 'regeneration -> N) {
     * ...   Scanamo.putAll(client)("doctors")(
     * ...     Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> NonEmptySet.of("McCoy" -> 9, "Ecclestone" -> 11))
+    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> keySet("McCoy" -> 9, "Ecclestone" -> 11))
     * ... }
     * Set(Right(Doctor(McCoy,9)), Right(Doctor(Ecclestone,11)))
     * }}}
@@ -216,20 +215,19 @@ object Scanamo {
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import com.gu.scanamo._
     * >>> import com.gu.scanamo.syntax._
-    * >>> import cats.data.NonEmptySet
-    * >>> import cats.kernel.instances.string._
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> val dataSet = Set(
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
-    * >>> val keySet = NonEmptySet.of("Patty", "Ted", "Jack")
+    * >>> val ks = keySet("Patty", "Ted", "Jack")
     *
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   Scanamo.putAll(client)("farmers")(dataSet)
-    * ...   Scanamo.deleteAll(client)("farmers")('name -> keySet)
+    * ...   Scanamo.deleteAll(client)("farmers")('name -> ks)
     * ...   Scanamo.scan[Farmer](client)("farmers").toList
     * ... }
     * List()

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -50,16 +50,19 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import cats.data.NonEmptySet
+    * >>> import cats.kernel.instances.string._
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> val dataSet = Set(
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
+    * >>> val keySet = NonEmptySet.of("Patty", "Ted", "Farmer")
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   val operations = for {
     * ...     _       <- farm.putAll(dataSet)
-    * ...     _       <- farm.deleteAll('name -> dataSet.map(_.name))
+    * ...     _       <- farm.deleteAll('name -> keySet)
     * ...     scanned <- farm.scan
     * ...   } yield scanned.toList
     * ...   Scanamo.exec(client)(operations)

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -58,7 +58,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
-    * >>> val keySet = NonEmptySet.of("Patty", "Ted", "Farmer")
+    * >>> val keySet = NonEmptySet.of("Patty", "Ted", "Jack")
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   val operations = for {
     * ...     _       <- farm.putAll(dataSet)

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -49,20 +49,19 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val farm = Table[Farmer]("farmers")
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import com.gu.scanamo._
     * >>> import com.gu.scanamo.syntax._
-    * >>> import cats.data.NonEmptySet
-    * >>> import cats.kernel.instances.string._
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> val dataSet = Set(
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
-    * >>> val keySet = NonEmptySet.of("Patty", "Ted", "Jack")
+    * >>> val ks = keySet("Patty", "Ted", "Jack")
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
     * ...   val operations = for {
     * ...     _       <- farm.putAll(dataSet)
-    * ...     _       <- farm.deleteAll('name -> keySet)
+    * ...     _       <- farm.deleteAll('name -> ks)
     * ...     scanned <- farm.scan
     * ...   } yield scanned.toList
     * ...   Scanamo.exec(client)(operations)

--- a/scanamo/src/main/scala/com/gu/scanamo/package.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/package.scala
@@ -2,7 +2,6 @@ package com.gu
 
 import com.gu.scanamo.query._
 import com.gu.scanamo.update._
-import cats.data.NonEmptySet
 
 package object scanamo {
 
@@ -21,11 +20,11 @@ package object scanamo {
 
     implicit def toUniqueKey[T: UniqueKeyCondition](t: T) = UniqueKey(t)
 
-    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, NonEmptySet[V])) =
-      UniqueKeys(KeyList(pair._1, pair._2.toSortedSet))
+    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, Set[V])) =
+      UniqueKeys(KeyList(pair._1, pair._2))
 
-    implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, NonEmptySet[(H, R)])) =
-      UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2.toSortedSet))
+    implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, Set[(H, R)])) =
+      UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2))
 
     implicit def symbolTupleToQuery[V: DynamoFormat](pair: (Symbol, V)) =
       Query(KeyEquals(pair._1, pair._2))
@@ -70,6 +69,8 @@ package object scanamo {
       UpdateExpression.delete(fieldValue)
     def remove(field: AttributeName): UpdateExpression =
       UpdateExpression.remove(field)
+
+    def keySet[A](a: A, as: A*): Set[A] = as.toSet + a
 
     implicit def symbolAttributeName(s: Symbol): AttributeName = AttributeName.of(s)
     implicit def symbolAttributeNameValue[T](sv: (Symbol, T)): (AttributeName, T) = AttributeName.of(sv._1) -> sv._2

--- a/scanamo/src/main/scala/com/gu/scanamo/package.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/package.scala
@@ -2,6 +2,7 @@ package com.gu
 
 import com.gu.scanamo.query._
 import com.gu.scanamo.update._
+import cats.data.NonEmptySet
 
 package object scanamo {
 
@@ -20,11 +21,11 @@ package object scanamo {
 
     implicit def toUniqueKey[T: UniqueKeyCondition](t: T) = UniqueKey(t)
 
-    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, Set[V])) =
-      UniqueKeys(KeyList(pair._1, pair._2))
+    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, NonEmptySet[V])) =
+      UniqueKeys(KeyList(pair._1, pair._2.toSortedSet))
 
-    implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, Set[(H, R)])) =
-      UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2))
+    implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, NonEmptySet[(H, R)])) =
+      UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2.toSortedSet))
 
     implicit def symbolTupleToQuery[V: DynamoFormat](pair: (Symbol, V)) =
       Query(KeyEquals(pair._1, pair._2))


### PR DESCRIPTION
Addresses #105 

Cats 1.1.0 provides a `NonEmptySet` abstraction that can be used to avoid `BatchGetItem` queries that would error in the database. Because these are _ordered_ sets, instances for `Order[V]` and `Order[(H, R)]` must be available in scope, meaning the odd cats-kernel import will be required, e.g.
```scala
import cats.data.NonEmptySet
import cats.kernel.instances.string._

NonEmptySet.of("Boggis", "Bean")
```

---

I've thought about another solution to this problem, as I felt the `Order` constraint was completely unnecessary here. The only thing we need is a way to reify a non-empty `Set` similar to `NonEmptySet.of(h: A, t: A*)`. It turns out marrying this idea with tuples, which are central to the Scanamo DSL, is harder than it looks. I did not find a satisfying solution.