### PR TITLE
Add an option to query tables in reverse order.

### DIFF
--- a/scanamo/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
@@ -178,7 +178,12 @@ private[ops] object JavaRequests {
         })
       )
       .reduceLeft(_.compose(_))(
-        req.query(new QueryRequest().withTableName(req.tableName).withConsistentRead(req.options.consistent))
+        req.query(
+          new QueryRequest()
+            .withTableName(req.tableName)
+            .withConsistentRead(req.options.consistent)
+            .withScanIndexForward(req.options.scanIndexForward)
+        )
       )
   }
 

--- a/scanamo/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
@@ -42,10 +42,11 @@ case class ScanamoQueryOptions(
   consistent: Boolean,
   limit: Option[Int],
   exclusiveStartKey: Option[EvaluationKey],
-  filter: Option[Condition[_]]
+  filter: Option[Condition[_]],
+  scanIndexForward: Boolean = true
 )
 object ScanamoQueryOptions {
-  val default = ScanamoQueryOptions(false, None, None, None)
+  val default = ScanamoQueryOptions(false, None, None, None, true)
 }
 
 case class RequestCondition(


### PR DESCRIPTION
This should address #267. Please let me know if I missed adding support for this anywhere (e.g. does it need to be added to the top level Scanamo/ScanamoAsync/etc.), or if more tests are needed, etc.!