### PR TITLE
Write empty strings as null

### DIFF
--- a/formats/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -173,8 +173,8 @@ object DynamoFormat extends EnumDynamoFormat {
     * }}}
     */
   implicit val stringFormat: DynamoFormat[String] = new DynamoFormat[String] {
-    val default = Some("")
-    
+    override val default = Some("")
+
     def read(av: AttributeValue): Either[DynamoReadError, String] =
       if ((av.isNULL ne null) && av.isNULL)
         Right("")

--- a/formats/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -86,6 +86,8 @@ import scala.reflect.ClassTag
 }
 
 object DynamoFormat extends EnumDynamoFormat {
+  val NullAv = new AttributeValue().withNULL(true)
+
   private def attribute[T](decode: AttributeValue => T, propertyType: String)(
     encode: AttributeValue => T => AttributeValue
   ): DynamoFormat[T] =
@@ -170,7 +172,17 @@ object DynamoFormat extends EnumDynamoFormat {
     *     | DynamoFormat[String].read(DynamoFormat[String].write(s)) == Right(s)
     * }}}
     */
-  implicit val stringFormat = attribute(_.getS, "S")(_.withS)
+  implicit val stringFormat: DynamoFormat[String] = new DynamoFormat[String] {
+    def read(av: AttributeValue): Either[DynamoReadError, String] =
+      if ((av.isNULL ne null) && av.isNULL)
+        Right("")
+      else
+        Either.fromOption(Option(av.getS), NoPropertyOfType("S", av))
+    def write(s: String): AttributeValue = s match {
+      case "" => NullAv
+      case _  => new AttributeValue().withS(s)
+    }
+  }
 
   private val javaBooleanFormat = attribute[java.lang.Boolean](_.getBOOL, "BOOL")(_.withBOOL)
 
@@ -334,7 +346,7 @@ object DynamoFormat extends EnumDynamoFormat {
         } yield set.toSet
       // Set types cannot be empty
       override def write(t: Set[T]): AttributeValue = t.toList match {
-        case Nil => new AttributeValue().withNULL(true)
+        case Nil => NullAv
         case xs  => new AttributeValue().withNS(xs.map(w).asJava)
       }
       override val default: Option[Set[T]] = Some(Set.empty)

--- a/formats/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -173,6 +173,8 @@ object DynamoFormat extends EnumDynamoFormat {
     * }}}
     */
   implicit val stringFormat: DynamoFormat[String] = new DynamoFormat[String] {
+    val default = Some("")
+    
     def read(av: AttributeValue): Either[DynamoReadError, String] =
       if ((av.isNULL ne null) && av.isNULL)
         Right("")

--- a/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
@@ -3,6 +3,7 @@ package org.scanamo.update
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 import org.scanamo.syntax._
+import org.scanamo.DynamoFormat
 import scala.collection.JavaConverters._
 
 class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matchers with org.scalatest.prop.Checkers {
@@ -60,15 +61,15 @@ class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matc
 
   it("append/prepend should wrap scalar values in a list") {
     check { (s: Symbol, v: String) =>
-      append(s -> v).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == List(v))
-      prepend(s -> v).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == List(v))
+      append(s -> v).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(List(v)))
+      prepend(s -> v).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(List(v)))
     }
   }
 
   it("appendAll/prependAll should take the value as a list") {
     check { (s: Symbol, l: List[String]) =>
-      appendAll(s -> l).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == l)
-      prependAll(s -> l).unprefixedAttributeValues.get("update").exists(_.getL.asScala.toList.map(_.getS) == l)
+      appendAll(s -> l).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(l))
+      prependAll(s -> l).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(l))
     }
   }
 }

--- a/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
@@ -43,6 +43,8 @@ class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matc
     }
   implicit lazy val update: Arbitrary[UpdateExpression] = Arbitrary(genTree(0))
 
+  val stringList = DynamoFormat[List[String]]
+
   it("should have all value placeholders in the expression") {
     check { (ue: UpdateExpression) =>
       ue.attributeValues.keys.forall(s => {
@@ -61,15 +63,15 @@ class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matc
 
   it("append/prepend should wrap scalar values in a list") {
     check { (s: Symbol, v: String) =>
-      append(s -> v).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(List(v)))
-      prepend(s -> v).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(List(v)))
+      append(s -> v).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(List(v)))
+      prepend(s -> v).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(List(v)))
     }
   }
 
   it("appendAll/prependAll should take the value as a list") {
     check { (s: Symbol, l: List[String]) =>
-      appendAll(s -> l).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(l))
-      prependAll(s -> l).unprefixedAttributeValues.get("update").exists(DynamoFormat[List[String]].read(_) == Right(l))
+      appendAll(s -> l).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(l))
+      prependAll(s -> l).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(l))
     }
   }
 }


### PR DESCRIPTION
Fixes #366 

That DynamoDB won't accept empty strings is a long-standing pain in the ass. As of now, we've been encoding strings without taking care of it, but the result is this behaviour bubbles up into user-land code where people must come up with handling mechanisms. It seems we can take care of this ourselves, by encoding empty strings as nulls.

To make matters even worse, when marshalling an object, if a key has a null value, it will be stripped off in DynamoDB. As a result, we must make sure that missing properties of type `String` are properly decoded into the empty string: this is what the `DynanoFormat[String]#default` value is for.