### PR TITLE
Aggregate the cats-effect module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val catsEffect = (project in file("cats"))
       "AWS_SECRET_KEY" -> "credentials"
     ),
     dynamoDBLocalDownloadDir := file(".cats-effect-dynamodb-local"),
-    dynamoDBLocalPort := 8042,
+    dynamoDBLocalPort := 8043,
     scalacOptions in (Compile, doc) += "-no-link-warnings",
   )
   .dependsOn(formats, scanamo)

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val dynamoTestSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(formats, scanamo, testkit, alpakka, refined)
+  .aggregate(formats, scanamo, testkit, alpakka, refined, catsEffect)
   .settings(
     commonSettings,
     publishingSettings,
@@ -132,7 +132,7 @@ lazy val testkit = (project in file("testkit"))
     )
   )
 
-lazy val cats = (project in file("cats"))
+lazy val catsEffect = (project in file("cats"))
   .settings(
     name := "scanamo-cats-effect",
     commonSettings,


### PR DESCRIPTION
I noticed that the cats-effect module was missing from Maven central and I think this is why. 

I looked at including the scalaz module too, but tests seemed to be consistently failing on that for me, so concentrated on cats-effect for now.