### PR TITLE
Delete table if exists

### DIFF
--- a/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -16,12 +16,20 @@ object LocalDynamoDB {
       .build()
 
   def createTable(client: AmazonDynamoDB)(tableName: String)(attributes: (Symbol, ScalarAttributeType)*) = {
-    client.createTable(
-      attributeDefinitions(attributes),
-      tableName,
-      keySchema(attributes),
-      arbitraryThroughputThatIsIgnoredByDynamoDBLocal
-    )
+    var created = false
+    while (!created) {
+      try {
+        client.createTable(
+          attributeDefinitions(attributes),
+          tableName,
+          keySchema(attributes),
+          arbitraryThroughputThatIsIgnoredByDynamoDBLocal
+        )
+        created = true
+      } catch {
+        case _ => client.deleteTable(tableName)          
+      }
+    }
   }
 
   def deleteTable(client: AmazonDynamoDB)(tableName: String) = {

--- a/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -27,7 +27,7 @@ object LocalDynamoDB {
         )
         created = true
       } catch {
-        case _ => client.deleteTable(tableName)          
+        case x: ResourceInUseException if x.getMessage.contains("preexisting") => client.deleteTable(tableName)
       }
     }
   }


### PR DESCRIPTION
There seems to be tables not being properly deleted in tests, perhaps because of concurrency issues. Trying the brute force first.