### PR TITLE
Fix release

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,5 +13,3 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC4")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.23")
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.7")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.1")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC4")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
I forgot to remove the `version.sbt` file and because of that the release of a tag tried to publish `1.0.0-SNAPSHOT` to the release repository, which blows up with a `Bad Request` exception.