### PR TITLE
Random table API in testkit

### DIFF
--- a/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
@@ -314,13 +314,13 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
 
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-      Scanamo.putAll(client)("transport")(
+    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { tableName =>
+      Scanamo.putAll(client)(tableName)(
         Set(
           Transport("Underground", "Circle"),
           Transport("Underground", "Metropolitan"),
           Transport("Underground", "Central")))
-      val results = ScanamoAlpakka.queryWithLimit[Transport](alpakkaClient)("transport")(
+      val results = ScanamoAlpakka.queryWithLimit[Transport](alpakkaClient)(tableName)(
         'mode -> "Underground" and ('line beginsWith "C"),
         1)
       results.futureValue should equal(List(Right(Transport("Underground", "Central"))))

--- a/cats/src/test/scala/com/gu/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/com/gu/scanamo/ScanamoCatsSpec.scala
@@ -279,12 +279,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-      Scanamo.putAll(client)("transport")(Set(
+    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+      Scanamo.putAll(client)(t)(Set(
         Transport("Underground", "Circle"),
         Transport("Underground", "Metropolitan"),
         Transport("Underground", "Central")))
-      val results = ScanamoCats.queryWithLimit[IO, Transport](client)("transport")('mode -> "Underground" and ('line beginsWith "C"), 1)
+      val results = ScanamoCats.queryWithLimit[IO, Transport](client)(t)('mode -> "Underground" and ('line beginsWith "C"), 1)
       results.unsafeRunSync() should equal(List(Right(Transport("Underground","Central"))))
     }
   }

--- a/scalaz/src/test/scala/com/gu/scanamo/ScanamoScalazSpec.scala
+++ b/scalaz/src/test/scala/com/gu/scanamo/ScanamoScalazSpec.scala
@@ -278,12 +278,12 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-      Scanamo.putAll(client)("transport")(Set(
+    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+      Scanamo.putAll(client)(t)(Set(
         Transport("Underground", "Circle"),
         Transport("Underground", "Metropolitan"),
         Transport("Underground", "Central")))
-      val results = ScanamoScalaz.queryWithLimit[Transport](client)("transport")('mode -> "Underground" and ('line beginsWith "C"), 1)
+      val results = ScanamoScalaz.queryWithLimit[Transport](client)(t)('mode -> "Underground" and ('line beginsWith "C"), 1)
       unsafePerformIO(results) should equal(List(Right(Transport("Underground","Central"))))
     }
   }

--- a/scalaz/src/test/scala/com/gu/scanamo/ScanamoScalazSpec.scala
+++ b/scalaz/src/test/scala/com/gu/scanamo/ScanamoScalazSpec.scala
@@ -19,78 +19,78 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should put asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
       import com.gu.scanamo.syntax._
 
       val result = for {
-        _ <- ScanamoScalaz.put[Farmer](client)("asyncFarmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-      } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McDonald")
+        _ <- ScanamoScalaz.put[Farmer](client)(t)(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
+      } yield Scanamo.get[Farmer](client)(t)('name -> "McDonald")
 
       unsafePerformIO(result) should equal(Some(Right(Farmer("McDonald", 156, Farm(List("sheep", "cow"))))))
     }
   }
 
   it("should get asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.put[Farmer](client)("asyncFarmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
+      Scanamo.put[Farmer](client)(t)(Farmer("Maggot", 75L, Farm(List("dog"))))
 
-      unsafePerformIO(ScanamoScalaz.get[Farmer](client)("asyncFarmers")(UniqueKey(KeyEquals('name, "Maggot")))) should
+      unsafePerformIO(ScanamoScalaz.get[Farmer](client)(t)(UniqueKey(KeyEquals('name, "Maggot")))) should
         equal(Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))))
 
       import com.gu.scanamo.syntax._
 
-      unsafePerformIO(ScanamoScalaz.get[Farmer](client)("asyncFarmers")('name -> "Maggot")) should
+      unsafePerformIO(ScanamoScalaz.get[Farmer](client)(t)('name -> "Maggot")) should
         equal(Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))))
     }
 
-    LocalDynamoDB.usingTable(client)("asyncEngines")('name -> S, 'number -> N) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S, 'number -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      Scanamo.put(client)("asyncEngines")(Engine("Thomas", 1))
+      Scanamo.put(client)(t)(Engine("Thomas", 1))
 
       import com.gu.scanamo.syntax._
-      unsafePerformIO(ScanamoScalaz.get[Engine](client)("asyncEngines")('name -> "Thomas" and 'number -> 1)) should
+      unsafePerformIO(ScanamoScalaz.get[Engine](client)(t)('name -> "Thomas" and 'number -> 1)) should
         equal(Some(Right(Engine("Thomas", 1))))
     }
   }
 
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
-    LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       import com.gu.scanamo.syntax._
-      val _ = unsafePerformIO(ScanamoScalaz.put[City](client)("asyncCities")(City("Nashville", "US")))
-      unsafePerformIO(ScanamoScalaz.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")) should
+      val _ = unsafePerformIO(ScanamoScalaz.put[City](client)(t)(City("Nashville", "US")))
+      unsafePerformIO(ScanamoScalaz.getWithConsistency[City](client)(t)('name -> "Nashville")) should
         equal(Some(Right(City("Nashville", "US"))))
     }
   }
 
   it("should delete asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.put(client)("asyncFarmers")(Farmer("McGregor", 62L, Farm(List("rabbit"))))
+      Scanamo.put(client)(t)(Farmer("McGregor", 62L, Farm(List("rabbit"))))
 
       import com.gu.scanamo.syntax._
 
       val maybeFarmer = for {
-        _ <- ScanamoScalaz.delete[Farmer](client)("asyncFarmers")('name -> "McGregor")
-      } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McGregor")
+        _ <- ScanamoScalaz.delete[Farmer](client)(t)('name -> "McGregor")
+      } yield Scanamo.get[Farmer](client)(t)('name -> "McGregor")
 
       unsafePerformIO(maybeFarmer) should equal(None)
     }
   }
 
   it("should deleteAll asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
@@ -103,39 +103,39 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
         Farmer("Jack", 2L, Farm(List("velociraptor")))
       )
 
-      Scanamo.putAll(client)("asyncFarmers")(dataSet)
+      Scanamo.putAll(client)(t)(dataSet)
 
       val maybeFarmer = for {
-        _ <- ScanamoScalaz.deleteAll(client)("asyncFarmers")('name -> dataSet.map(_.name))
-      } yield Scanamo.scan[Farmer](client)("asyncFarmers")
+        _ <- ScanamoScalaz.deleteAll(client)(t)('name -> dataSet.map(_.name))
+      } yield Scanamo.scan[Farmer](client)(t)
 
       unsafePerformIO(maybeFarmer) should equal(List.empty)
     }
   }
 
   it("should update asynchronously") {
-    LocalDynamoDB.usingTable(client)("forecast")('location -> S) {
+    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
 
       case class Forecast(location: String, weather: String)
 
-      Scanamo.put(client)("forecast")(Forecast("London", "Rain"))
+      Scanamo.put(client)(t)(Forecast("London", "Rain"))
 
       import com.gu.scanamo.syntax._
 
       val forecasts = for {
-        _ <- ScanamoScalaz.update[Forecast](client)("forecast")('location -> "London", set('weather -> "Sun"))
-      } yield Scanamo.scan[Forecast](client)("forecast")
+        _ <- ScanamoScalaz.update[Forecast](client)(t)('location -> "London", set('weather -> "Sun"))
+      } yield Scanamo.scan[Forecast](client)(t)
 
       unsafePerformIO(forecasts) should equal(List(Right(Forecast("London", "Sun"))))
     }
   }
 
   it("should update asynchronously if a condition holds") {
-    LocalDynamoDB.usingTable(client)("forecast")('location -> S) {
+    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
 
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Forecast]("forecast")
+      val forecasts = Table[Forecast](t)
 
       import com.gu.scanamo.syntax._
 
@@ -152,37 +152,37 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should scan asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncBears")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Bear(name: String, favouriteFood: String)
 
-      Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
-      Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
+      Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+      Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
 
-      unsafePerformIO(ScanamoScalaz.scan[Bear](client)("asyncBears")) should equal(
+      unsafePerformIO(ScanamoScalaz.scan[Bear](client)(t)) should equal(
         List(Right(Bear("Pooh", "honey")), Right(Bear("Yogi", "picnic baskets")))
       )
     }
 
-    LocalDynamoDB.usingTable(client)("asyncLemmings")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Lemming(name: String, stuff: String)
 
-      Scanamo.putAll(client)("asyncLemmings")(
+      Scanamo.putAll(client)(t)(
         (for {_ <- 0 until 100} yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet
       )
 
-      unsafePerformIO(ScanamoScalaz.scan[Lemming](client)("asyncLemmings")).size should equal(100)
+      unsafePerformIO(ScanamoScalaz.scan[Lemming](client)(t)).size should equal(100)
     }
   }
 
   it("scans with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingTable(client)("asyncBears")('name -> S) {
-      Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
-      Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
-      val results = ScanamoScalaz.scanWithLimit[Bear](client)("asyncBears", 1)
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+      Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+      val results = ScanamoScalaz.scanWithLimit[Bear](client)(t, 1)
       unsafePerformIO(results) should equal(List(Right(Bear("Pooh","honey"))))
     }
   }
@@ -190,14 +190,14 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("paginates with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingTable(client)("asyncBears")('name -> S) {
-      Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
-      Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
-      Scanamo.put(client)("asyncBears")(Bear("Graham", "quinoa"))
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+      Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+      Scanamo.put(client)(t)(Bear("Graham", "quinoa"))
       val results = for {
-        res1 <- ScanamoScalaz.scanFrom[Bear](client)("asyncBears", 1, None)
-        res2 <- ScanamoScalaz.scanFrom[Bear](client)("asyncBears", 1, res1._2)
-        res3 <- ScanamoScalaz.scanFrom[Bear](client)("asyncBears", 1, res2._2)
+        res1 <- ScanamoScalaz.scanFrom[Bear](client)(t, 1, None)
+        res2 <- ScanamoScalaz.scanFrom[Bear](client)(t, 1, res1._2)
+        res3 <- ScanamoScalaz.scanFrom[Bear](client)(t, 1, res2._2)
       } yield res2._1 ::: res3._1
       unsafePerformIO(results) should equal(List(Right(Bear("Yogi","picnic baskets")), Right(Bear("Graham","quinoa"))))
     }
@@ -233,42 +233,42 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should query asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncAnimals")('species -> S, 'number -> N) {
+    LocalDynamoDB.usingRandomTable(client)('species -> S, 'number -> N) { t =>
 
       case class Animal(species: String, number: Int)
 
-      Scanamo.put(client)("asyncAnimals")(Animal("Wolf", 1))
+      Scanamo.put(client)(t)(Animal("Wolf", 1))
 
-      for {i <- 1 to 3} Scanamo.put(client)("asyncAnimals")(Animal("Pig", i))
+      for {i <- 1 to 3} Scanamo.put(client)(t)(Animal("Pig", i))
 
       import com.gu.scanamo.syntax._
 
-      unsafePerformIO(ScanamoScalaz.query[Animal](client)("asyncAnimals")('species -> "Pig")) should equal(
+      unsafePerformIO(ScanamoScalaz.query[Animal](client)(t)('species -> "Pig")) should equal(
         List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2)), Right(Animal("Pig", 3))))
 
-      unsafePerformIO(ScanamoScalaz.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number < 3)) should equal(
+      unsafePerformIO(ScanamoScalaz.query[Animal](client)(t)('species -> "Pig" and 'number < 3)) should equal(
         List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2))))
-      unsafePerformIO(ScanamoScalaz.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number > 1)) should equal(
+      unsafePerformIO(ScanamoScalaz.query[Animal](client)(t)('species -> "Pig" and 'number > 1)) should equal(
         List(Right(Animal("Pig", 2)), Right(Animal("Pig", 3))))
-      unsafePerformIO(ScanamoScalaz.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number <= 2)) should equal(
+      unsafePerformIO(ScanamoScalaz.query[Animal](client)(t)('species -> "Pig" and 'number <= 2)) should equal(
         List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2))))
-      unsafePerformIO(ScanamoScalaz.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number >= 2)) should equal(
+      unsafePerformIO(ScanamoScalaz.query[Animal](client)(t)('species -> "Pig" and 'number >= 2)) should equal(
         List(Right(Animal("Pig", 2)), Right(Animal("Pig", 3))))
 
     }
 
-    LocalDynamoDB.usingTable(client)("asyncTransport")('mode -> S, 'line -> S) {
+    LocalDynamoDB.usingRandomTable(client)('mode -> S, 'line -> S) { t =>
 
       case class Transport(mode: String, line: String)
 
       import com.gu.scanamo.syntax._
 
-      Scanamo.putAll(client)("asyncTransport")(Set(
+      Scanamo.putAll(client)(t)(Set(
         Transport("Underground", "Circle"),
         Transport("Underground", "Metropolitan"),
         Transport("Underground", "Central")))
 
-      unsafePerformIO(ScanamoScalaz.query[Transport](client)("asyncTransport")('mode -> "Underground" and ('line beginsWith "C"))) should equal(
+      unsafePerformIO(ScanamoScalaz.query[Transport](client)(t)('mode -> "Underground" and ('line beginsWith "C"))) should equal(
         List(Right(Transport("Underground", "Central")), Right(Transport("Underground", "Circle"))))
     }
   }
@@ -358,9 +358,9 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     import com.gu.scanamo.syntax._
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('firstName -> S, 'surname -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('firstName -> S, 'surname -> S) {
       val farmerOps: ScanamoOps[List[Either[DynamoReadError, Farmer]]] = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -373,12 +373,12 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("should put multiple items asynchronously") {
     case class Rabbit(name: String)
 
-    LocalDynamoDB.usingTable(client)("asyncRabbits")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       val result = for {
-        _ <- ScanamoScalaz.putAll[Rabbit](client)("asyncRabbits")((
+        _ <- ScanamoScalaz.putAll[Rabbit](client)(t)((
           for {_ <- 0 until 100} yield Rabbit(util.Random.nextString(500))
           ).toSet)
-      } yield Scanamo.scan[Rabbit](client)("asyncRabbits")
+      } yield Scanamo.scan[Rabbit](client)(t)
 
       unsafePerformIO(result).size should equal(100)
     }
@@ -386,34 +386,34 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should get multiple items asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.putAll(client)("asyncFarmers")(Set(
+      Scanamo.putAll(client)(t)(Set(
         Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
       ))
 
-      unsafePerformIO(ScanamoScalaz.getAll[Farmer](client)("asyncFarmers")(
+      unsafePerformIO(ScanamoScalaz.getAll[Farmer](client)(t)(
         UniqueKeys(KeyList('name, Set("Boggis", "Bean")))
       )) should equal(
         Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
 
       import com.gu.scanamo.syntax._
 
-      unsafePerformIO(ScanamoScalaz.getAll[Farmer](client)("asyncFarmers")('name -> Set("Boggis", "Bean"))) should equal(
+      unsafePerformIO(ScanamoScalaz.getAll[Farmer](client)(t)('name -> Set("Boggis", "Bean"))) should equal(
         Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
     }
 
-    LocalDynamoDB.usingTable(client)("asyncDoctors")('actor -> S, 'regeneration -> N) {
+    LocalDynamoDB.usingRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
 
-      Scanamo.putAll(client)("asyncDoctors")(
+      Scanamo.putAll(client)(t)(
         Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
 
       import com.gu.scanamo.syntax._
-      unsafePerformIO(ScanamoScalaz.getAll[Doctor](client)("asyncDoctors")(
+      unsafePerformIO(ScanamoScalaz.getAll[Doctor](client)(t)(
         ('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11)
       )) should equal(
         Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
@@ -422,28 +422,28 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should get multiple items asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingTable(client)("asyncFarms")('id -> N) {
+    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
 
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
 
-      Scanamo.putAll(client)("asyncFarms")(farms)
+      Scanamo.putAll(client)(t)(farms)
 
-      unsafePerformIO(ScanamoScalaz.getAll[Farm](client)("asyncFarms")(
+      unsafePerformIO(ScanamoScalaz.getAll[Farm](client)(t)(
         UniqueKeys(KeyList('id, farms.map(_.id)))
       )) should equal(farms.map(Right(_)))
     }
   }
 
   it("should get multiple items consistently asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingTable(client)("asyncFarms")('id -> N) {
+    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
 
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
 
-      Scanamo.putAll(client)("asyncFarms")(farms)
+      Scanamo.putAll(client)(t)(farms)
 
-      unsafePerformIO(ScanamoScalaz.getAllWithConsistency[Farm](client)("asyncFarms")(
+      unsafePerformIO(ScanamoScalaz.getAllWithConsistency[Farm](client)(t)(
         UniqueKeys(KeyList('id, farms.map(_.id)))
       )) should equal(farms.map(Right(_)))
     }
@@ -453,9 +453,9 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -469,9 +469,9 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -485,9 +485,9 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     import com.gu.scanamo.syntax._
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
@@ -505,9 +505,9 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     import com.gu.scanamo.syntax._
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
         _ <- farmersTable.put(Farmer("Butch", 57, Farm(List("cattle"))))
@@ -527,9 +527,9 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     import com.gu.scanamo.syntax._
 
-    val gremlinsTable = Table[Gremlin]("gremlins")
+    LocalDynamoDB.usingRandomTable(client)('number -> N) { t =>
+      val gremlinsTable = Table[Gremlin](t)
 
-    LocalDynamoDB.usingTable(client)("gremlins")('number -> N) {
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
         _ <- gremlinsTable.given('wet -> true).delete('number -> 1)

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -30,9 +30,9 @@ object Scanamo {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
     *
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.put(client)("farmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-    * ...   Scanamo.get[Farmer](client)("farmers")('name -> "McDonald")
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t => 
+    * ...   Scanamo.put(client)(t)(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
+    * ...   Scanamo.get[Farmer](client)(t)('name -> "McDonald")
     * ... }
     * Some(Right(Farmer(McDonald,156,Farm(List(sheep, cow)))))
     * }}}
@@ -48,10 +48,10 @@ object Scanamo {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> LocalDynamoDB.withTable(client)("rabbits")('name -> S) {
-    * ...   Scanamo.putAll(client)("rabbits")((
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)((
     * ...   for { _ <- 0 until 100 } yield Rabbit(util.Random.nextString(500))).toSet)
-    * ...   Scanamo.scan[Rabbit](client)("rabbits").size
+    * ...   Scanamo.scan[Rabbit](client)(t).size
     * ... }
     * 100
     * }}}
@@ -68,27 +68,27 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> import com.gu.scanamo.query._
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.put(client)("farmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
-    * ...   Scanamo.get[Farmer](client)("farmers")(UniqueKey(KeyEquals('name, "Maggot")))
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.put(client)(t)(Farmer("Maggot", 75L, Farm(List("dog"))))
+    * ...   Scanamo.get[Farmer](client)(t)(UniqueKey(KeyEquals('name, "Maggot")))
     * ... }
     * Some(Right(Farmer(Maggot,75,Farm(List(dog)))))
     * }}}
     * or with some added syntactic sugar:
     * {{{
     * >>> import com.gu.scanamo.syntax._
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.put(client)("farmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
-    * ...   Scanamo.get[Farmer](client)("farmers")('name -> "Maggot")
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.put(client)(t)(Farmer("Maggot", 75L, Farm(List("dog"))))
+    * ...   Scanamo.get[Farmer](client)(t)('name -> "Maggot")
     * ... }
     * Some(Right(Farmer(Maggot,75,Farm(List(dog)))))
     * }}}
     * Can also be used with tables that have both a hash and a range key:
     * {{{
     * >>> case class Engine(name: String, number: Int)
-    * >>> LocalDynamoDB.withTable(client)("engines")('name -> S, 'number -> N) {
-    * ...   Scanamo.put(client)("engines")(Engine("Thomas", 1))
-    * ...   Scanamo.get[Engine](client)("engines")('name -> "Thomas" and 'number -> 1)
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S, 'number -> N) { t =>
+    * ...   Scanamo.put(client)(t)(Engine("Thomas", 1))
+    * ...   Scanamo.get[Engine](client)(t)('name -> "Thomas" and 'number -> 1)
     * ... }
     * Some(Right(Engine(Thomas,1)))
     * }}}
@@ -103,10 +103,10 @@ object Scanamo {
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
-    * >>> LocalDynamoDB.withTable(client)("asyncCities")('name -> S) {
-    * ...  Scanamo.put(client)("asyncCities")(City("Nashville", "US"))
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...  Scanamo.put(client)(t)(City("Nashville", "US"))
     * ...  import com.gu.scanamo.syntax._
-    * ...  Scanamo.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")
+    * ...  Scanamo.getWithConsistency[City](client)(t)('name -> "Nashville")
     * ... }
     * Some(Right(City(Nashville,US)))
     * }}}
@@ -128,32 +128,32 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> import com.gu.scanamo.query._
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.putAll(client)("farmers")(Set(
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAll[Farmer](client)("farmers")(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
+    * ...   Scanamo.getAll[Farmer](client)(t)(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
     * ... }
     * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
     * or with some added syntactic sugar:
     * {{{
     * >>> import com.gu.scanamo.syntax._
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.putAll(client)("farmers")(Set(
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> Set("Boggis", "Bean"))
+    * ...   Scanamo.getAll[Farmer](client)(t)('name -> Set("Boggis", "Bean"))
     * ... }
     * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
     * You can also retrieve items from a table with both a hash and range key
     * {{{
     * >>> case class Doctor(actor: String, regeneration: Int)
-    * >>> LocalDynamoDB.withTable(client)("doctors")('actor -> S, 'regeneration -> N) {
-    * ...   Scanamo.putAll(client)("doctors")(
+    * >>> LocalDynamoDB.withRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
+    * ...   Scanamo.putAll(client)(t)(
     * ...     Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+    * ...   Scanamo.getAll[Doctor](client)(t)(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
     * ... }
     * Set(Right(Doctor(McCoy,9)), Right(Doctor(Ecclestone,11)))
     * }}}
@@ -171,11 +171,11 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> import com.gu.scanamo.query._
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.putAll(client)("farmers")(Set(
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAllWithConsistency[Farmer](client)("farmers")(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
+    * ...   Scanamo.getAllWithConsistency[Farmer](client)(t)(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
     * ... }
     * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
@@ -195,10 +195,10 @@ object Scanamo {
     * >>> import com.gu.scanamo.syntax._
     * >>> val client = LocalDynamoDB.client()
     *
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.put(client)("farmers")(Farmer("McGregor", 62L, Farm(List("rabbit"))))
-    * ...   Scanamo.delete(client)("farmers")('name -> "McGregor")
-    * ...   Scanamo.get[Farmer](client)("farmers")('name -> "McGregor")
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.put(client)(t)(Farmer("McGregor", 62L, Farm(List("rabbit"))))
+    * ...   Scanamo.delete(client)(t)('name -> "McGregor")
+    * ...   Scanamo.get[Farmer](client)(t)('name -> "McGregor")
     * ... }
     * None
     * }}}
@@ -222,10 +222,10 @@ object Scanamo {
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
     *
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.putAll(client)("farmers")(dataSet)
-    * ...   Scanamo.deleteAll(client)("farmers")('name -> dataSet.map(_.name))
-    * ...   Scanamo.scan[Farmer](client)("farmers").toList
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(dataSet)
+    * ...   Scanamo.deleteAll(client)(t)('name -> dataSet.map(_.name))
+    * ...   Scanamo.scan[Farmer](client)(t).toList
     * ... }
     * List()
     * }}}
@@ -242,11 +242,11 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("forecast")('location -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('location -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
-    * ...   Scanamo.put(client)("forecast")(Forecast("London", "Rain"))
-    * ...   Scanamo.update(client)("forecast")('location -> "London", set('weather -> "Sun"))
-    * ...   Scanamo.scan[Forecast](client)("forecast").toList
+    * ...   Scanamo.put(client)(t)(Forecast("London", "Rain"))
+    * ...   Scanamo.update(client)(t)('location -> "London", set('weather -> "Sun"))
+    * ...   Scanamo.scan[Forecast](client)(t).toList
     * ... }
     * List(Right(Forecast(London,Sun)))
     * }}}
@@ -264,10 +264,10 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("bears")('name -> S) {
-    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey"))
-    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets"))
-    * ...   Scanamo.scan[Bear](client)("bears")
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+    * ...   Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+    * ...   Scanamo.scan[Bear](client)(t)
     * ... }
     * List(Right(Bear(Pooh,honey)), Right(Bear(Yogi,picnic baskets)))
     * }}}
@@ -277,11 +277,11 @@ object Scanamo {
     * {{{
     * >>> case class Lemming(name: String, stuff: String)
     *
-    * >>> LocalDynamoDB.withTable(client)("lemmings")('name -> S) {
-    * ...   Scanamo.putAll(client)("lemmings")(
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(
     * ...     (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet
     * ...   )
-    * ...   Scanamo.scan[Lemming](client)("lemmings").size
+    * ...   Scanamo.scan[Lemming](client)(t).size
     * ... }
     * 100
     * }}}
@@ -298,10 +298,10 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("bears")('name -> S) {
-    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey"))
-    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets"))
-    * ...   Scanamo.scanWithLimit[Bear](client)("bears", 1)
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+    * ...   Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+    * ...   Scanamo.scanWithLimit[Bear](client)(t, 1)
     * ... }
     * List(Right(Bear(Pooh,honey)))
     * }}}
@@ -319,11 +319,11 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("bears")('name -> S) {
-    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey"))
-    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets"))
-    * ...   val res1 = Scanamo.scanFrom[Bear](client)("bears", 1, None)
-    * ...   Scanamo.scanFrom[Bear](client)("bears", 1, res1._2)._1
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+    * ...   Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+    * ...   val res1 = Scanamo.scanFrom[Bear](client)(t, 1, None)
+    * ...   Scanamo.scanFrom[Bear](client)(t, 1, res1._2)._1
     * ... }
     * List(Right(Bear(Yogi,picnic baskets)))
     * }}}
@@ -413,21 +413,21 @@ object Scanamo {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> LocalDynamoDB.withTable(client)("animals")('species -> S, 'number -> N) {
-    * ...   Scanamo.put(client)("animals")(Animal("Wolf", 1))
+    * >>> LocalDynamoDB.withRandomTable(client)('species -> S, 'number -> N) { t =>
+    * ...   Scanamo.put(client)(t)(Animal("Wolf", 1))
     * ...   import com.gu.scanamo.query._
-    * ...   for { i <- 1 to 3 } Scanamo.put(client)("animals")(Animal("Pig", i))
-    * ...   Scanamo.query[Animal](client)("animals")(Query(KeyEquals('species, "Pig")))
+    * ...   for { i <- 1 to 3 } Scanamo.put(client)(t)(Animal("Pig", i))
+    * ...   Scanamo.query[Animal](client)(t)(Query(KeyEquals('species, "Pig")))
     * ... }
     * List(Right(Animal(Pig,1)), Right(Animal(Pig,2)), Right(Animal(Pig,3)))
     * }}}
     * or with some syntactic sugar
     * {{{
-    * >>> LocalDynamoDB.withTable(client)("animalCircus")('species -> S, 'number -> N) {
-    * ...   Scanamo.put(client)("animalCircus")(Animal("Wolf", 1))
+    * >>> LocalDynamoDB.withRandomTable(client)('species -> S, 'number -> N) { t =>
+    * ...   Scanamo.put(client)(t)(Animal("Wolf", 1))
     * ...   import com.gu.scanamo.syntax._
-    * ...   for { i <- 1 to 3 } Scanamo.put(client)("animalCircus")(Animal("Pig", i))
-    * ...   Scanamo.query[Animal](client)("animalCircus")('species -> "Pig")
+    * ...   for { i <- 1 to 3 } Scanamo.put(client)(t)(Animal("Pig", i))
+    * ...   Scanamo.query[Animal](client)(t)('species -> "Pig")
     * ... }
     * List(Right(Animal(Pig,1)), Right(Animal(Pig,2)), Right(Animal(Pig,3)))
     * }}}
@@ -435,12 +435,12 @@ object Scanamo {
     * {{{
     * >>> import com.gu.scanamo.syntax._
     * >>> case class Transport(mode: String, line: String)
-    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-    * ...   Scanamo.putAll(client)("transport")(Set(
+    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Transport("Underground", "Circle"),
     * ...     Transport("Underground", "Metropolitan"),
     * ...     Transport("Underground", "Central")))
-    * ...   Scanamo.query[Transport](client)("transport")('mode -> "Underground" and ('line beginsWith "C"))
+    * ...   Scanamo.query[Transport](client)(t)('mode -> "Underground" and ('line beginsWith "C"))
     * ... }
     * List(Right(Transport(Underground,Central)), Right(Transport(Underground,Circle)))
     * }}}
@@ -458,12 +458,12 @@ object Scanamo {
     * >>> import com.gu.scanamo.syntax._
     *
     * >>> case class Transport(mode: String, line: String)
-    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-    * ...   Scanamo.putAll(client)("transport")(Set(
+    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Transport("Underground", "Circle"),
     * ...     Transport("Underground", "Metropolitan"),
     * ...     Transport("Underground", "Central")))
-    * ...   Scanamo.queryWithLimit[Transport](client)("transport")('mode -> "Underground" and ('line beginsWith "C"), 1)
+    * ...   Scanamo.queryWithLimit[Transport](client)(t)('mode -> "Underground" and ('line beginsWith "C"), 1)
     * ... }
     * List(Right(Transport(Underground,Central)))
     * }}}
@@ -482,14 +482,14 @@ object Scanamo {
     * >>> import com.gu.scanamo.syntax._
     *
     * >>> case class Transport(mode: String, line: String)
-    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-    * ...   Scanamo.putAll(client)("transport")(Set(
+    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Transport("Underground", "Circle"),
     * ...     Transport("Underground", "Metropolitan"),
     * ...     Transport("Underground", "Central")))
-    * ...   val res1 = Scanamo.queryFrom[Transport](client)("transport")(
+    * ...   val res1 = Scanamo.queryFrom[Transport](client)(t)(
     * ...       ('mode -> "Underground" and ('line beginsWith "C")), 1, None)
-    * ...   Scanamo.queryFrom[Transport](client)("transport")(
+    * ...   Scanamo.queryFrom[Transport](client)(t)(
     * ...       ('mode -> "Underground" and ('line beginsWith "C")), 1, res1._2)._1
     * ... }
     * List(Right(Transport(Underground,Circle)))

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -343,10 +343,10 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("bears", "alias-index")('name -> S)('alias -> S) {
-    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey", Some("Winnie")))
-    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets", None))
-    * ...   Scanamo.scanIndex[Bear](client)("bears", "alias-index")
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    * ...   Scanamo.put(client)(t)(Bear("Pooh", "honey", Some("Winnie")))
+    * ...   Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets", None))
+    * ...   Scanamo.scanIndex[Bear](client)(t, i)
     * ... }
     * List(Right(Bear(Pooh,honey,Some(Winnie))))
     * }}}
@@ -364,11 +364,11 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("bears", "alias-index")('name -> S)('alias -> S) {
-    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey", Some("Winnie")))
-    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets", None))
-    * ...   Scanamo.put(client)("bears")(Bear("Graham", "quinoa", Some("Guardianista")))
-    * ...   Scanamo.scanIndexWithLimit[Bear](client)("bears", "alias-index", 1)
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    * ...   Scanamo.put(client)(t)(Bear("Pooh", "honey", Some("Winnie")))
+    * ...   Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets", None))
+    * ...   Scanamo.put(client)(t)(Bear("Graham", "quinoa", Some("Guardianista")))
+    * ...   Scanamo.scanIndexWithLimit[Bear](client)(t, i, 1)
     * ... }
     * List(Right(Bear(Graham,quinoa,Some(Guardianista))))
     * }}}
@@ -387,12 +387,12 @@ object Scanamo {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("bears", "alias-index")('name -> S)('alias -> S) {
-    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey", Some("Winnie")))
-    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets", None))
-    * ...   Scanamo.put(client)("bears")(Bear("Graham", "quinoa", Some("Guardianista")))
-    * ...   val res1 = Scanamo.scanIndexFrom[Bear](client)("bears", "alias-index", 1, None)
-    * ...   Scanamo.scanIndexFrom[Bear](client)("bears", "alias-index", 1, res1._2)._1
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    * ...   Scanamo.put(client)(t)(Bear("Pooh", "honey", Some("Winnie")))
+    * ...   Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets", None))
+    * ...   Scanamo.put(client)(t)(Bear("Graham", "quinoa", Some("Guardianista")))
+    * ...   val res1 = Scanamo.scanIndexFrom[Bear](client)(t, i, 1, None)
+    * ...   Scanamo.scanIndexFrom[Bear](client)(t, i, 1, res1._2)._1
     * ... }
     * List(Right(Bear(Pooh,honey,Some(Winnie))))
     * }}}
@@ -510,12 +510,12 @@ object Scanamo {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")('mode -> S, 'line -> S)('colour -> S) {
-    * ...   Scanamo.putAll(client)("transport")(Set(
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('colour -> S) { (t, i) =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Transport("Underground", "Circle", "Yellow"),
     * ...     Transport("Underground", "Metropolitan", "Magenta"),
     * ...     Transport("Underground", "Central", "Red")))
-    * ...   Scanamo.queryIndex[Transport](client)("transport", "colour-index")('colour -> "Magenta")
+    * ...   Scanamo.queryIndex[Transport](client)(t, i)('colour -> "Magenta")
     * ... }
     * List(Right(Transport(Underground,Metropolitan,Magenta)))
     * }}}
@@ -533,16 +533,16 @@ object Scanamo {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")(
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
-    * ... ) {
-    * ...   Scanamo.putAll(client)("transport")(Set(
+    * ... ) { (t, i) =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Transport("Underground", "Circle", "Yellow"),
     * ...     Transport("Underground", "Metropolitan", "Magenta"),
     * ...     Transport("Underground", "Central", "Red"),
     * ...     Transport("Underground", "Picadilly", "Blue"),
     * ...     Transport("Underground", "Northern", "Black")))
-    * ...   Scanamo.queryIndexWithLimit[Transport](client)("transport", "colour-index")(
+    * ...   Scanamo.queryIndexWithLimit[Transport](client)(t, i)(
     * ...     ('mode -> "Underground" and ('colour beginsWith "Bl")), 1)
     * ... }
     * List(Right(Transport(Underground,Northern,Black)))
@@ -562,18 +562,18 @@ object Scanamo {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")(
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
-    * ... ) {
-    * ...   Scanamo.putAll(client)("transport")(Set(
+    * ... ) { (t, i) =>
+    * ...   Scanamo.putAll(client)(t)(Set(
     * ...     Transport("Underground", "Circle", "Yellow"),
     * ...     Transport("Underground", "Metropolitan", "Magenta"),
     * ...     Transport("Underground", "Central", "Red"),
     * ...     Transport("Underground", "Picadilly", "Blue"),
     * ...     Transport("Underground", "Northern", "Black")))
-    * ...   val res1 = Scanamo.queryIndexFrom[Transport](client)("transport", "colour-index")(
+    * ...   val res1 = Scanamo.queryIndexFrom[Transport](client)(t, i)(
     * ...       ('mode -> "Underground" and ('colour beginsWith "Bl")), 1, None)
-    * ...   Scanamo.queryIndexFrom[Transport](client)("transport", "colour-index")(
+    * ...   Scanamo.queryIndexFrom[Transport](client)(t, i)(
     * ...       ('mode -> "Underground" and ('colour beginsWith "Bl")), 1, res1._2)._1
     * ... }
     * List(Right(Transport(Underground,Picadilly,Blue)))

--- a/scanamo/src/main/scala/com/gu/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/SecondaryIndex.scala
@@ -24,16 +24,16 @@ sealed abstract class SecondaryIndex[V] {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val table = Table[Bear]("bears")
     *
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("bears", "antagonist")('name -> S)('antagonist -> S) {
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('antagonist -> S) { (t, i) =>
+    * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey", None))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets", Some("Ranger Smith")))
     * ...     _ <- table.put(Bear("Paddington", "marmalade sandwiches", Some("Mr Curry")))
-    * ...     antagonisticBears <- table.index("antagonist").scan()
+    * ...     antagonisticBears <- table.index(i).scan()
     * ...   } yield antagonisticBears
     * ...   Scanamo.exec(client)(ops)
     * ... }
@@ -47,14 +47,14 @@ sealed abstract class SecondaryIndex[V] {
     *
     * {{{
     * >>> case class GithubProject(organisation: String, repository: String, language: String, license: String)
-    * >>> val githubProjects = Table[GithubProject]("github-projects")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("github-projects", "language-license")('organisation -> S, 'repository -> S)('language -> S, 'license -> S) {
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('organisation -> S, 'repository -> S)('language -> S, 'license -> S) { (t, i) =>
+    * ...   val githubProjects = Table[GithubProject](t)
     * ...   val operations = for {
     * ...     _ <- githubProjects.putAll(Set(
     * ...       GithubProject("typelevel", "cats", "Scala", "MIT"),
@@ -62,7 +62,7 @@ sealed abstract class SecondaryIndex[V] {
     * ...       GithubProject("tpolecat", "tut", "Scala", "MIT"),
     * ...       GithubProject("guardian", "scanamo", "Scala", "Apache 2")
     * ...     ))
-    * ...     scalaMIT <- githubProjects.index("language-license").query('language -> "Scala" and ('license -> "MIT"))
+    * ...     scalaMIT <- githubProjects.index(i).query('language -> "Scala" and ('license -> "MIT"))
     * ...   } yield scalaMIT.toList
     * ...   Scanamo.exec(client)(operations)
     * ... }
@@ -76,15 +76,15 @@ sealed abstract class SecondaryIndex[V] {
     *
     * {{{
     * >>> case class Transport(mode: String, line: String, colour: String)
-    * >>> val transport = Table[Transport]("transport")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")(
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
-    * ... ) {
+    * ... ) { (t, i) =>
+    * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
@@ -92,7 +92,7 @@ sealed abstract class SecondaryIndex[V] {
     * ...       Transport("Underground", "Central", "Red"),
     * ...       Transport("Underground", "Picadilly", "Blue"),
     * ...       Transport("Underground", "Northern", "Black")))
-    * ...     somethingBeginningWithBl <- transport.index("colour-index").limit(1).query(
+    * ...     somethingBeginningWithBl <- transport.index(i).limit(1).query(
     * ...       ('mode -> "Underground" and ('colour beginsWith "Bl")).descending
     * ...     )
     * ...   } yield somethingBeginningWithBl.toList
@@ -109,15 +109,15 @@ sealed abstract class SecondaryIndex[V] {
     * Note that rows filtered out still count towards your consumed capacity
     * {{{
     * >>> case class Transport(mode: String, line: String, colour: String)
-    * >>> val transport = Table[Transport]("transport")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")(
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
-    * ... ) {
+    * ... ) { (t, i) =>
+    * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
@@ -125,7 +125,7 @@ sealed abstract class SecondaryIndex[V] {
     * ...       Transport("Underground", "Central", "Red"),
     * ...       Transport("Underground", "Picadilly", "Blue"),
     * ...       Transport("Underground", "Northern", "Black")))
-    * ...     somethingBeginningWithC <- transport.index("colour-index")
+    * ...     somethingBeginningWithC <- transport.index(i)
     * ...                                   .filter('line beginsWith ("C"))
     * ...                                   .query('mode -> "Underground")
     * ...   } yield somethingBeginningWithC.toList

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -74,19 +74,19 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Transport(mode: String, line: String, colour: String)
-    * >>> val transport = Table[Transport]("transport")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")('mode -> S, 'line -> S)('colour -> S) {
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('colour -> S) { (t, i) =>
+    * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
     * ...       Transport("Underground", "Metropolitan", "Magenta"),
     * ...       Transport("Underground", "Central", "Red")))
-    * ...     MagentaLine <- transport.index("colour-index").query('colour -> "Magenta")
+    * ...     MagentaLine <- transport.index(i).query('colour -> "Magenta")
     * ...   } yield MagentaLine.toList
     * ...   Scanamo.exec(client)(operations)
     * ... }
@@ -95,9 +95,9 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class GithubProject(organisation: String, repository: String, language: String, license: String)
-    * >>> val githubProjects = Table[GithubProject]("github-projects")
     *
-    * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("github-projects", "language-license")('organisation -> S, 'repository -> S)('language -> S, 'license -> S) {
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('organisation -> S, 'repository -> S)('language -> S, 'license -> S) { (t, i) =>
+    * ...   val githubProjects = Table[GithubProject](t)
     * ...   val operations = for {
     * ...     _ <- githubProjects.putAll(Set(
     * ...       GithubProject("typelevel", "cats", "Scala", "MIT"),
@@ -105,7 +105,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       GithubProject("tpolecat", "tut", "Scala", "MIT"),
     * ...       GithubProject("guardian", "scanamo", "Scala", "Apache 2")
     * ...     ))
-    * ...     scalaMIT <- githubProjects.index("language-license").query('language -> "Scala" and ('license -> "MIT"))
+    * ...     scalaMIT <- githubProjects.index(i).query('language -> "Scala" and ('license -> "MIT"))
     * ...   } yield scalaMIT.toList
     * ...   Scanamo.exec(client)(operations)
     * ... }

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -13,13 +13,13 @@ import com.gu.scanamo.update.UpdateExpression
   *
   * {{{
   * >>> case class Transport(mode: String, line: String)
-  * >>> val transport = Table[Transport]("transport")
   *
   * >>> val client = LocalDynamoDB.client()
   * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
   *
-  * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
+  * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
   * ...   import com.gu.scanamo.syntax._
+  * ...   val transport = Table[Transport](t)
   * ...   val operations = for {
   * ...     _ <- transport.putAll(Set(
   * ...       Transport("Underground", "Circle"),
@@ -46,7 +46,6 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Farm(animals: List[String])
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
-    * >>> val farm = Table[Farmer]("farmers")
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
@@ -56,7 +55,8 @@ case class Table[V: DynamoFormat](name: String) {
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
-    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   val farm = Table[Farmer](t)
     * ...   val operations = for {
     * ...     _       <- farm.putAll(dataSet)
     * ...     _       <- farm.deleteAll('name -> dataSet.map(_.name))
@@ -122,13 +122,13 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Forecast(location: String, weather: String)
-    * >>> val forecast = Table[Forecast]("forecast")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("forecast")('location -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('location -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val forecast = Table[Forecast](t)
     * ...   val operations = for {
     * ...     _ <- forecast.put(Forecast("London", "Rain"))
     * ...     updated <- forecast.update('location -> "London", set('weather -> "Sun"))
@@ -142,10 +142,10 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Character(name: String, actors: List[String])
-    * >>> val characters = Table[Character]("characters")
     *
-    * >>> LocalDynamoDB.withTable(client)("characters")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val characters = Table[Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.put(Character("The Doctor", List("Ecclestone", "Tennant", "Smith")))
     * ...     _ <- characters.update('name -> "The Doctor", append('actors -> "Capaldi"))
@@ -160,8 +160,9 @@ case class Table[V: DynamoFormat](name: String) {
     * Appending or prepending creates the list if it does not yet exist:
     *
     * {{{
-    * >>> LocalDynamoDB.withTable(client)("characters")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val characters = Table[Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.update('name -> "James Bond", append('actors -> "Craig"))
     * ...     results <- characters.query('name -> "James Bond")
@@ -175,10 +176,10 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Fruit(kind: String, sources: List[String])
-    * >>> val fruits = Table[Fruit]("fruits")
     *
-    * >>> LocalDynamoDB.withTable(client)("fruits")('kind -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('kind -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val fruits = Table[Fruit](t)
     * ...   val operations = for {
     * ...     _ <- fruits.put(Fruit("watermelon", List("USA")))
     * ...     _ <- fruits.update('kind -> "watermelon", appendAll('sources -> List("China", "Turkey")))
@@ -193,10 +194,10 @@ case class Table[V: DynamoFormat](name: String) {
     * Multiple operations can also be performed in one call:
     * {{{
     * >>> case class Foo(name: String, bar: Int, l: List[String])
-    * >>> val foos = Table[Foo]("foos")
     *
-    * >>> LocalDynamoDB.withTable(client)("foos")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val foos = Table[Foo](t)
     * ...   val operations = for {
     * ...     _ <- foos.put(Foo("x", 0, List("First")))
     * ...     updated <- foos.update('name -> "x",
@@ -210,10 +211,10 @@ case class Table[V: DynamoFormat](name: String) {
     * It's also possible to perform `ADD` and `DELETE` updates
     * {{{
     * >>> case class Bar(name: String, counter: Long, set: Set[String])
-    * >>> val bars = Table[Bar]("bars")
     *
-    * >>> LocalDynamoDB.withTable(client)("bars")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val bars = Table[Bar](t)
     * ...   val operations = for {
     * ...     _ <- bars.put(Bar("x", 1L, Set("First")))
     * ...     _ <- bars.update('name -> "x",
@@ -230,10 +231,10 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class Inner(session: String)
     * >>> case class Middle(name: String, counter: Long, inner: Inner, list: List[Int])
     * >>> case class Outer(id: java.util.UUID, middle: Middle)
-    * >>> val outers = Table[Outer]("outers")
     *
-    * >>> LocalDynamoDB.withTable(client)("outers")('id -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('id -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val outers = Table[Outer](t)
     * ...   val id = java.util.UUID.fromString("a8345373-9a93-43be-9bcd-e3682c9197f4")
     * ...   val operations = for {
     * ...     _ <- outers.put(Outer(id, Middle("x", 1L, Inner("alpha"), List(1, 2))))
@@ -249,10 +250,10 @@ case class Table[V: DynamoFormat](name: String) {
     * It's possible to update one field to the value of another
     * {{{
     * >>> case class Thing(id: String, mandatory: Int, optional: Option[Int])
-    * >>> val things = Table[Thing]("things")
     *
-    * >>> LocalDynamoDB.withTable(client)("things")('id -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('id -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val things = Table[Thing](t)
     * ...   val operations = for {
     * ...     _ <- things.put(Thing("a1", 3, None))
     * ...     updated <- things.update('id -> "a1", set('optional -> 'mandatory))
@@ -269,13 +270,13 @@ case class Table[V: DynamoFormat](name: String) {
     * Query or scan a table, limiting the number of items evaluated by Dynamo
     * {{{
     * >>> case class Transport(mode: String, line: String)
-    * >>> val transport = Table[Transport]("transport")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle"),
@@ -298,12 +299,12 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class City(country: String, name: String)
-    * >>> val cityTable = Table[City]("cities")
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
-    * >>> val (get, scan, query) = LocalDynamoDB.withTable(client)("cities")('country -> S, 'name -> S) {
+    * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)('country -> S, 'name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   val cityTable = Table[City](t)
     * ...   val ops = for {
     * ...     putRes <- cityTable.putAll(Set(
     * ...       City("US", "Nashville"), City("IT", "Rome"), City("IT", "Siena"), City("TZ", "Dar es Salaam")))
@@ -337,8 +338,8 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
     *
-    * >>> val farmersTable = Table[Farmer]("nursery-farmers")
-    * >>> LocalDynamoDB.withTable(client)("nursery-farmers")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   val farmersTable = Table[Farmer](t)
     * ...   val farmerOps = for {
     * ...     _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
     * ...     _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"), 30)))
@@ -350,8 +351,8 @@ case class Table[V: DynamoFormat](name: String) {
     * Some(Right(Farmer(McDonald,156,Farm(List(sheep, chicken),30))))
     *
     * >>> case class Letter(roman: String, greek: String)
-    * >>> val lettersTable = Table[Letter]("letters")
-    * >>> LocalDynamoDB.withTable(client)("letters")('roman -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('roman -> S) { t => 
+    * ...   val lettersTable = Table[Letter](t)
     * ...   val ops = for {
     * ...     _ <- lettersTable.putAll(Set(Letter("a", "alpha"), Letter("b", "beta"), Letter("c", "gammon")))
     * ...     _ <- lettersTable.given('greek beginsWith "ale").put(Letter("a", "aleph"))
@@ -364,8 +365,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import cats.implicits._
     * >>> case class Turnip(size: Int, description: Option[String])
-    * >>> val turnipsTable = Table[Turnip]("turnips")
-    * >>> LocalDynamoDB.withTable(client)("turnips")('size -> N) {
+    * >>> LocalDynamoDB.withRandomTable(client)('size -> N) { t =>
+    * ...   val turnipsTable = Table[Turnip](t)
     * ...   val ops = for {
     * ...     _ <- turnipsTable.putAll(Set(Turnip(1, None), Turnip(1000, None)))
     * ...     initialTurnips <- turnipsTable.scan()
@@ -382,8 +383,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Thing(a: String, maybe: Option[Int])
-    * >>> val thingTable = Table[Thing]("things")
-    * >>> LocalDynamoDB.withTable(client)("things")('a -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('a -> S) { t =>
+    * ...   val thingTable = Table[Thing](t)
     * ...   val ops = for {
     * ...     _ <- thingTable.putAll(Set(Thing("a", None), Thing("b", Some(1)), Thing("c", None)))
     * ...     _ <- thingTable.given(attributeExists('maybe)).put(Thing("a", Some(2)))
@@ -401,8 +402,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Compound(a: String, maybe: Option[Int])
-    * >>> val compoundTable = Table[Compound]("compounds")
-    * >>> LocalDynamoDB.withTable(client)("compounds")('a -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('a -> S) { t =>
+    * ...   val compoundTable = Table[Compound](t)
     * ...   val ops = for {
     * ...     _ <- compoundTable.putAll(Set(Compound("alpha", None), Compound("beta", Some(1)), Compound("gamma", None)))
     * ...     _ <- compoundTable.given(attributeExists('maybe) and 'a -> "alpha").put(Compound("alpha", Some(2)))
@@ -419,8 +420,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Choice(number: Int, description: String)
-    * >>> val choicesTable = Table[Choice]("choices")
-    * >>> LocalDynamoDB.withTable(client)("choices")('number -> N) {
+    * >>> LocalDynamoDB.withRandomTable(client)('number -> N) { t =>
+    * ...   val choicesTable = Table[Choice](t)
     * ...   val ops = for {
     * ...     _ <- choicesTable.putAll(Set(Choice(1, "cake"), Choice(2, "crumble"), Choice(3, "custard")))
     * ...     _ <- choicesTable.given(Condition('description -> "cake") or Condition('description -> "death")).put(Choice(1, "victoria sponge"))
@@ -436,8 +437,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Gremlin(number: Int, wet: Boolean, friendly: Boolean)
-    * >>> val gremlinsTable = Table[Gremlin]("gremlins")
-    * >>> LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
+    * >>> LocalDynamoDB.withRandomTable(client)('number -> N) { t =>
+    * ...   val gremlinsTable = Table[Gremlin](t)
     * ...   val ops = for {
     * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, false)))
     * ...     _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
@@ -452,7 +453,8 @@ case class Table[V: DynamoFormat](name: String) {
     * and updates
     *
     * {{{
-    * >>> LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
+    * >>> LocalDynamoDB.withRandomTable(client)('number -> N) { t =>
+    * ...   val gremlinsTable = Table[Gremlin](t)
     * ...   val ops = for {
     * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, true)))
     * ...     _ <- gremlinsTable.given('wet -> true).update('number -> 1, set('friendly -> false))
@@ -467,8 +469,8 @@ case class Table[V: DynamoFormat](name: String) {
     * Conditions can also be placed on nested attributes
     *
     * {{{
-    * >>> val smallscaleFarmersTable = Table[Farmer]("smallscale-farmers")
-    * >>> LocalDynamoDB.withTable(client)("smallscale-farmers")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   val smallscaleFarmersTable = Table[Farmer](t)
     * ...   val farmerOps = for {
     * ...     _ <- smallscaleFarmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
     * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares < 40L).put(Farmer("McDonald", 156L, Farm(List("gerbil", "hamster"), 20)))
@@ -491,9 +493,9 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val table = Table[Bear]("bears")
     *
-    * >>> LocalDynamoDB.withTable(client)("bears")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey"))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets"))
@@ -513,12 +515,12 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class Transport(mode: String, line: String)
     *
     * >>> val client = LocalDynamoDB.client()
-    * >>> val table = Table[Transport]("transport")
     *
     * >>> import com.gu.scanamo.syntax._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * ...   val table = Table[Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
     * ...       Transport("Underground", "Circle"),
@@ -542,11 +544,11 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val table = Table[Bear]("bears")
     *
     * >>> import com.gu.scanamo.syntax._
     *
-    * >>> LocalDynamoDB.withTable(client)("bears")('name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey", None))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets", Some("Ranger Smith")))
@@ -559,11 +561,11 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> case class Station(line: String, name: String, zone: Int)
     *
-    * >>> val stationTable = Table[Station]("Station")
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("Station")('line -> S, 'name -> S) {
+    * >>> LocalDynamoDB.withRandomTable(client)('line -> S, 'name -> S) { t =>
+    * ...   val stationTable = Table[Station](t)
     * ...   val ops = for {
     * ...     _ <- stationTable.putAll(Set(
     * ...       Station("Metropolitan", "Chalfont & Latimer", 8),

--- a/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -20,79 +20,79 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should put asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
       import com.gu.scanamo.syntax._
 
       val result = for {
-        _ <- ScanamoAsync.put(client)("asyncFarmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-      } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McDonald")
+        _ <- ScanamoAsync.put(client)(t)(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
+      } yield Scanamo.get[Farmer](client)(t)('name -> "McDonald")
 
       result.futureValue should equal(Some(Right(Farmer("McDonald", 156, Farm(List("sheep", "cow"))))))
     }
   }
 
   it("should get asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.put(client)("asyncFarmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
+      Scanamo.put(client)(t)(Farmer("Maggot", 75L, Farm(List("dog"))))
 
-      ScanamoAsync.get[Farmer](client)("asyncFarmers")(UniqueKey(KeyEquals('name, "Maggot"))).futureValue should equal(
+      ScanamoAsync.get[Farmer](client)(t)(UniqueKey(KeyEquals('name, "Maggot"))).futureValue should equal(
         Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))))
 
       import com.gu.scanamo.syntax._
 
-      ScanamoAsync.get[Farmer](client)("asyncFarmers")('name -> "Maggot").futureValue should equal(
+      ScanamoAsync.get[Farmer](client)(t)('name -> "Maggot").futureValue should equal(
         Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))))
     }
 
-    LocalDynamoDB.usingTable(client)("asyncEngines")('name -> S, 'number -> N) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S, 'number -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      Scanamo.put(client)("asyncEngines")(Engine("Thomas", 1))
+      Scanamo.put(client)(t)(Engine("Thomas", 1))
 
       import com.gu.scanamo.syntax._
-      ScanamoAsync.get[Engine](client)("asyncEngines")('name -> "Thomas" and 'number -> 1).futureValue should equal(
+      ScanamoAsync.get[Engine](client)(t)('name -> "Thomas" and 'number -> 1).futureValue should equal(
         Some(Right(Engine("Thomas", 1))))
     }
   }
 
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
-    LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       import com.gu.scanamo.syntax._
-      ScanamoAsync.put(client)("asyncCities")(City("Nashville", "US")).flatMap {
+      ScanamoAsync.put(client)(t)(City("Nashville", "US")).flatMap {
         case _ =>
-          ScanamoAsync.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")
+          ScanamoAsync.getWithConsistency[City](client)(t)('name -> "Nashville")
       }.futureValue should equal(Some(Right(City("Nashville", "US"))))
     }
   }
 
   it("should delete asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.put(client)("asyncFarmers")(Farmer("McGregor", 62L, Farm(List("rabbit"))))
+      Scanamo.put(client)(t)(Farmer("McGregor", 62L, Farm(List("rabbit"))))
 
       import com.gu.scanamo.syntax._
 
       val maybeFarmer = for {
-        _ <- ScanamoAsync.delete(client)("asyncFarmers")('name -> "McGregor")
-      } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McGregor")
+        _ <- ScanamoAsync.delete(client)(t)('name -> "McGregor")
+      } yield Scanamo.get[Farmer](client)(t)('name -> "McGregor")
 
       maybeFarmer.futureValue should equal(None)
     }
   }
 
   it("should deleteAll asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
@@ -105,39 +105,39 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
         Farmer("Jack", 2L, Farm(List("velociraptor")))
       )
 
-      Scanamo.putAll(client)("asyncFarmers")(dataSet)
+      Scanamo.putAll(client)(t)(dataSet)
 
       val maybeFarmer = for {
-        _ <- ScanamoAsync.deleteAll(client)("asyncFarmers")('name -> dataSet.map(_.name))
-      } yield Scanamo.scan[Farmer](client)("asyncFarmers")
+        _ <- ScanamoAsync.deleteAll(client)(t)('name -> dataSet.map(_.name))
+      } yield Scanamo.scan[Farmer](client)(t)
 
       maybeFarmer.futureValue should equal(List.empty)
     }
   }
 
   it("should update asynchronously") {
-    LocalDynamoDB.usingTable(client)("forecast")('location -> S) {
+    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
 
       case class Forecast(location: String, weather: String)
 
-      Scanamo.put(client)("forecast")(Forecast("London", "Rain"))
+      Scanamo.put(client)(t)(Forecast("London", "Rain"))
 
       import com.gu.scanamo.syntax._
 
       val forecasts = for {
-        _ <- ScanamoAsync.update(client)("forecast")('location -> "London", set('weather -> "Sun"))
-      } yield Scanamo.scan[Forecast](client)("forecast")
+        _ <- ScanamoAsync.update(client)(t)('location -> "London", set('weather -> "Sun"))
+      } yield Scanamo.scan[Forecast](client)(t)
 
       forecasts.futureValue should equal(List(Right(Forecast("London", "Sun"))))
     }
   }
 
   it("should update asynchronously if a condition holds") {
-    LocalDynamoDB.usingTable(client)("forecast")('location -> S) {
+    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
 
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Forecast]("forecast")
+      val forecasts = Table[Forecast](t)
 
       import com.gu.scanamo.syntax._
 
@@ -154,37 +154,37 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should scan asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncBears")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Bear(name: String, favouriteFood: String)
 
-      Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
-      Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
+      Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+      Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
 
-      ScanamoAsync.scan[Bear](client)("asyncBears").futureValue.toList should equal(
+      ScanamoAsync.scan[Bear](client)(t).futureValue.toList should equal(
         List(Right(Bear("Pooh", "honey")), Right(Bear("Yogi", "picnic baskets")))
       )
     }
 
-    LocalDynamoDB.usingTable(client)("asyncLemmings")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Lemming(name: String, stuff: String)
 
-      Scanamo.putAll(client)("asyncLemmings")(
+      Scanamo.putAll(client)(t)(
         (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet
       )
 
-      ScanamoAsync.scan[Lemming](client)("asyncLemmings").futureValue.toList.size should equal(100)
+      ScanamoAsync.scan[Lemming](client)(t).futureValue.toList.size should equal(100)
     }
   }
 
   it("scans with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingTable(client)("asyncBears")('name -> S) {
-      Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
-      Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
-      val results = ScanamoAsync.scanWithLimit[Bear](client)("asyncBears", 1)
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+      Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+      val results = ScanamoAsync.scanWithLimit[Bear](client)(t, 1)
       results.futureValue should equal(List(Right(Bear("Pooh", "honey"))))
     }
   }
@@ -192,14 +192,14 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("paginates with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingTable(client)("asyncBears")('name -> S) {
-      Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
-      Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
-      Scanamo.put(client)("asyncBears")(Bear("Graham", "quinoa"))
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      Scanamo.put(client)(t)(Bear("Pooh", "honey"))
+      Scanamo.put(client)(t)(Bear("Yogi", "picnic baskets"))
+      Scanamo.put(client)(t)(Bear("Graham", "quinoa"))
       val results = for {
-        res1 <- ScanamoAsync.scanFrom[Bear](client)("asyncBears", 1, None)
-        res2 <- ScanamoAsync.scanFrom[Bear](client)("asyncBears", 1, res1._2)
-        res3 <- ScanamoAsync.scanFrom[Bear](client)("asyncBears", 1, res2._2)
+        res1 <- ScanamoAsync.scanFrom[Bear](client)(t, 1, None)
+        res2 <- ScanamoAsync.scanFrom[Bear](client)(t, 1, res1._2)
+        res3 <- ScanamoAsync.scanFrom[Bear](client)(t, 1, res2._2)
       } yield res2._1 ::: res3._1
       results.futureValue should equal(List(Right(Bear("Yogi", "picnic baskets")), Right(Bear("Graham", "quinoa"))))
     }
@@ -236,55 +236,55 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should query asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncAnimals")('species -> S, 'number -> N) {
+    LocalDynamoDB.usingRandomTable(client)('species -> S, 'number -> N) { t =>
 
       case class Animal(species: String, number: Int)
 
-      Scanamo.put(client)("asyncAnimals")(Animal("Wolf", 1))
+      Scanamo.put(client)(t)(Animal("Wolf", 1))
 
-      for { i <- 1 to 3 } Scanamo.put(client)("asyncAnimals")(Animal("Pig", i))
+      for { i <- 1 to 3 } Scanamo.put(client)(t)(Animal("Pig", i))
 
       import com.gu.scanamo.syntax._
 
-      ScanamoAsync.query[Animal](client)("asyncAnimals")('species -> "Pig").futureValue.toList should equal(
+      ScanamoAsync.query[Animal](client)(t)('species -> "Pig").futureValue.toList should equal(
         List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2)), Right(Animal("Pig", 3))))
 
       ScanamoAsync
-        .query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number < 3)
+        .query[Animal](client)(t)('species -> "Pig" and 'number < 3)
         .futureValue
         .toList should equal(List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2))))
 
       ScanamoAsync
-        .query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number > 1)
+        .query[Animal](client)(t)('species -> "Pig" and 'number > 1)
         .futureValue
         .toList should equal(List(Right(Animal("Pig", 2)), Right(Animal("Pig", 3))))
 
       ScanamoAsync
-        .query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number <= 2)
+        .query[Animal](client)(t)('species -> "Pig" and 'number <= 2)
         .futureValue
         .toList should equal(List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2))))
 
       ScanamoAsync
-        .query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number >= 2)
+        .query[Animal](client)(t)('species -> "Pig" and 'number >= 2)
         .futureValue
         .toList should equal(List(Right(Animal("Pig", 2)), Right(Animal("Pig", 3))))
 
     }
 
-    LocalDynamoDB.usingTable(client)("asyncTransport")('mode -> S, 'line -> S) {
+    LocalDynamoDB.usingRandomTable(client)('mode -> S, 'line -> S) { t =>
 
       case class Transport(mode: String, line: String)
 
       import com.gu.scanamo.syntax._
 
-      Scanamo.putAll(client)("asyncTransport")(
+      Scanamo.putAll(client)(t)(
         Set(
           Transport("Underground", "Circle"),
           Transport("Underground", "Metropolitan"),
           Transport("Underground", "Central")))
 
       ScanamoAsync
-        .query[Transport](client)("asyncTransport")('mode -> "Underground" and ('line beginsWith "C"))
+        .query[Transport](client)(t)('mode -> "Underground" and ('line beginsWith "C"))
         .futureValue
         .toList should equal(
         List(Right(Transport("Underground", "Central")), Right(Transport("Underground", "Circle"))))
@@ -384,9 +384,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     import com.gu.scanamo.syntax._
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('firstName -> S, 'surname -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('firstName -> S, 'surname -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -399,13 +399,13 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("should put multiple items asynchronously") {
     case class Rabbit(name: String)
 
-    LocalDynamoDB.usingTable(client)("asyncRabbits")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       val result = for {
-        _ <- ScanamoAsync.putAll(client)("asyncRabbits")(
+        _ <- ScanamoAsync.putAll(client)(t)(
           (
             for { _ <- 0 until 100 } yield Rabbit(util.Random.nextString(500))
           ).toSet)
-      } yield Scanamo.scan[Rabbit](client)("asyncRabbits")
+      } yield Scanamo.scan[Rabbit](client)(t)
 
       result.futureValue.toList.size should equal(100)
     }
@@ -413,12 +413,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should get multiple items asynchronously") {
-    LocalDynamoDB.usingTable(client)("asyncFarmers")('name -> S) {
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
 
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.putAll(client)("asyncFarmers")(
+      Scanamo.putAll(client)(t)(
         Set(
           Farmer("Boggis", 43L, Farm(List("chicken"))),
           Farmer("Bunce", 52L, Farm(List("goose"))),
@@ -426,7 +426,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
         ))
 
       ScanamoAsync
-        .getAll[Farmer](client)("asyncFarmers")(
+        .getAll[Farmer](client)(t)(
           UniqueKeys(KeyList('name, Set("Boggis", "Bean")))
         )
         .futureValue should equal(
@@ -434,19 +434,19 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
       import com.gu.scanamo.syntax._
 
-      ScanamoAsync.getAll[Farmer](client)("asyncFarmers")('name -> Set("Boggis", "Bean")).futureValue should equal(
+      ScanamoAsync.getAll[Farmer](client)(t)('name -> Set("Boggis", "Bean")).futureValue should equal(
         Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
     }
 
-    LocalDynamoDB.usingTable(client)("asyncDoctors")('actor -> S, 'regeneration -> N) {
+    LocalDynamoDB.usingRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
 
-      Scanamo.putAll(client)("asyncDoctors")(
+      Scanamo.putAll(client)(t)(
         Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
 
       import com.gu.scanamo.syntax._
       ScanamoAsync
-        .getAll[Doctor](client)("asyncDoctors")(
+        .getAll[Doctor](client)(t)(
           ('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11)
         )
         .futureValue should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
@@ -455,15 +455,15 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should get multiple items asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingTable(client)("asyncFarms")('id -> N) {
+    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
 
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
 
-      Scanamo.putAll(client)("asyncFarms")(farms)
+      Scanamo.putAll(client)(t)(farms)
 
       ScanamoAsync
-        .getAll[Farm](client)("asyncFarms")(
+        .getAll[Farm](client)(t)(
           UniqueKeys(KeyList('id, farms.map(_.id)))
         )
         .futureValue should equal(farms.map(Right(_)))
@@ -471,15 +471,15 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should get multiple items consistently asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingTable(client)("asyncFarms")('id -> N) {
+    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
 
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
 
-      Scanamo.putAll(client)("asyncFarms")(farms)
+      Scanamo.putAll(client)(t)(farms)
 
       ScanamoAsync
-        .getAllWithConsistency[Farm](client)("asyncFarms")(
+        .getAllWithConsistency[Farm](client)(t)(
           UniqueKeys(KeyList('id, farms.map(_.id)))
         )
         .futureValue should equal(farms.map(Right(_)))
@@ -490,9 +490,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -506,9 +506,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -522,9 +522,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     import com.gu.scanamo.syntax._
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
@@ -542,9 +542,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     import com.gu.scanamo.syntax._
 
-    val farmersTable = Table[Farmer]("nursery-farmers")
+    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      val farmersTable = Table[Farmer](t)
 
-    LocalDynamoDB.usingTable(client)("nursery-farmers")('name -> S) {
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
         _ <- farmersTable.put(Farmer("Butch", 57, Farm(List("cattle"))))
@@ -564,9 +564,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     import com.gu.scanamo.syntax._
 
-    val gremlinsTable = Table[Gremlin]("gremlins")
+    LocalDynamoDB.usingRandomTable(client)('number -> N) { t =>
+      val gremlinsTable = Table[Gremlin](t)
 
-    LocalDynamoDB.usingTable(client)("gremlins")('number -> N) {
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
         _ <- gremlinsTable.given('wet -> true).delete('number -> 1)

--- a/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -296,13 +296,13 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-      Scanamo.putAll(client)("transport")(
+    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+      Scanamo.putAll(client)(t)(
         Set(
           Transport("Underground", "Circle"),
           Transport("Underground", "Metropolitan"),
           Transport("Underground", "Central")))
-      val results = ScanamoAsync.queryWithLimit[Transport](client)("transport")(
+      val results = ScanamoAsync.queryWithLimit[Transport](client)(t)(
         'mode -> "Underground" and ('line beginsWith "C"),
         1)
       results.futureValue should equal(List(Right(Transport("Underground", "Central"))))

--- a/scanamo/src/test/scala/com/gu/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/update/UpdateExpressionTest.scala
@@ -34,7 +34,7 @@ class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matc
     } yield left and right
 
   def genTree(level: Int): Gen[UpdateExpression] =
-    if (level >= 100) leaf
+    if (level >= 10) leaf
     else {
       Gen.oneOf(leaf, genNode(level + 1))
     }

--- a/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -23,6 +23,28 @@ object LocalDynamoDB {
       arbitraryThroughputThatIsIgnoredByDynamoDBLocal
     )
 
+  def createTableWithIndex(
+    client: AmazonDynamoDB, 
+    tableName: String, 
+    secondaryIndexName: String,
+    primaryIndexAttributes: List[(Symbol, ScalarAttributeType)],
+    secondaryIndexAttributes: List[(Symbol, ScalarAttributeType)]
+  ) =
+    client.createTable(
+      new CreateTableRequest()
+        .withTableName(tableName)
+        .withAttributeDefinitions(attributeDefinitions(
+          primaryIndexAttributes ++ (secondaryIndexAttributes diff primaryIndexAttributes)))
+        .withKeySchema(keySchema(primaryIndexAttributes))
+        .withProvisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+        .withGlobalSecondaryIndexes(
+          new GlobalSecondaryIndex()
+            .withIndexName(secondaryIndexName)
+            .withKeySchema(keySchema(secondaryIndexAttributes))
+            .withProvisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+            .withProjection(new Projection().withProjectionType(ProjectionType.ALL)))
+    )
+
   def deleteTable(client: AmazonDynamoDB)(tableName: String) = {
       client.deleteTable(tableName)
   }
@@ -75,22 +97,35 @@ object LocalDynamoDB {
       primaryIndexAttributes: (Symbol, ScalarAttributeType)*)(secondaryIndexAttributes: (Symbol, ScalarAttributeType)*)(
       thunk: => T
   ): T = {
-    client.createTable(
-      new CreateTableRequest()
-        .withTableName(tableName)
-        .withAttributeDefinitions(attributeDefinitions(
-          primaryIndexAttributes.toList ++ (secondaryIndexAttributes.toList diff primaryIndexAttributes.toList)))
-        .withKeySchema(keySchema(primaryIndexAttributes))
-        .withProvisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
-        .withGlobalSecondaryIndexes(
-          new GlobalSecondaryIndex()
-            .withIndexName(secondaryIndexName)
-            .withKeySchema(keySchema(secondaryIndexAttributes))
-            .withProvisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
-            .withProjection(new Projection().withProjectionType(ProjectionType.ALL)))
-    )
+    createTableWithIndex(client, tableName, secondaryIndexName, primaryIndexAttributes.toList, secondaryIndexAttributes.toList)
     val res = try {
       thunk
+    } finally {
+      client.deleteTable(tableName)
+      ()
+    }
+    res
+  }
+
+  def withRandomTableWithSecondaryIndex[T](client: AmazonDynamoDB)(primaryIndexAttributes: (Symbol, ScalarAttributeType)*)(secondaryIndexAttributes: (Symbol, ScalarAttributeType)*)(
+      thunk: (String, String) => T
+  ): T = {
+    var tableName: String = null
+    var indexName: String = null
+    var created: Boolean = false
+    while (!created) {
+      try {
+        tableName = java.util.UUID.randomUUID.toString
+        indexName = java.util.UUID.randomUUID.toString
+        createTableWithIndex(client, tableName, indexName, primaryIndexAttributes.toList, secondaryIndexAttributes.toList)
+        created = true
+      } catch {
+        case t: ResourceInUseException =>
+      }
+    }
+
+    val res = try {
+      thunk(tableName, indexName)
     } finally {
       client.deleteTable(tableName)
       ()

--- a/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -15,22 +15,13 @@ object LocalDynamoDB {
       .withEndpointConfiguration(new EndpointConfiguration("http://localhost:8042", ""))
       .build()
 
-  def createTable(client: AmazonDynamoDB)(tableName: String)(attributes: (Symbol, ScalarAttributeType)*) = {
-    var created = false
-    while (!created) {
-      try {
+  def createTable(client: AmazonDynamoDB)(tableName: String)(attributes: (Symbol, ScalarAttributeType)*) =
         client.createTable(
           attributeDefinitions(attributes),
           tableName,
           keySchema(attributes),
           arbitraryThroughputThatIsIgnoredByDynamoDBLocal
         )
-        created = true
-      } catch {
-        case x: ResourceInUseException if x.getMessage.contains("preexisting") => client.deleteTable(tableName)
-      }
-    }
-  }
 
   def deleteTable(client: AmazonDynamoDB)(tableName: String) = {
       client.deleteTable(tableName)

--- a/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -93,6 +93,13 @@ object LocalDynamoDB {
     ()
   }
 
+  def usingRandomTable[T](client: AmazonDynamoDB)(attributeDefinitions: (Symbol, ScalarAttributeType)*)(
+      thunk: String => T
+  ): Unit = {
+    withRandomTable(client)(attributeDefinitions: _*)(thunk)
+    ()
+  }
+
   def withTableWithSecondaryIndex[T](client: AmazonDynamoDB)(tableName: String, secondaryIndexName: String)(
       primaryIndexAttributes: (Symbol, ScalarAttributeType)*)(secondaryIndexAttributes: (Symbol, ScalarAttributeType)*)(
       thunk: => T


### PR DESCRIPTION
Coming up with table names is an annoyance in tests, only exacerbated by the fact that there may be some race condition lurking around (explaining the "cannot create preexisting table" exceptions occurring on Travis but not locally).

This PR introduces three new APIs in the `LocalDynamoDB` facility:

- `withRandomTable`
- `withRandomTableWithSecondaryIndex`
- `usingRandomTable`

They work exactly the same as their non-random counterparts, only that the thunk takes the table name as input.