### PR TITLE
Add startDynamodbLocal sbt task information to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,7 @@ Building and testing Scanamo
 ----------------------------
 
 Scanamo uses a standard [SBT](https://www.scala-sbt.org/) build. If you
-have SBT installed you can just run the `test` command from the SBT prompt
-to compile Scanamo and run its tests.
+have SBT installed, you should first run `startDynamodbLocal` task from the SBT prompt to start a local dynamodb instance and afterwards run the `test` command to compile Scanamo and run its tests.
 
 Most, though not all of Scanamo's tests are from examples in the scaladoc, 
 or `README.md`, which are turned into tests by 


### PR DESCRIPTION
I noticed while trying to run tests that a local dynamodb is required to be running at port 8042. I added this information to CONTRIBUTING.md, so that future contributers won't waste time on this. Cheers :)