### PR TITLE
Return a Left of MissingKeyValue if the key provided is not the primary key

### DIFF
--- a/alpakka/src/main/scala/org/scanamo/ops/AlpakkaInterpreter.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/AlpakkaInterpreter.scala
@@ -16,7 +16,12 @@ object AlpakkaInterpreter {
       override def apply[A](ops: ScanamoOpsA[A]) =
         ops match {
           case Put(req)        => client.single(JavaRequests.put(req))
-          case Get(req)        => client.single(req)
+          case Get(req)        =>
+            client.single(req)
+              .map(Either.right[AmazonDynamoDBException, GetItemResult])
+              .recover{
+                case e: AmazonDynamoDBException => Either.left(e)
+              }
           case Delete(req)     => client.single(JavaRequests.delete(req))
           case Scan(req)       => client.single(JavaRequests.scan(req))
           case Query(req)      => client.single(JavaRequests.query(req))

--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -40,7 +40,17 @@ object CatsInterpreter {
             )
           )
       case Get(req) =>
-        eff(client.getItemAsync, req)
+        eff(client.getItemAsync, req).attempt
+          .flatMap(
+            _.fold(
+              _ match {
+                case e: AmazonDynamoDBException => F.delay(Left(e))
+                case t                          => F.raiseError(t) // raise error as opposed to swallowing
+              },
+              a => F.delay(Right(a))
+            )
+          )
+
       case Delete(req) =>
         eff(client.deleteItemAsync, JavaRequests.delete(req))
       case ConditionalDelete(req) =>

--- a/formats/src/main/scala/org/scanamo/error/DynamoReadError.scala
+++ b/formats/src/main/scala/org/scanamo/error/DynamoReadError.scala
@@ -11,6 +11,8 @@ sealed abstract class DynamoReadError extends ScanamoError
 final case class NoPropertyOfType(propertyType: String, actual: AttributeValue) extends DynamoReadError
 final case class TypeCoercionError(t: Throwable) extends DynamoReadError
 final case object MissingProperty extends DynamoReadError
+//TODO: Is missing key value a dynamo read error?
+final case class MissingKeyValue(attribute: String) extends DynamoReadError
 
 final case class PropertyReadError(name: String, problem: DynamoReadError)
 final case class InvalidPropertiesError(errors: NonEmptyList[PropertyReadError]) extends DynamoReadError
@@ -33,5 +35,6 @@ object DynamoReadError {
     case NoPropertyOfType(propertyType, actual) => s"not of type: '$propertyType' was '$actual'"
     case TypeCoercionError(e)                   => s"could not be converted to desired type: $e"
     case MissingProperty                        => "missing"
+    case MissingKeyValue(attribute)             => s"Attribute $attribute is not the partition or sort key"
   }
 }

--- a/scalaz-zio/src/main/scala/org/scanamo/ops/ZioInterpreter.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ops/ZioInterpreter.scala
@@ -40,7 +40,12 @@ object ZioInterpreter {
             a => IO.succeed(Right(a))
           )
         case Get(req) =>
-          eff(client.getItemAsync, req)
+          eff(client.getItemAsync, req).redeem(
+            _ match {
+              case e: AmazonDynamoDBException => IO.now(Left(e))
+              case t                          => IO.fail(t)
+            }, a => IO.now(Right(a))
+          )
         case Delete(req) =>
           eff(client.deleteItemAsync, JavaRequests.delete(req))
         case ConditionalDelete(req) =>

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSpec, Matchers}
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-import org.scanamo.error.DynamoReadError
+import org.scanamo.error.{DynamoReadError, MissingKeyValue}
 import org.scanamo.ops.ScanamoOps
 import org.scanamo.query._
 import org.scanamo.syntax._
@@ -553,6 +553,41 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       unsafeRun(ScanamoZio.exec(client)(ops)) should equal(
         List(Right(Gremlin(1, false)))
       )
+    }
+  }
+
+  it("should return MissingKeyError when queried field is not a key") {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('age -> N) { (t, i) =>
+      case class Farm(asyncAnimals: List[String])
+      case class Farmer(name: String, age: Long, farm: Farm)
+      val farm = Farm(List("dog"))
+
+      val farmers = Table[Farmer](t)
+
+      val ops = for {
+        _ <- farmers.put(Farmer("Maggot", 75L, farm))
+        r<- farmers.get('farm -> farm)
+      } yield r
+
+
+      unsafeRun(ScanamoZio.exec(client)(ops)).get.left.get shouldBe a [MissingKeyValue]
+
+    }
+  }
+
+  it("should return MissingKeyError when queried field does not exist") {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('age -> N) { (t, i) =>
+      case class Farm(asyncAnimals: List[String])
+      case class Farmer(name: String, age: Long, farm: Farm)
+      val farm = Farm(List("dog"))
+
+      val farmers = Table[Farmer](t)
+
+      val ops = for {
+        _ <- farmers.put(Farmer("Maggot", 75L, farm))
+        r<- farmers.get('DoesNotExist -> farm)
+      } yield r
+      unsafeRun(ScanamoZio.exec(client)(ops)).get.left.get shouldBe a [MissingKeyValue]
     }
   }
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
@@ -7,7 +7,7 @@ sealed trait ScanamoOpsA[A] extends Product with Serializable
 final case class Put(req: ScanamoPutRequest) extends ScanamoOpsA[PutItemResult]
 final case class ConditionalPut(req: ScanamoPutRequest)
     extends ScanamoOpsA[Either[ConditionalCheckFailedException, PutItemResult]]
-final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
+final case class Get(req: GetItemRequest) extends ScanamoOpsA[Either[AmazonDynamoDBException, GetItemResult]]
 final case class Delete(req: ScanamoDeleteRequest) extends ScanamoOpsA[DeleteItemResult]
 final case class ConditionalDelete(req: ScanamoDeleteRequest)
     extends ScanamoOpsA[Either[ConditionalCheckFailedException, DeleteItemResult]]
@@ -26,7 +26,8 @@ object ScanamoOps {
   def put(req: ScanamoPutRequest): ScanamoOps[PutItemResult] = liftF[ScanamoOpsA, PutItemResult](Put(req))
   def conditionalPut(req: ScanamoPutRequest): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] =
     liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, PutItemResult]](ConditionalPut(req))
-  def get(req: GetItemRequest): ScanamoOps[GetItemResult] = liftF[ScanamoOpsA, GetItemResult](Get(req))
+  def get(req: GetItemRequest): ScanamoOps[Either[AmazonDynamoDBException, GetItemResult]] =
+    liftF[ScanamoOpsA, Either[AmazonDynamoDBException, GetItemResult]](Get(req))
   def delete(req: ScanamoDeleteRequest): ScanamoOps[DeleteItemResult] =
     liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
   def conditionalDelete(

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSpec, Matchers}
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-import org.scanamo.error.DynamoReadError
+import org.scanamo.error.{DynamoReadError, MissingKeyValue}
 import org.scanamo.ops.ScanamoOps
 import org.scanamo.query._
 import org.scanamo.syntax._
@@ -550,6 +550,41 @@ class ScanamoTest extends org.scalatest.FunSpec with org.scalatest.Matchers {
       Scanamo.exec(client)(ops) should equal(
         List(Right(Gremlin(1, false)))
       )
+    }
+  }
+
+  it("should return MissingKeyError when queried field is not a key") {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('age -> N) { (t, i) =>
+      case class Farm(asyncAnimals: List[String])
+      case class Farmer(name: String, age: Long, farm: Farm)
+      val farm = Farm(List("dog"))
+
+      val farmers = Table[Farmer](t)
+
+      val result = for {
+        _ <- farmers.put(Farmer("Maggot", 75L, farm))
+        r<- farmers.get('farm -> farm)
+      } yield r
+
+      Scanamo.exec(client)(result).get.left.get shouldBe a [MissingKeyValue]
+
+    }
+  }
+
+  it("should return MissingKeyError when queried field does not exist") {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('age -> N) { (t, i) =>
+      case class Farm(asyncAnimals: List[String])
+      case class Farmer(name: String, age: Long, farm: Farm)
+      val farm = Farm(List("dog"))
+
+      val farmers = Table[Farmer](t)
+
+      val result = for {
+        _ <- farmers.put(Farmer("Maggot", 75L, farm))
+        r<- farmers.get('DoesNotExist -> farm)
+      } yield r
+
+      Scanamo.exec(client)(result).get.left.get shouldBe a [MissingKeyValue]
     }
   }
 }


### PR DESCRIPTION
Addressing issue https://github.com/scanamo/scanamo/issues/290

Previous Behaviour: If a key provided for a get operation was not a primary key an exception was thrown

New Behaviour: Instead of throwing an exception a `Left(MissingKeyValue)` is returned