### PR TITLE
Add automatic and semi-automatic derivation of DynamoFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Note: the `LocalDynamoDB` object is provided by the `scanamo-testkit` package.
 ```scala
 scala> import com.gu.scanamo._
 scala> import com.gu.scanamo.syntax._
+scala> import com.gu.scanamo.auto._
  
 scala> val client = LocalDynamoDB.client()
 scala> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._

--- a/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/com/gu/scanamo/ScanamoAlpakkaSpec.scala
@@ -9,6 +9,7 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}

--- a/cats/src/test/scala/com/gu/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/com/gu/scanamo/ScanamoCatsSpec.scala
@@ -11,6 +11,7 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 class ScanamoCatsSpec extends FunSpec with Matchers {
 

--- a/docs/src/main/tut/asynchronous.md
+++ b/docs/src/main/tut/asynchronous.md
@@ -13,6 +13,7 @@ a client that implements the `AmazonDynamoDBAsync` interface:
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -12,6 +12,7 @@ has support for putting, getting and deleting in batches
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/docs/src/main/tut/conditional-operations.md
+++ b/docs/src/main/tut/conditional-operations.md
@@ -14,6 +14,7 @@ execution.
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 val client = LocalDynamoDB.client()
 case class Gremlin(number: Int, name: String, wet: Boolean, friendly: Boolean)

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -50,8 +50,8 @@ import com.gu.scanamo.semiauto._
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
 
-implicit val formatFarm: DynamoFormat[Farm] = deriveFormat[Farm]
-implicit val formatFarmer: DynamoFormat[Farmer] = deriveFormat
+implicit val formatFarm: DynamoFormat[Farm] = deriveDynamoFormat[Farm]
+implicit val formatFarmer: DynamoFormat[Farmer] = deriveDynamoFormat
 ```
 
 ### Custom Formats

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -16,6 +16,25 @@ Scanamo also supports automatically deriving formats for case classes and
 sealed trait families where all the contained types have a defined or derivable
 `DynamoFormat`.
 
+### Automatic Derivation
+
+Scanamo can automatically derive `DynamoFormat` for case classes (as long as all its members can also be derived). Ex:
+
+```tut:silent
+import com.gu.scanamo.auto._
+
+case class Farm(animals: List[String])
+case class Farmer(name: String, age: Long, farm: Farm)
+
+val table = Table[Farmer]("farmer")
+table.putAll(
+    Set(
+        Farmer("McDonald", 156L, Farm(List("sheep", "cow"))),
+        Farmer("Boggis", 43L, Farm(List("chicken")))
+    )
+)
+```
+
 ### Custom Formats
 
 It's also possible to define a serialisation format for types which Scanamo

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -35,6 +35,21 @@ table.putAll(
 )
 ```
 
+### Semi-automatic Derivation
+
+Scanamo offers a convenient way (semi-automoatic) to derive `DynamoFormat` in your code. 
+Ex:
+
+```tut:silent
+import com.gu.scanamo.semiauto._
+
+case class Farm(animals: List[String])
+case class Farmer(name: String, age: Long, farm: Farm)
+
+implicit val formatFarm: DynamoFormat[Farm] = deriveFormat[Farm]
+implicit val formatFarmer: DynamoFormat[Farmer] = deriveFormat
+```
+
 ### Custom Formats
 
 It's also possible to define a serialisation format for types which Scanamo

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -21,6 +21,8 @@ sealed trait families where all the contained types have a defined or derivable
 Scanamo can automatically derive `DynamoFormat` for case classes (as long as all its members can also be derived). Ex:
 
 ```tut:silent
+import com.gu.scanamo._
+import com.gu.scanamo.syntax._
 import com.gu.scanamo.auto._
 
 case class Farm(animals: List[String])
@@ -41,6 +43,8 @@ Scanamo offers a convenient way (semi-automoatic) to derive `DynamoFormat` in yo
 Ex:
 
 ```tut:silent
+import com.gu.scanamo._
+import com.gu.scanamo.syntax._
 import com.gu.scanamo.semiauto._
 
 case class Farm(animals: List[String])
@@ -65,6 +69,7 @@ import org.joda.time._
 
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 case class Foo(dateTime: DateTime)
 
@@ -103,7 +108,9 @@ libraryDependencies += "com.gu" %% "scanamo-refined" % "x.y.z"
 And then import the support for refined types and define your model:
 
 ```tut:silent
+import com.gu.scanamo._
 import com.gu.scanamo.refined._
+import com.gu.scanamo.auto._
 import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
@@ -137,6 +144,7 @@ import java.util.UUID
 
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 // Sealed trait family for events.
 sealed trait Event

--- a/docs/src/main/tut/filters.md
+++ b/docs/src/main/tut/filters.md
@@ -18,6 +18,7 @@ provisioned capacity to autoscale up to an expensive level.
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 val client = LocalDynamoDB.client()
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -30,6 +30,7 @@ then, given a table and some case classes
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
  
 val client = LocalDynamoDB.client()
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._

--- a/docs/src/main/tut/operations.md
+++ b/docs/src/main/tut/operations.md
@@ -28,6 +28,7 @@ Dynamo and subsequently retrieving them:
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 val client = LocalDynamoDB.client()
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._

--- a/docs/src/main/tut/using-indexes.md
+++ b/docs/src/main/tut/using-indexes.md
@@ -14,6 +14,7 @@ with only a hash key on the `colour` attribute:
 ```tut:silent
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 case class Transport(mode: String, line: String, colour: String)
 val transport = Table[Transport]("transport")

--- a/formats/src/main/scala/com/gu/scanamo/Derivation/SemiAutoDerivation.scala
+++ b/formats/src/main/scala/com/gu/scanamo/Derivation/SemiAutoDerivation.scala
@@ -3,7 +3,7 @@ package com.gu.scanamo.Derivation
 import com.gu.scanamo.{DerivedDynamoFormat, DynamoFormat}
 import com.gu.scanamo.export.Exported
 
-trait SemiAutoDerivation extends DerivedDynamoFormat{
+trait SemiAutoDerivation extends DerivedDynamoFormat {
 
   final def deriveDynamoFormat[A](
     implicit exported: Exported[DynamoFormat[A]]

--- a/formats/src/main/scala/com/gu/scanamo/Derivation/SemiAutoDerivation.scala
+++ b/formats/src/main/scala/com/gu/scanamo/Derivation/SemiAutoDerivation.scala
@@ -1,0 +1,12 @@
+package com.gu.scanamo.Derivation
+
+import com.gu.scanamo.{DerivedDynamoFormat, DynamoFormat}
+import com.gu.scanamo.export.Exported
+
+trait SemiAutoDerivation extends DerivedDynamoFormat{
+
+  final def deriveDynamoFormat[A](
+    implicit exported: Exported[DynamoFormat[A]]
+  ): DynamoFormat[A] = exported.instance
+
+}

--- a/formats/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -29,9 +29,9 @@ import scala.reflect.ClassTag
   * Right(List(Some(1), None, Some(3)))
   * }}}
   *
-  * Also supports automatic derivation for case classes
-  *
   * {{{
+  * >>> import com.gu.scanamo.auto._
+  * >>>
   * >>> case class Farm(animals: List[String])
   * >>> case class Farmer(name: String, age: Long, farm: Farm)
   * >>> val farmerF = DynamoFormat[Farmer]

--- a/formats/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -27,6 +27,9 @@ import scala.reflect.ClassTag
   * >>> val listOptionFormat = DynamoFormat[List[Option[Int]]]
   * >>> listOptionFormat.read(listOptionFormat.write(List(Some(1), None, Some(3))))
   * Right(List(Some(1), None, Some(3)))
+  *
+  * Also supports automatic and semi-automatic derivation for case classes
+  *
   * }}}
   *
   * {{{

--- a/formats/src/main/scala/com/gu/scanamo/EnumerationDynamoFormat.scala
+++ b/formats/src/main/scala/com/gu/scanamo/EnumerationDynamoFormat.scala
@@ -3,7 +3,7 @@ package com.gu.scanamo
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
 import com.gu.scanamo.export.Exported
-import shapeless.labelled.{FieldType, field}
+import shapeless.labelled.{field, FieldType}
 import shapeless.{:+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness}
 
 abstract class EnumerationDynamoFormat[T] extends DynamoFormat[T]

--- a/formats/src/main/scala/com/gu/scanamo/auto.scala
+++ b/formats/src/main/scala/com/gu/scanamo/auto.scala
@@ -1,0 +1,9 @@
+package com.gu.scanamo
+
+/**
+  * Fully automatic format derivation.
+  *
+  * Importing the contents of this package object provides [[com.gu.scanamo.DynamoFormat]]
+  * instances for case classes (if all members have instances)
+  */
+package object auto extends DerivedDynamoFormat

--- a/formats/src/main/scala/com/gu/scanamo/export/Exported.scala
+++ b/formats/src/main/scala/com/gu/scanamo/export/Exported.scala
@@ -1,0 +1,3 @@
+package com.gu.scanamo.export
+
+final case class Exported[T](instance: T) extends AnyVal

--- a/formats/src/main/scala/com/gu/scanamo/semiauto.scala
+++ b/formats/src/main/scala/com/gu/scanamo/semiauto.scala
@@ -1,0 +1,22 @@
+package com.gu.scanamo
+
+import com.gu.scanamo.Derivation.SemiAutoDerivation
+
+/**
+  * Semi-automatic format derivation.
+  *
+  * This object provides helpers for creating [[com.gu.scanamo.DynamoFormat]]
+  * instances for case classes
+  *
+  * Typical usage will look like the following:
+  *
+  * {{{
+  * import com.gu.scanamo.semiauto._
+  *
+  * case class Bear(name: String, favouriteFood: String)
+  * object Bear {
+  *   implicit val formatBear: DynamoFormat[Bear] = deriveDynamoFormat[Bear]
+  * }
+  * }}}
+  */
+package object semiauto extends SemiAutoDerivation

--- a/formats/src/test/scala/com/gu/scanamo/Derivation/SemiAutoDerivationTest.scala
+++ b/formats/src/test/scala/com/gu/scanamo/Derivation/SemiAutoDerivationTest.scala
@@ -1,0 +1,24 @@
+package com.gu.scanamo.Derivation
+
+import com.gu.scanamo.DynamoFormat
+import org.scalatest.{FunSuite, Matchers}
+
+class SemiAutoDerivationTest extends FunSuite with Matchers {
+
+  test("Derivation should fail if no derived format or automatic derivation") {
+    """write(Person("Alice", 65))""" shouldNot compile
+  }
+
+  test("Derivation should succeed if derived format in scope") {
+    """
+      |import com.gu.scanamo.semiauto._
+      |implicit val formatPerson: DynamoFormat[Person] = deriveDynamoFormat[Person]
+      |
+      |write(Person("Bob", 12))
+      |""".stripMargin should compile
+  }
+
+  def write[T](t: T)(implicit f: DynamoFormat[T]) = f.write(t)
+}
+
+case class Person(name: String, age: Int)

--- a/formats/src/test/scala/com/gu/scanamo/DynamoFormatTest.scala
+++ b/formats/src/test/scala/com/gu/scanamo/DynamoFormatTest.scala
@@ -8,6 +8,7 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import org.scalacheck._
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import com.gu.scanamo.auto._
 
 class DynamoFormatTest extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
 

--- a/scalaz-zio/src/test/scala/com/gu/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/com/gu/scanamo/ScanamoZioSpec.scala
@@ -9,6 +9,7 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 import cats.implicits._
 import scalaz.zio.{IO, RTS}
 

--- a/scalaz/src/test/scala/com/gu/scanamo/ScanamoScalazSpec.scala
+++ b/scalaz/src/test/scala/com/gu/scanamo/ScanamoScalazSpec.scala
@@ -7,6 +7,7 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 import scalaz.ioeffect.RTS
 import scalaz._
 import Scalaz._

--- a/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -15,6 +15,8 @@ object Scanamo {
     * provided synchronously
     *
     * {{{
+    * >>> import com.gu.scanamo.auto._
+    *
     * >>> case class Transport(mode: String, line: String)
     * >>> val transport = Table[Transport]("transport")
     *

--- a/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -45,7 +45,7 @@ object ScanamoFree {
                   .asJava
               ).asJava
             )
-        )
+          )
       )
 
   def deleteAll(tableName: String)(items: UniqueKeys[_]): ScanamoOps[List[BatchWriteItemResult]] =

--- a/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -45,7 +45,7 @@ object ScanamoFree {
                   .asJava
               ).asJava
             )
-          )
+        )
       )
 
   def deleteAll(tableName: String)(items: UniqueKeys[_]): ScanamoOps[List[BatchWriteItemResult]] =

--- a/scanamo/src/main/scala/com/gu/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/SecondaryIndex.scala
@@ -27,6 +27,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('antagonist -> S) { (t, i) =>
     * ...   val table = Table[Bear](t)
@@ -53,6 +54,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('organisation -> S, 'repository -> S)('language -> S, 'license -> S) { (t, i) =>
     * ...   val githubProjects = Table[GithubProject](t)
@@ -81,6 +83,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
@@ -114,6 +117,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S

--- a/scanamo/src/main/scala/com/gu/scanamo/Table.scala
+++ b/scanamo/src/main/scala/com/gu/scanamo/Table.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
   *
   * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
   * ...   import com.gu.scanamo.syntax._
+  * ...   import com.gu.scanamo.auto._
   * ...   val transport = Table[Transport](t)
   * ...   val operations = for {
   * ...     _ <- transport.putAll(Set(
@@ -50,6 +51,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
+    *
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> val dataSet = Set(
@@ -79,6 +82,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('colour -> S) { (t, i) =>
     * ...   val transport = Table[Transport](t)
@@ -96,6 +100,8 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class GithubProject(organisation: String, repository: String, language: String, license: String)
+    *
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('organisation -> S, 'repository -> S)('language -> S, 'license -> S) { (t, i) =>
     * ...   val githubProjects = Table[GithubProject](t)
@@ -129,6 +135,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('location -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val forecast = Table[Forecast](t)
     * ...   val operations = for {
     * ...     _ <- forecast.put(Forecast("London", "Rain"))
@@ -146,6 +153,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val characters = Table[Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.put(Character("The Doctor", List("Ecclestone", "Tennant", "Smith")))
@@ -163,6 +171,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val characters = Table[Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.update('name -> "James Bond", append('actors -> "Craig"))
@@ -180,6 +189,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('kind -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val fruits = Table[Fruit](t)
     * ...   val operations = for {
     * ...     _ <- fruits.put(Fruit("watermelon", List("USA")))
@@ -198,6 +208,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val foos = Table[Foo](t)
     * ...   val operations = for {
     * ...     _ <- foos.put(Foo("x", 0, List("First")))
@@ -215,6 +226,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val bars = Table[Bar](t)
     * ...   val operations = for {
     * ...     _ <- bars.put(Bar("x", 1L, Set("First")))
@@ -235,6 +247,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('id -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val outers = Table[Outer](t)
     * ...   val id = java.util.UUID.fromString("a8345373-9a93-43be-9bcd-e3682c9197f4")
     * ...   val operations = for {
@@ -254,6 +267,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('id -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val things = Table[Thing](t)
     * ...   val operations = for {
     * ...     _ <- things.put(Thing("a1", 3, None))
@@ -277,6 +291,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
@@ -305,6 +320,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val client = LocalDynamoDB.client()
     * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)('country -> S, 'name -> S) { t =>
     * ...   import com.gu.scanamo.syntax._
+    * ...   import com.gu.scanamo.auto._
     * ...   val cityTable = Table[City](t)
     * ...   val ops = for {
     * ...     putRes <- cityTable.putAll(Set(
@@ -335,6 +351,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     * >>> import com.gu.scanamo.query._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
@@ -491,6 +508,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     * >>> import com.gu.scanamo.query._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
@@ -547,6 +565,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * ...   import com.gu.scanamo.auto._
     * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey"))
@@ -577,6 +596,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import com.gu.scanamo.error._
     * >>> import com.gu.scanamo.ops._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     * >>> import com.gu.scanamo.query._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
@@ -609,6 +629,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val client = LocalDynamoDB.client()
     *
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
@@ -645,6 +666,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import com.gu.scanamo.error._
     * >>> import com.gu.scanamo.ops._
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     * >>> import com.gu.scanamo.query._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
@@ -681,6 +703,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> import com.gu.scanamo.syntax._
+    * >>> import com.gu.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
     * ...   val table = Table[Bear](t)

--- a/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
   implicit val defaultPatience =

--- a/scanamo/src/test/scala/com/gu/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/com/gu/scanamo/ScanamoTest.scala
@@ -11,6 +11,7 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.auto._
 
 class ScanamoTest extends org.scalatest.FunSpec with org.scalatest.Matchers {
 


### PR DESCRIPTION
- Auto derivation of case classes now requires `import com.gu.scanamo.auto._`
and doesn't come automatically as soon as DynamoFormat is in scope
- Adding semi-automatic derivation via `deriveDynamoFormat[A]` helper method

Closes #201 