### PR TITLE
A few cleanups

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -15,6 +15,7 @@ object ScanamoFree {
   import collection.JavaConverters._
 
   private val batchSize = 25
+  private val batchGetSize = 100
 
   def put[T](tableName: String)(item: T)(implicit f: DynamoFormat[T]): ScanamoOps[Option[Either[DynamoReadError, T]]] =
     ScanamoOps
@@ -72,7 +73,7 @@ object ScanamoFree {
     tableName: String
   )(keys: UniqueKeys[_], consistent: Boolean): ScanamoOps[Set[Either[DynamoReadError, T]]] =
     keys.asAVMap
-      .grouped(batchSize)
+      .grouped(batchGetSize)
       .toList
       .traverse(
         batch =>

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -34,21 +34,21 @@ object ScanamoFree {
           ScanamoOps.batchWrite(
             new BatchWriteItemRequest().withRequestItems(
               Map(
-                tableName -> batch.toList
-                  .map(i => new WriteRequest().withPutRequest(new PutRequest().withItem(f.write(i).getM)))
-                  .asJava
-              ).asJava
-            )
-          )
+            tableName -> batch
+              .foldRight(List.empty[WriteRequest]) { case (i, reqs) => reqs :+ new WriteRequest().withPutRequest(new PutRequest().withItem(f.write(i).getM)) }
+              .asJava
+          ).asJava
+        )
       )
+    )
 
   def deleteAll(tableName: String)(items: UniqueKeys[_]): ScanamoOps[List[BatchWriteItemResult]] =
     items.asAVMap.grouped(batchSize).toList.traverse { batch =>
       ScanamoOps.batchWrite(
         new BatchWriteItemRequest().withRequestItems(
           Map(
-            tableName -> batch.toList
-              .map(item => new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(item.asJava)))
+            tableName -> batch
+              .foldRight(List.empty[WriteRequest]) { case (i, reqs) => reqs :+ new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(i.asJava)) }
               .asJava
           ).asJava
         )

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -22,13 +22,7 @@ object ScanamoFree {
         ScanamoPutRequest(tableName, f.write(item), None)
       )
       .map { r =>
-        if (Option(r.getAttributes).exists(_.asScala.nonEmpty)) {
-          Some(
-            f.read(new AttributeValue().withM(r.getAttributes))
-          )
-        } else {
-          None
-        }
+        Option(r.getAttributes).filter(!_.isEmpty).map(attrs => f.read(new AttributeValue().withM(attrs)))
       }
 
   def putAll[T](tableName: String)(items: Set[T])(implicit f: DynamoFormat[T]): ScanamoOps[List[BatchWriteItemResult]] =

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -38,8 +38,8 @@ case class Table[V: DynamoFormat](name: String) {
 
   def put(v: V): ScanamoOps[Option[Either[DynamoReadError, V]]] = ScanamoFree.put(name)(v)
   def putAll(vs: Set[V]): ScanamoOps[List[BatchWriteItemResult]] = ScanamoFree.putAll(name)(vs)
-  def get(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] = ScanamoFree.get[V](name)(key)
-  def getAll(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, V]]] = ScanamoFree.getAll[V](name)(keys)
+  def get(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] = ScanamoFree.get[V](name)(key, false)
+  def getAll(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, V]]] = ScanamoFree.getAll[V](name)(keys, false)
   def delete(key: UniqueKey[_]): ScanamoOps[DeleteItemResult] = ScanamoFree.delete(name)(key)
 
   /**
@@ -756,9 +756,9 @@ private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](tableName: St
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.query(query)
 
   def get(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] =
-    ScanamoFree.getWithConsistency[V](tableName)(key)
+    ScanamoFree.get[V](tableName)(key, true)
   def getAll(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, V]]] =
-    ScanamoFree.getAllWithConsistency[V](tableName)(keys)
+    ScanamoFree.getAll[V](tableName)(keys, true)
 }
 
 private[scanamo] case class TableWithOptions[V: DynamoFormat](tableName: String, queryOptions: ScanamoQueryOptions) {

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -39,7 +39,8 @@ case class Table[V: DynamoFormat](name: String) {
   def put(v: V): ScanamoOps[Option[Either[DynamoReadError, V]]] = ScanamoFree.put(name)(v)
   def putAll(vs: Set[V]): ScanamoOps[List[BatchWriteItemResult]] = ScanamoFree.putAll(name)(vs)
   def get(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] = ScanamoFree.get[V](name)(key, false)
-  def getAll(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, V]]] = ScanamoFree.getAll[V](name)(keys, false)
+  def getAll(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, V]]] =
+    ScanamoFree.getAll[V](name)(keys, false)
   def delete(key: UniqueKey[_]): ScanamoOps[DeleteItemResult] = ScanamoFree.delete(name)(key)
 
   /**

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoInterpreters.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoInterpreters.scala
@@ -141,7 +141,7 @@ private[ops] object JavaRequests {
         queryRefinement(_.options.limit)(_.withLimit(_)),
         queryRefinement(_.options.exclusiveStartKey)((r, k) => r.withExclusiveStartKey(k)),
         queryRefinement(_.options.filter)((r, f) => {
-          val requestCondition = f.apply(None)
+          val requestCondition = f.apply
           val filteredRequest = r
             .withFilterExpression(requestCondition.expression)
             .withExpressionAttributeNames(requestCondition.attributeNames.asJava)
@@ -167,7 +167,7 @@ private[ops] object JavaRequests {
         queryRefinement(_.options.limit)(_.withLimit(_)),
         queryRefinement(_.options.exclusiveStartKey)((r, k) => r.withExclusiveStartKey(k)),
         queryRefinement(_.options.filter)((r, f) => {
-          val requestCondition = f.apply(None)
+          val requestCondition = f.apply
           r.withFilterExpression(requestCondition.expression)
             .withExpressionAttributeNames(
               (r.getExpressionAttributeNames.asScala ++ requestCondition.attributeNames).asJava

--- a/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
@@ -13,54 +13,49 @@ case class ConditionalOperation[V, T](tableName: String, t: T)(
   implicit state: ConditionExpression[T],
   format: DynamoFormat[V]
 ) {
-  def put(item: V): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] = {
-    val unconditionalRequest = ScanamoPutRequest(tableName, format.write(item), None)
+  def put(item: V): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] =
     ScanamoOps.conditionalPut(
-      unconditionalRequest.copy(condition = Some(state.apply(t)(unconditionalRequest.condition)))
+      ScanamoPutRequest(tableName, format.write(item), Some(state.apply(t)))
     )
-  }
 
-  def delete(key: UniqueKey[_]): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] = {
-    val unconditionalRequest = ScanamoDeleteRequest(tableName = tableName, key = key.asAVMap, None)
+  def delete(key: UniqueKey[_]): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] =
     ScanamoOps.conditionalDelete(
-      unconditionalRequest.copy(condition = Some(state.apply(t)(unconditionalRequest.condition)))
+      ScanamoDeleteRequest(tableName = tableName, key = key.asAVMap, Some(state.apply(t)))
     )
-  }
 
-  def update(key: UniqueKey[_], update: UpdateExpression): ScanamoOps[Either[ScanamoError, V]] = {
-
-    val unconditionalRequest = ScanamoUpdateRequest(
-      tableName,
-      key.asAVMap,
-      update.expression,
-      update.attributeNames,
-      update.attributeValues,
-      None
-    )
+  def update(key: UniqueKey[_], update: UpdateExpression): ScanamoOps[Either[ScanamoError, V]] =
     ScanamoOps
-      .conditionalUpdate(unconditionalRequest.copy(condition = Some(state.apply(t)(unconditionalRequest.condition))))
+      .conditionalUpdate(
+        ScanamoUpdateRequest(
+          tableName,
+          key.asAVMap,
+          update.expression,
+          update.attributeNames,
+          update.attributeValues,
+          Some(state.apply(t))
+        )
+      )
       .map(
         either =>
           either
             .leftMap[ScanamoError](ConditionNotMet(_))
             .flatMap(r => format.read(new AttributeValue().withM(r.getAttributes)))
       )
-  }
 }
 
 @typeclass trait ConditionExpression[T] {
-  def apply(t: T)(condition: Option[RequestCondition]): RequestCondition
+  def apply(t: T): RequestCondition
 }
 
 object ConditionExpression {
   implicit def symbolValueEqualsCondition[V: DynamoFormat] = new ConditionExpression[(Symbol, V)] {
-    override def apply(pair: (Symbol, V))(condition: Option[RequestCondition]): RequestCondition =
-      attributeValueEqualsCondition.apply((AttributeName.of(pair._1), pair._2))(condition)
+    override def apply(pair: (Symbol, V)): RequestCondition =
+      attributeValueEqualsCondition.apply((AttributeName.of(pair._1), pair._2))
   }
 
   implicit def attributeValueEqualsCondition[V: DynamoFormat] = new ConditionExpression[(AttributeName, V)] {
     val prefix = "equalsCondition"
-    override def apply(pair: (AttributeName, V))(condition: Option[RequestCondition]): RequestCondition = {
+    override def apply(pair: (AttributeName, V)): RequestCondition = {
       val attributeName = pair._1
       RequestCondition(
         s"#${attributeName.placeholder(prefix)} = :conditionAttributeValue",
@@ -71,13 +66,13 @@ object ConditionExpression {
   }
 
   implicit def symbolValueInCondition[V: DynamoFormat] = new ConditionExpression[(Symbol, Set[V])] {
-    override def apply(pair: (Symbol, Set[V]))(condition: Option[RequestCondition]): RequestCondition =
-      attributeValueInCondition.apply((AttributeName.of(pair._1), pair._2))(condition)
+    override def apply(pair: (Symbol, Set[V])): RequestCondition =
+      attributeValueInCondition.apply((AttributeName.of(pair._1), pair._2))
   }
 
   implicit def attributeValueInCondition[V: DynamoFormat] = new ConditionExpression[(AttributeName, Set[V])] {
     val prefix = "inCondition"
-    override def apply(pair: (AttributeName, Set[V]))(condition: Option[RequestCondition]): RequestCondition = {
+    override def apply(pair: (AttributeName, Set[V])): RequestCondition = {
       val format = DynamoFormat[V]
       val attributeName = pair._1
       val attributeValues = pair._2.zipWithIndex.map {
@@ -94,26 +89,26 @@ object ConditionExpression {
 
   implicit def attributeExistsCondition = new ConditionExpression[AttributeExists] {
     val prefix = "attributeExists"
-    override def apply(t: AttributeExists)(condition: Option[RequestCondition]): RequestCondition =
+    override def apply(t: AttributeExists): RequestCondition =
       RequestCondition(s"attribute_exists(#${t.key.placeholder(prefix)})", t.key.attributeNames(s"#$prefix"), None)
   }
 
   implicit def attributeNotExistsCondition = new ConditionExpression[AttributeNotExists] {
     val prefix = "attributeNotExists"
-    override def apply(t: AttributeNotExists)(condition: Option[RequestCondition]): RequestCondition =
+    override def apply(t: AttributeNotExists): RequestCondition =
       RequestCondition(s"attribute_not_exists(#${t.key.placeholder(prefix)})", t.key.attributeNames(s"#$prefix"), None)
   }
 
   implicit def notCondition[T](implicit pcs: ConditionExpression[T]) = new ConditionExpression[Not[T]] {
-    override def apply(not: Not[T])(condition: Option[RequestCondition]): RequestCondition = {
-      val conditionToNegate = pcs(not.condition)(condition)
+    override def apply(not: Not[T]): RequestCondition = {
+      val conditionToNegate = pcs(not.condition)
       conditionToNegate.copy(expression = s"NOT(${conditionToNegate.expression})")
     }
   }
 
   implicit def beginsWithCondition[V: DynamoFormat] = new ConditionExpression[BeginsWith[V]] {
     val prefix = "beginsWith"
-    override def apply(b: BeginsWith[V])(condition: Option[RequestCondition]): RequestCondition =
+    override def apply(b: BeginsWith[V]): RequestCondition =
       RequestCondition(
         s"begins_with(#${b.key.placeholder(prefix)}, :conditionAttributeValue)",
         b.key.attributeNames(s"#$prefix"),
@@ -123,7 +118,7 @@ object ConditionExpression {
 
   implicit def betweenCondition[V: DynamoFormat] = new ConditionExpression[Between[V]] {
     val prefix = "between"
-    override def apply(b: Between[V])(condition: Option[RequestCondition]): RequestCondition =
+    override def apply(b: Between[V]): RequestCondition =
       RequestCondition(
         s"#${b.key.placeholder(prefix)} BETWEEN :lower and :upper",
         b.key.attributeNames(s"#$prefix"),
@@ -138,7 +133,7 @@ object ConditionExpression {
 
   implicit def keyIsCondition[V: DynamoFormat] = new ConditionExpression[KeyIs[V]] {
     val prefix = "keyIs"
-    override def apply(k: KeyIs[V])(condition: Option[RequestCondition]): RequestCondition =
+    override def apply(k: KeyIs[V]): RequestCondition =
       RequestCondition(
         s"#${k.key.placeholder(prefix)} ${k.operator.op} :conditionAttributeValue",
         k.key.attributeNames(s"#$prefix"),
@@ -148,17 +143,17 @@ object ConditionExpression {
 
   implicit def andCondition[L, R](implicit lce: ConditionExpression[L], rce: ConditionExpression[R]) =
     new ConditionExpression[AndCondition[L, R]] {
-      override def apply(and: AndCondition[L, R])(condition: Option[RequestCondition]): RequestCondition =
-        combineConditions(condition, and.l, and.r, "AND")
+      override def apply(and: AndCondition[L, R]): RequestCondition =
+        combineConditions(and.l, and.r, "AND")
     }
 
   implicit def orCondition[L, R](implicit lce: ConditionExpression[L], rce: ConditionExpression[R]) =
     new ConditionExpression[OrCondition[L, R]] {
-      override def apply(and: OrCondition[L, R])(condition: Option[RequestCondition]): RequestCondition =
-        combineConditions(condition, and.l, and.r, "OR")
+      override def apply(and: OrCondition[L, R]): RequestCondition =
+        combineConditions(and.l, and.r, "OR")
     }
 
-  private def combineConditions[L, R](condition: Option[RequestCondition], l: L, r: R, combininingOperator: String)(
+  private def combineConditions[L, R](l: L, r: R, combininingOperator: String)(
     implicit lce: ConditionExpression[L],
     rce: ConditionExpression[R]
   ): RequestCondition = {
@@ -174,8 +169,8 @@ object ConditionExpression {
     val lPrefix = s"${combininingOperator.toLowerCase}_l_"
     val rPrefix = s"${combininingOperator.toLowerCase}_r_"
 
-    val lCondition = lce(l)(condition)
-    val rCondition = rce(r)(condition)
+    val lCondition = lce(l)
+    val rCondition = rce(r)
 
     val mergedExpressionAttributeNames =
       prefixKeys(lCondition.attributeNames, lPrefix, '#') ++
@@ -216,7 +211,7 @@ case class AndCondition[L: ConditionExpression, R: ConditionExpression](l: L, r:
 case class OrCondition[L: ConditionExpression, R: ConditionExpression](l: L, r: R)
 
 case class Condition[T: ConditionExpression](t: T) {
-  def apply(condition: Option[RequestCondition]) = implicitly[ConditionExpression[T]].apply(t)(condition)
+  def apply = implicitly[ConditionExpression[T]].apply(t)
   def and[Y: ConditionExpression](other: Y) = AndCondition(t, other)
   def or[Y: ConditionExpression](other: Y) = OrCondition(t, other)
 }
@@ -224,7 +219,6 @@ case class Condition[T: ConditionExpression](t: T) {
 object Condition {
   implicit def conditionExpression[T]: ConditionExpression[Condition[T]] =
     new ConditionExpression[Condition[T]] {
-      override def apply(condition: Condition[T])(possibleCondition: Option[RequestCondition]): RequestCondition =
-        condition(possibleCondition)
+      override def apply(condition: Condition[T]): RequestCondition = condition.apply
     }
 }


### PR DESCRIPTION
- I've noticed the `Option[RequestCondition]` was never used in instances of `ConditionExpression`, so removing that
- also got rid of the `xxxWithConsistency` calls, replaced with a simple boolean in `ScanamoFree.xxx`
- the max batch size for `BatchGetItem` is 100, not 25
- avoids extra allocations when we get closer to the metal. I'd like to develop a habit of directly using the Java structures when we interact with the dynamo api instead of relying on java converters