### PR TITLE
Add `Table.queryFrom` and `Table.scanFrom`

### DIFF
--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -510,7 +510,7 @@ case class Table[V: DynamoFormat](name: String) {
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] = ScanamoFree.scan[V](name)
 
   /**
-    * Scans all elements of a table
+    * Scans all elements of a table starting from the specified key
     *
     * {{{
     * >>> case class Bear(name: String, favouriteFood: String)
@@ -566,7 +566,7 @@ case class Table[V: DynamoFormat](name: String) {
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] = ScanamoFree.query[V](name)(query)
 
   /**
-    * Query a table based on the hash key and optionally the range key
+    * Query a table based on the hash key and optionally the range key, starting from the specified key
     *
     * {{{
     * >>> case class Transport(mode: String, line: String)

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -642,4 +642,8 @@ private[scanamo] case class TableWithOptions[V: DynamoFormat](tableName: String,
     ScanResultStream.stream[V](ScanamoScanRequest(tableName, None, queryOptions)).map(_._1)
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =
     QueryResultStream.stream[V](ScanamoQueryRequest(tableName, None, query, queryOptions)).map(_._1)
+  def scanWithLastKey(): ScanamoOps[(List[Either[DynamoReadError, V]], Option[EvaluationKey])] =
+    ScanResultStream.stream[V](ScanamoScanRequest(tableName, None, queryOptions))
+  def queryWithLastKey(query: Query[_]): ScanamoOps[(List[Either[DynamoReadError, V]], Option[EvaluationKey])] =
+    QueryResultStream.stream[V](ScanamoQueryRequest(tableName, None, query, queryOptions))
 }

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -528,7 +528,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...     _ <- table.put(Bear("Iorek Byrnison", "seal"))
     * ...     _ <- table.put(Bear("Rupert Bear", "tuna sandwich"))
     * ...     bears <- table.scanFrom('name -> "Paddington")
-    * ...   } yield bears
+    * ...   } yield bears._1
     * ...   Scanamo.exec(client)(ops)
     * ... }
     * List(Right(Bear(Baloo,ants)), Right(Bear(Pooh,honey)), Right(Bear(Iorek Byrnison,seal)), Right(Bear(Rupert Bear,tuna sandwich)))

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -311,11 +311,11 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       Transport("Underground", "Metropolitan"),
     * ...       Transport("Underground", "Victorias"),
     * ...       Transport("Underground", "Central")))
-    * ...     results <- transport.from(???).scan('mode -> "Underground" and ('line beginsWith "C"))
-    * ...   } yield results.toList
+    * ...     results <- transport.from('mode -> "Underground" and 'line -> "Circle").scanWithLastKey
+    * ...   } yield results._1.toList
     * ...   Scanamo.exec(client)(operations)
     * ... }
-    * List(Right(Transport(Underground,Central)))
+    * List(Right(Transport(Underground,Metropolitan)), Right(Transport(Underground,Victorias)))
     * }}}
     */
   def from(k: UniqueKey[_]) = TableWithOptions[V](name, ScanamoQueryOptions.default).from(k)

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -7,6 +7,7 @@ import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
 import com.gu.scanamo.request.{ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest}
 import com.gu.scanamo.update.UpdateExpression
+import scala.collection.JavaConverters._
 
 /**
   * Represents a DynamoDB table that operations can be performed against
@@ -317,7 +318,7 @@ case class Table[V: DynamoFormat](name: String) {
     * List(Right(Transport(Underground,Central)))
     * }}}
     */
-  def from(k: EvaluationKey) = TableWithOptions[V](name, ScanamoQueryOptions.default).from(k)
+  def from(k: UniqueKey[_]) = TableWithOptions[V](name, ScanamoQueryOptions.default).from(k)
 
   /**
     * Perform strongly consistent (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html)
@@ -616,7 +617,7 @@ case class Table[V: DynamoFormat](name: String) {
 private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](tableName: String) {
   def limit(n: Int): TableWithOptions[V] =
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.limit(n)
-  def from(k: EvaluationKey): TableWithOptions[V] =
+  def from(k: UniqueKey[_]): TableWithOptions[V] =
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.from(k)
   def filter[T](c: Condition[T]): TableWithOptions[V] =
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.filter(c)
@@ -633,7 +634,7 @@ private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](tableName: St
 
 private[scanamo] case class TableWithOptions[V: DynamoFormat](tableName: String, queryOptions: ScanamoQueryOptions) {
   def limit(n: Int): TableWithOptions[V] = copy(queryOptions = queryOptions.copy(limit = Some(n)))
-  def from(k: EvaluationKey): TableWithOptions[V] = copy(queryOptions = queryOptions.copy(exclusiveStartKey = Some(k)))
+  def from(k: UniqueKey[_]): TableWithOptions[V] = copy(queryOptions = queryOptions.copy(exclusiveStartKey = Some(k.asAVMap.asJava)))
   def consistently: TableWithOptions[V] = copy(queryOptions = queryOptions.copy(consistent = true))
   def filter[T](c: Condition[T]): TableWithOptions[V] = copy(queryOptions = queryOptions.copy(filter = Some(c)))
 

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -531,7 +531,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...   } yield bears
     * ...   Scanamo.exec(client)(ops)
     * ... }
-    * List(Right(Bear("Baloo", "ants")), Right(Bear("Iorek Byrnison", "seal")), Right(Bear("Rupert Bear", "tuna sandwich")))
+    * List(Right(Bear(Baloo,ants)), Right(Bear(Pooh,honey)), Right(Bear(Iorek Byrnison,seal)), Right(Bear(Rupert Bear,tuna sandwich)))
     * }}}
     */
   def scanFrom[K: UniqueKeyCondition](key: UniqueKey[K]): ScanamoOps[(List[Either[DynamoReadError, V]], Option[UniqueKey[K]])] = 

--- a/scanamo/src/main/scala/com/gu/scanamo/query/UniqueKeyCondition.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/query/UniqueKeyCondition.scala
@@ -5,18 +5,31 @@ import com.gu.scanamo.DynamoFormat
 import simulacrum.typeclass
 
 @typeclass trait UniqueKeyCondition[T] {
+  type K
   def asAVMap(t: T): Map[String, AttributeValue]
+  def fromAVMap(key: K, map: Map[String, AttributeValue]): Option[T]
 }
 
 object UniqueKeyCondition {
   implicit def uniqueEqualsKey[V: DynamoFormat] = new UniqueKeyCondition[KeyEquals[V]] {
+    type K = Symbol
     override def asAVMap(t: KeyEquals[V]): Map[String, AttributeValue] =
       Map(t.key.name -> DynamoFormat[V].write(t.v))
+    override def fromAVMap(key: K, map: Map[String, AttributeValue]) =
+      map.get(key.name).flatMap(DynamoFormat[V].read(_).fold(_ => None, v => Some(KeyEquals(key, v))))
   }
   implicit def uniqueAndEqualsKey[H: UniqueKeyCondition, R: UniqueKeyCondition] =
     new UniqueKeyCondition[AndEqualsCondition[H, R]] {
+      val H = UniqueKeyCondition[H]
+      val R = UniqueKeyCondition[R]
+      type K = (H.K, R.K)
       override def asAVMap(t: AndEqualsCondition[H, R]): Map[String, AttributeValue] =
-        UniqueKeyCondition[H].asAVMap(t.hashEquality) ++ UniqueKeyCondition[R].asAVMap(t.rangeEquality)
+        H.asAVMap(t.hashEquality) ++ R.asAVMap(t.rangeEquality)
+      override def fromAVMap(key: K, map: Map[String, AttributeValue]) =
+        for {
+          h <- H.fromAVMap(key._1, map)
+          r <- R.fromAVMap(key._2, map)
+        } yield AndEqualsCondition(h, r)
     }
 }
 


### PR DESCRIPTION
Adds the ability to paginate using the `Table` API, as methods other than `exec` on `Scanamo*` will eventually be [deprecated](#146).

At the moment, it requires the addition of two new APIs on `TableWithOptions`, namely `scanWithLastKey` and `queryWithLastKey`, so that the result can contain the last pagination key if there is one. This is not ideal, augmenting the surface API introduces new opportunities for bugs to creep in. What we want are "all-powerful" scan/query operations, let's call them `scan0`/`query0` and all the other variants piggyback on them with ad hoc defaults.

Another issue I need to figure out is the asymmetry between the input key (a `UniqueKey[_]`) and the output key (a `java.util.Map[String, AttributeValue]`). I have added enriched `UniqueKeyCondition` with a `fromAVMap` function, but it is not yet clear when or where to call it; I still need to look into that.