### PR TITLE
Upgrade scalafmt to RC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val formats = (project in file("formats"))
   .settings(
     commonSettings,
     publishingSettings,
-    name := "scanamo-formats",
+    name := "scanamo-formats"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -143,7 +143,7 @@ lazy val catsEffect = (project in file("cats"))
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
     ),
     fork in Test := true,
-    scalacOptions in (Compile, doc) += "-no-link-warnings",
+    scalacOptions in (Compile, doc) += "-no-link-warnings"
   )
   .dependsOn(formats, scanamo, testkit % "test->test")
 
@@ -161,7 +161,7 @@ lazy val scalaz = (project in file("scalaz"))
       "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
     ),
     fork in Test := true,
-    scalacOptions in (Compile, doc) += "-no-link-warnings",
+    scalacOptions in (Compile, doc) += "-no-link-warnings"
   )
   .dependsOn(formats, scanamo, testkit % "test->test")
 
@@ -169,7 +169,7 @@ lazy val alpakka = (project in file("alpakka"))
   .settings(
     commonSettings,
     publishingSettings,
-    name := "scanamo-alpakka",
+    name := "scanamo-alpakka"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -181,7 +181,7 @@ lazy val alpakka = (project in file("alpakka"))
     ),
     fork in Test := true,
     // unidoc can work out links to other project, but scalac can't
-    scalacOptions in (Compile, doc) += "-no-link-warnings",
+    scalacOptions in (Compile, doc) += "-no-link-warnings"
   )
   .dependsOn(formats, scanamo, testkit % "test->test")
 
@@ -189,7 +189,7 @@ lazy val javaTime = (project in file("java-time"))
   .settings(
     commonSettings,
     publishingSettings,
-    name := "scanamo-time",
+    name := "scanamo-time"
   )
   .settings(
     libraryDependencies ++= List(
@@ -204,7 +204,7 @@ lazy val joda = (project in file("joda"))
   .settings(
     commonSettings,
     publishingSettings,
-    name := "scanamo-joda",
+    name := "scanamo-joda"
   )
   .settings(
     libraryDependencies ++= List(
@@ -227,7 +227,7 @@ lazy val docs = (project in file("docs"))
     git.remoteRepo := "git@github.com:scanamo/scanamo.git",
     makeMicrosite := makeMicrosite.dependsOn(unidoc in Compile).value,
     addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc),
-    siteSubdirName in ScalaUnidoc := "latest/api",
+    siteSubdirName in ScalaUnidoc := "latest/api"
   )
   .enablePlugins(MicrositesPlugin, SiteScaladocPlugin, GhpagesPlugin, ScalaUnidocPlugin)
   .disablePlugins(ReleasePlugin)
@@ -278,7 +278,7 @@ val publishingSettings = Seq(
     commitNextVersion,
     releaseStepCommandAndRemaining("+sonatypeReleaseAll"),
     pushChanges,
-    releaseStepCommandAndRemaining("publishMicrosite"),
+    releaseStepCommandAndRemaining("publishMicrosite")
   )
 )
 

--- a/cats/src/main/scala/com/gu/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/com/gu/scanamo/ops/CatsInterpreter.scala
@@ -10,8 +10,10 @@ import com.amazonaws.services.dynamodbv2.model._
 
 object CatsInterpreter {
   def effect[F[_]](client: AmazonDynamoDBAsync)(implicit F: Effect[F]): ScanamoOpsA ~> F = new (ScanamoOpsA ~> F) {
-    private def eff[A <: AmazonWebServiceRequest, B](f: (A, AsyncHandler[A, B]) => java.util.concurrent.Future[B],
-                                                     req: A): F[B] =
+    private def eff[A <: AmazonWebServiceRequest, B](
+      f: (A, AsyncHandler[A, B]) => java.util.concurrent.Future[B],
+      req: A
+    ): F[B] =
       F.async { cb =>
         val handler = new AsyncHandler[A, B] {
           def onError(exception: Exception): Unit =

--- a/formats/src/main/scala/com/gu/scanamo/DerivedDynamoFormat.scala
+++ b/formats/src/main/scala/com/gu/scanamo/DerivedDynamoFormat.scala
@@ -91,15 +91,19 @@ trait DerivedDynamoFormat {
     }
   }
 
-  implicit def genericProduct[T: NotSymbol, R](implicit gen: LabelledGeneric.Aux[T, R],
-                                               formatR: Lazy[ValidConstructedDynamoFormat[R]]): DynamoFormat[T] =
+  implicit def genericProduct[T: NotSymbol, R](
+    implicit gen: LabelledGeneric.Aux[T, R],
+    formatR: Lazy[ValidConstructedDynamoFormat[R]]
+  ): DynamoFormat[T] =
     new DynamoFormat[T] {
       def read(av: AttributeValue): Either[DynamoReadError, T] = formatR.value.read(av).map(gen.from).toEither
       def write(t: T): AttributeValue = formatR.value.write(gen.to(t))
     }
 
-  implicit def genericCoProduct[T, R](implicit gen: LabelledGeneric.Aux[T, R],
-                                      formatR: Lazy[CoProductDynamoFormat[R]]): DynamoFormat[T] =
+  implicit def genericCoProduct[T, R](
+    implicit gen: LabelledGeneric.Aux[T, R],
+    formatR: Lazy[CoProductDynamoFormat[R]]
+  ): DynamoFormat[T] =
     new DynamoFormat[T] {
       def read(av: AttributeValue): Either[DynamoReadError, T] = formatR.value.read(av).map(gen.from)
       def write(t: T): AttributeValue = formatR.value.write(gen.to(t))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC5")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC4")
 
 // Not available for SBT 1.0
 //addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC5")
 
 // Not available for SBT 1.0
 //addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")

--- a/scalaz/src/main/scala/com/gu/scanamo/ScanamoScalaz.scala
+++ b/scalaz/src/main/scala/com/gu/scanamo/ScanamoScalaz.scala
@@ -71,8 +71,9 @@ object ScanamoScalaz {
     exec(client)(ScanamoFree.scan(tableName))
 
   @deprecated("Use [[exec]] with [[com.gu.scanamo.Table.limit]]", "1.0")
-  def scanWithLimit[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String,
-                                                                  limit: Int): Task[List[Either[DynamoReadError, T]]] =
+  def scanWithLimit[T: DynamoFormat](
+    client: AmazonDynamoDBAsync
+  )(tableName: String, limit: Int): Task[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.scanWithLimit(tableName, limit))
 
   @deprecated("Use [[exec]] with [[com.gu.scanamo.Table.scanFrom]]", "1.0")

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -347,8 +347,9 @@ object Scanamo {
     * }}}
     */
   @deprecated("Use [[exec]] with [[com.gu.scanamo.Table.limit]]", "1.0")
-  def scanWithLimit[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String,
-                                                             limit: Int): List[Either[DynamoReadError, T]] =
+  def scanWithLimit[T: DynamoFormat](
+    client: AmazonDynamoDB
+  )(tableName: String, limit: Int): List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.scanWithLimit(tableName, limit))
 
   /**
@@ -395,8 +396,9 @@ object Scanamo {
     * }}}
     */
   @deprecated("Use [[exec]] with [[com.gu.scanamo.Table.index]]", "1.0")
-  def scanIndex[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String,
-                                                         indexName: String): List[Either[DynamoReadError, T]] =
+  def scanIndex[T: DynamoFormat](
+    client: AmazonDynamoDB
+  )(tableName: String, indexName: String): List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.scanIndex(tableName, indexName))
 
   /**

--- a/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -45,7 +45,7 @@ object ScanamoFree {
                   .asJava
               ).asJava
             )
-        )
+          )
       )
 
   def deleteAll(tableName: String)(items: UniqueKeys[_]): ScanamoOps[List[BatchWriteItemResult]] =
@@ -143,9 +143,11 @@ object ScanamoFree {
   def scanIndex[T: DynamoFormat](tableName: String, indexName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream.stream[T](ScanamoScanRequest(tableName, Some(indexName), ScanamoQueryOptions.default)).map(_._1)
 
-  def scanIndexWithLimit[T: DynamoFormat](tableName: String,
-                                          indexName: String,
-                                          limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
+  def scanIndexWithLimit[T: DynamoFormat](
+    tableName: String,
+    indexName: String,
+    limit: Int
+  ): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream
       .stream[T](ScanamoScanRequest(tableName, Some(indexName), ScanamoQueryOptions.default.copy(limit = Some(limit))))
       .map(_._1)
@@ -174,8 +176,9 @@ object ScanamoFree {
       .stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default.copy(consistent = true)))
       .map(_._1)
 
-  def queryWithLimit[T: DynamoFormat](tableName: String)(query: Query[_],
-                                                         limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
+  def queryWithLimit[T: DynamoFormat](
+    tableName: String
+  )(query: Query[_], limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream
       .stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default.copy(limit = Some(limit))))
       .map(_._1)
@@ -194,8 +197,9 @@ object ScanamoFree {
       )
     )
 
-  def queryIndex[T: DynamoFormat](tableName: String,
-                                  indexName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
+  def queryIndex[T: DynamoFormat](tableName: String, indexName: String)(
+    query: Query[_]
+  ): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream
       .stream[T](ScanamoQueryRequest(tableName, Some(indexName), query, ScanamoQueryOptions.default))
       .map(_._1)

--- a/scanamo/src/main/scala/com/gu/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/SecondaryIndex.scala
@@ -137,10 +137,11 @@ sealed abstract class SecondaryIndex[V] {
   def filter[C: ConditionExpression](condition: C): SecondaryIndex[V]
 }
 
-private[scanamo] case class SecondaryIndexWithOptions[V: DynamoFormat](tableName: String,
-                                                                       indexName: String,
-                                                                       queryOptions: ScanamoQueryOptions)
-    extends SecondaryIndex[V] {
+private[scanamo] case class SecondaryIndexWithOptions[V: DynamoFormat](
+  tableName: String,
+  indexName: String,
+  queryOptions: ScanamoQueryOptions
+) extends SecondaryIndex[V] {
   def limit(n: Int): SecondaryIndexWithOptions[V] = copy(queryOptions = queryOptions.copy(limit = Some(n)))
   def filter[C: ConditionExpression](condition: C) =
     SecondaryIndexWithOptions[V](tableName, indexName, ScanamoQueryOptions.default).filter(Condition(condition))

--- a/scanamo/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
@@ -9,8 +9,10 @@ import com.gu.scanamo.update.UpdateExpression
 import simulacrum.typeclass
 import cats.syntax.either._
 
-case class ConditionalOperation[V, T](tableName: String, t: T)(implicit state: ConditionExpression[T],
-                                                               format: DynamoFormat[V]) {
+case class ConditionalOperation[V, T](tableName: String, t: T)(
+  implicit state: ConditionExpression[T],
+  format: DynamoFormat[V]
+) {
   def put(item: V): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] = {
     val unconditionalRequest = ScanamoPutRequest(tableName, format.write(item), None)
     ScanamoOps.conditionalPut(


### PR DESCRIPTION
There's a weird conflict that did not appear when I ran it locally (neither when I raised the PR 🤔 ), where v1.5 of scalafmt depends on an older version of scalameta, while sbt-doctest uses a more recent one. This fixes the issue. There is one open regression with this version of scalafmt but I don't think it affects our project, so I would say it's not much of a risk.

Plus it catches a few uses cases that were not caught and the code looks nicer ✨