### PR TITLE
Fix links in doc pages

### DIFF
--- a/docs/src/main/tut/conditional-operations.md
+++ b/docs/src/main/tut/conditional-operations.md
@@ -45,4 +45,4 @@ LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
 }
 ```
 
-More examples can be found in the [Table ScalaDoc](/latest/api/com/gu/scanamo/Table.html#given[T](condition:T)(implicitevidence$2:org.scanamo.query.ConditionExpression[T]):org.scanamo.query.ConditionalOperation[V,T]).
+More examples can be found in the [Table ScalaDoc](/latest/api/org/scanamo/Table.html#given[T](condition:T)(implicitevidence$2:org.scanamo.query.ConditionExpression[T]):org.scanamo.query.ConditionalOperation[V,T]).

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -6,11 +6,11 @@ position:  6
 
 ## DynamoFormat
 
-Scanamo uses the [`DynamoFormat`](latest/api/com/gu/scanamo/DynamoFormat.html)
+Scanamo uses the [`DynamoFormat`](latest/api/org/scanamo/DynamoFormat.html)
 type class to define how to read and write different types to DynamoDB.
 
 Many common types have a `DynamoFormat` provided by Scanamo. For a full list see
-of those supported, you can look at the [companion object](latest/api/com/gu/scanamo/DynamoFormat$.html).
+of those supported, you can look at the [companion object](latest/api/org/scanamo/DynamoFormat$.html).
 
 Scanamo also supports automatically deriving formats for case classes and
 sealed trait families where all the contained types have a defined or derivable
@@ -58,8 +58,8 @@ implicit val formatFarmer: DynamoFormat[Farmer] = deriveDynamoFormat
 
 It's also possible to define a serialisation format for types which Scanamo
 doesn't already support and can't derive. Normally this involves using the
-[xmap](latest/api/com/gu/scanamo/DynamoFormat$.html#xmap[A,B](r:B=>Either[org.scanamo.error.DynamoReadError,A])(w:A=>B)(implicitf:org.scanamo.DynamoFormat[B]):org.scanamo.DynamoFormat[A])
-or [coercedXmap](latest/api/com/gu/scanamo/DynamoFormat$.html#coercedXmap[A,B,T>:Null<:Throwable](read:B=>A)(write:A=>B)(implicitf:org.scanamo.DynamoFormat[B],implicitT:scala.reflect.ClassTag[T],implicitNT:cats.NotNull[T]):org.scanamo.DynamoFormat[A])
+[xmap](latest/api/org/scanamo/DynamoFormat$.html#xmap[A,B](r:B=>Either[org.scanamo.error.DynamoReadError,A])(w:A=>B)(implicitf:org.scanamo.DynamoFormat[B]):org.scanamo.DynamoFormat[A])
+or [coercedXmap](latest/api/org/scanamo/DynamoFormat$.html#coercedXmap[A,B,T>:Null<:Throwable](read:B=>A)(write:A=>B)(implicitf:org.scanamo.DynamoFormat[B],implicitT:scala.reflect.ClassTag[T],implicitNT:cats.NotNull[T]):org.scanamo.DynamoFormat[A])
 to translate between the type and one Scanamo does already know about.
 
 For example, to store Joda `DateTime` objects as ISO `String`s in Dynamo:
@@ -137,7 +137,7 @@ Scanamo.exec(client)(operations).toList
 
 ### Derived Formats
 
-Scanamo uses [shapeless](https://github.com/milessabin/shapeless) and implicit derivation to automatically derive [`DynamoFormat`](latest/api/com/gu/scanamo/DynamoFormat)s for case classes and sealed trait families. You may also see or hear sealed trait families referred to as Algebraic Data Types (ADTs) and co-products. Here is an example that could be used to support event sourcing (assuming a table with a partition key of `id` and sort key `seqNo`):
+Scanamo uses [shapeless](https://github.com/milessabin/shapeless) and implicit derivation to automatically derive [`DynamoFormat`](latest/api/org/scanamo/DynamoFormat)s for case classes and sealed trait families. You may also see or hear sealed trait families referred to as Algebraic Data Types (ADTs) and co-products. Here is an example that could be used to support event sourcing (assuming a table with a partition key of `id` and sort key `seqNo`):
 
 ```tut:silent
 import java.util.UUID

--- a/docs/src/main/tut/filters.md
+++ b/docs/src/main/tut/filters.md
@@ -44,4 +44,4 @@ LocalDynamoDB.withTable(client)("Station")('line -> S, 'name -> S) {
 }
 ```
 
-More examples can be found in the [Table ScalaDoc](/latest/api/com/gu/scanamo/Table.html#filter[C](condition:C)(implicitevidence$3:org.scanamo.query.ConditionExpression[C]):org.scanamo.TableWithOptions[V]).
+More examples can be found in the [Table ScalaDoc](/latest/api/org/scanamo/Table.html#filter[C](condition:C)(implicitevidence$3:org.scanamo.query.ConditionExpression[C]):org.scanamo.TableWithOptions[V]).

--- a/docs/src/main/tut/operations.md
+++ b/docs/src/main/tut/operations.md
@@ -142,7 +142,7 @@ Scanamo.exec(client)(
 ```
 
 Further examples, showcasing different types of update can be found in the 
-[scaladoc for the `update` method on `Table`](/latest/api/com/gu/scanamo/Table.html#update(key:org.scanamo.query.UniqueKey[_],expression:org.scanamo.update.UpdateExpression):org.scanamo.ops.ScanamoOps[Either[org.scanamo.error.DynamoReadError,V]])
+[scaladoc for the `update` method on `Table`](/latest/api/org/scanamo/Table.html#update(key:org.scanamo.query.UniqueKey[_],expression:org.scanamo.update.UpdateExpression):org.scanamo.ops.ScanamoOps[Either[org.scanamo.error.DynamoReadError,V]])
 
 ### Scan
 


### PR DESCRIPTION
It looks like package structure was changed at some point but links on doc pages weren't adjusted.