### PR TITLE
Fix a few release issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ lazy val zio = (project in file("scalaz-zio"))
       "org.scalaz" %% "scalaz-zio" % zioVersion,
       "org.scalaz" %% "scalaz-zio-interop" % zioVersion,
       "org.scalatest" %% "scalatest" % "3.0.4" % Test,
-      "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
+      "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
     ),
     fork in Test := true,
     scalacOptions in (Compile, doc) += "-no-link-warnings"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-scalaVersion in ThisBuild := "2.12.4"
-crossScalaVersions in ThisBuild := Seq("2.11.11", scalaVersion.value)
+scalaVersion in ThisBuild := "2.12.7"
+crossScalaVersions in ThisBuild := Seq("2.11.12", scalaVersion.value)
 
 val catsVersion = "1.3.1"
 val catsEffectVersion = "1.0.0"
@@ -288,7 +288,7 @@ val publishingSettings = Seq(
     releaseStepCommand("startDynamodbLocal"),
     runTest,
     releaseStepCommand("dynamodbLocalTestCleanup"),
-    releaseStepCommandAndRemaining("+docs/tut"),
+    releaseStepCommandAndRemaining("docs/tut"),
     releaseStepCommand("stopDynamodbLocal"),
     setReleaseVersion,
     commitReleaseVersion,
@@ -296,7 +296,7 @@ val publishingSettings = Seq(
     releaseStepCommandAndRemaining("+publishSigned"),
     setNextVersion,
     commitNextVersion,
-    releaseStepCommandAndRemaining("+sonatypeReleaseAll"),
+    releaseStepCommandAndRemaining("+sonatypeRelease"),
     pushChanges,
     releaseStepCommandAndRemaining("publishMicrosite")
   )

--- a/formats/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -316,7 +316,7 @@ object DynamoFormat extends EnumDynamoFormat {
       override def read(av: AttributeValue): Either[DynamoReadError, Set[T]] =
         for {
           ns <- Either.fromOption(
-            if (av.isNULL) Some(Nil) else Option(av.getNS).map(_.asScala.toList),
+            if ((av.isNULL ne null) && av.isNULL) Some(Nil) else Option(av.getNS).map(_.asScala.toList),
             NoPropertyOfType("NS", av)
           )
           set <- ns.traverse(r)
@@ -418,7 +418,7 @@ object DynamoFormat extends EnumDynamoFormat {
       override def read(av: AttributeValue): Either[DynamoReadError, Set[String]] =
         for {
           ss <- Either.fromOption(
-            if (av.isNULL) Some(Nil) else Option(av.getSS).map(_.asScala.toList),
+            if ((av.isNULL ne null) && av.isNULL) Some(Nil) else Option(av.getSS).map(_.asScala.toList),
             NoPropertyOfType("SS", av)
           )
         } yield ss.toSet

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-SNAPSHOT"
+version in ThisBuild := "1.0.0-M8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-M8"
+version in ThisBuild := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
- scalacheck has some problems in forked mode that have been fixed in this new version
- `sonatypeReleaseAll` sends _all_ published package of the com.gu organisation to maven, as opposed to `sonatypeRelease`
- in scala 2.11, the AWS SDK returns `null` when calling `av.isNULL` on an attribute value that is not null
- updated scala for security and performance improvements