### PR TITLE
update doctest version since it's causing exception on windows

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.3")
 
-addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.2")
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.9.4")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages"    % "0.6.3")


### PR DESCRIPTION
As highlighted on this comment:
https://github.com/scanamo/scanamo/pull/422#issuecomment-498638872

sbt-doctest 0.9.2 is causing an issue on windows which is this exception:
`
[error] org.scalameta.invariants.InvariantFailedException: invariant failed: [error] when verifying ScalametaTokenizer.this.input.chars.apply(curr.endOffset.+(1)).==('\"') [error] found that ScalametaTokenizer.this.input.chars.apply(curr.endOffset.+(1)) is not equal to '\"' [error] where ScalametaTokenizer = scala.meta.internal.tokenizers.ScalametaTokenizer@3b827a9e [error] at org.scalameta.invariants.InvariantFailedException$.raise(Exceptions.scala:15) [error] at scala.meta.internal.tokenizers.ScalametaTokenizer.emitContents$1(ScalametaTokenizer.scala:222) [error] at scala.meta.internal.tokenizers.ScalametaTokenizer.loop$1(ScalametaTokenizer.scala:231) [error] at scala.meta.internal.tokenizers.ScalametaTokenizer.uncachedTokenize(ScalametaTokenizer.scala:276) [error] at scala.meta.internal.tokenizers.ScalametaTokenizer.tokenize(ScalametaTokenizer.scala:31) [error] at scala.meta.internal.tokenizers.ScalametaTokenizer$$anon$2.apply(ScalametaTokenizer.scala:287) [error] at scala.meta.tokenizers.Api$XtensionTokenizeDialectInput.tokenize(Api.scala:21) [error] at scala.meta.tokenizers.Api$XtensionTokenizeInputLike.tokenize(Api.scala:10) [error] at scala.meta.internal.parsers.ScalametaParser.scannerTokens$lzycompute(ScalametaParser.scala:183) [error] at scala.meta.internal.parsers.ScalametaParser.scannerTokens(ScalametaParser.scala:183) [error] at scala.meta.internal.parsers.ScalametaParser.<init>(ScalametaParser.scala:140) [error] at scala.meta.internal.parsers.ScalametaParser$$anon$189.apply(ScalametaParser.scala:3465) [error] at scala.meta.parsers.Api$XtensionParseDialectInput.parse(Api.scala:21) [error] at scala.meta.parsers.Api$XtensionParseInputLike.parse(Api.scala:10) [error] at com.github.tkawachi.doctest.ScaladocExtractor$.extract(ScaladocExtractor.scala:16) [error] at com.github.tkawachi.doctest.ScaladocTestGenerator$.apply(ScaladocTestGenerator.scala:22) [error] at com.github.tkawachi.doctest.DoctestPlugin$.$anonfun$doctestScaladocGenTests$3(DoctestPlugin.scala:70) [error] at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:240) [error] at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:58) [error] at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:51) [error] at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47) [error] at scala.collection.TraversableLike.flatMap(TraversableLike.scala:240) [error] at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:237) [error] at scala.collection.AbstractTraversable.flatMap(Traversable.scala:104) [error] at com.github.tkawachi.doctest.DoctestPlugin$.doctestScaladocGenTests(DoctestPlugin.scala:70) [error] at com.github.tkawachi.doctest.DoctestPlugin$.$anonfun$doctestGenSettings$12(DoctestPlugin.scala:129) [error] at scala.Function1.$anonfun$compose$1(Function1.scala:44) [error] at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40) [error] at sbt.std.Transform$$anon$4.work(System.scala:67) [error] at sbt.Execute.$anonfun$submit$2(Execute.scala:269) [error] at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16) [error] at sbt.Execute.work(Execute.scala:278) [error] at sbt.Execute.$anonfun$submit$1(Execute.scala:269) [error] at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178) [error] at sbt.CompletionService$$anon$2.call(CompletionService.scala:37) [error] at java.util.concurrent.FutureTask.run(FutureTask.java:266) [error] at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [error] at java.util.concurrent.FutureTask.run(FutureTask.java:266) [error] at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [error] at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [error] at java.lang.Thread.run(Thread.java:748)
`

Updating to 0.9.4 fixed it.