### PR TITLE
Replace `Symbol` with `String`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ scala> import org.scanamo.auto._
  
 scala> val client = LocalDynamoDB.client()
 scala> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-scala> val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")('name -> S)
+scala> val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("name" -> S)
 
 scala> case class Farm(animals: List[String])
 scala> case class Farmer(name: String, age: Long, farm: Farm)
@@ -40,7 +40,7 @@ scala> val ops = for {
      |       Farmer("McDonald", 156L, Farm(List("sheep", "cow"))),
      |       Farmer("Boggis", 43L, Farm(List("chicken")))
      |     ))
-     |   mcdonald <- table.get('name -> "McDonald")
+     |   mcdonald <- table.get("name" -> "McDonald")
      | } yield mcdonald
 scala> Scanamo.exec(client)(ops)
 res1: Option[Either[error.DynamoReadError, Farmer]] = Some(Right(Farmer(McDonald,156,Farm(List(sheep, cow)))))

--- a/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
@@ -173,7 +173,9 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
         _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
-        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
+        _ <- forecasts
+          .given("weather" -> "Rain")
+          .update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -407,33 +409,34 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
-      val stationTable = Table[Station](t)
-      val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
-      val ops = for {
-        _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
-      } yield (ts1, ts2, ts3, ts4, ts5)
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
+      (t, i) =>
+        val stationTable = Table[Station](t)
+        val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
+        val ops = for {
+          _ <- stationTable.putAll(stations)
+          ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(LiverpoolStreet))
+          ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(CamdenTown))
+          ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
+        } yield (ts1, ts2, ts3, ts4, ts5)
 
-      scanamo
-        .exec(ops)
-        .runForeach(
-          _ should equal(
-            (
-              List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
-              List.empty,
-              List.empty,
-              List.empty,
-              List.empty
+        scanamo
+          .exec(ops)
+          .runForeach(
+            _ should equal(
+              (
+                List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
+                List.empty,
+                List.empty,
+                List.empty,
+                List.empty
+              )
             )
           )
-        )
     }
   }
 

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -153,7 +153,9 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
         _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
-        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
+        _ <- forecasts
+          .given("weather" -> "Rain")
+          .update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -367,39 +369,40 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
-      val stationTable = Table[Station](t)
-      val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
-      val ops = for {
-        _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
-      } yield (ts1, ts2, ts3, ts4, ts5)
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
+      (t, i) =>
+        val stationTable = Table[Station](t)
+        val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
+        val ops = for {
+          _ <- stationTable.putAll(stations)
+          ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(LiverpoolStreet))
+          ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(CamdenTown))
+          ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
+        } yield (ts1, ts2, ts3, ts4, ts5)
 
-      scanamo
-        .exec[
+        scanamo
+          .exec[
+            (
+              List[Either[org.scanamo.error.DynamoReadError, Station]],
+              List[Either[org.scanamo.error.DynamoReadError, Station]],
+              List[Either[org.scanamo.error.DynamoReadError, Station]],
+              List[Either[org.scanamo.error.DynamoReadError, Station]],
+              List[Either[org.scanamo.error.DynamoReadError, Station]]
+            )
+          ](ops)
+          .unsafeRunSync should equal(
           (
-            List[Either[org.scanamo.error.DynamoReadError, Station]],
-            List[Either[org.scanamo.error.DynamoReadError, Station]],
-            List[Either[org.scanamo.error.DynamoReadError, Station]],
-            List[Either[org.scanamo.error.DynamoReadError, Station]],
-            List[Either[org.scanamo.error.DynamoReadError, Station]]
+            List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
+            List.empty,
+            List.empty,
+            List.empty,
+            List.empty
           )
-        ](ops)
-        .unsafeRunSync should equal(
-        (
-          List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
-          List.empty,
-          List.empty,
-          List.empty,
-          List.empty
         )
-      )
     }
   }
 

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -16,7 +16,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   val scanamo = ScanamoCats[IO](client)
 
   it("should put asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -24,7 +24,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        f <- farmers.get('name -> "McDonald")
+        f <- farmers.get("name" -> "McDonald")
       } yield f
 
       scanamo.exec[Option[Either[DynamoReadError, Farmer]]](result).unsafeRunSync should equal(
@@ -34,7 +34,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should get asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -42,8 +42,8 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals('name, "Maggot")))
-        r2 <- farmers.get('name -> "Maggot")
+        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
+        r2 <- farmers.get("name" -> "Maggot")
       } yield (r1, r1 == r2)
 
       scanamo
@@ -53,14 +53,14 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
       val engines = Table[Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get('name -> "Thomas" and 'number -> 1)
+        e <- engines.get("name" -> "Thomas" and "number" -> 1)
       } yield e
 
       scanamo.exec[Option[Either[DynamoReadError, Engine]]](result).unsafeRunSync should equal(
@@ -71,12 +71,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val cities = Table[City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
-        c <- cities.consistently.get('name -> "Nashville")
+        c <- cities.consistently.get("name" -> "Nashville")
       } yield c
 
       scanamo.exec[Option[Either[DynamoReadError, City]]](result).unsafeRunSync should equal(
@@ -86,7 +86,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should delete asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -96,8 +96,8 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
         .exec[Option[Either[DynamoReadError, Farmer]]] {
           for {
             _ <- farmers.put(Farmer("McGregor", 62L, Farm(List("rabbit"))))
-            _ <- farmers.delete('name -> "McGregor")
-            f <- farmers.get('name -> "McGregor")
+            _ <- farmers.delete("name" -> "McGregor")
+            f <- farmers.get("name" -> "McGregor")
           } yield f
         }
         .unsafeRunSync should equal(None)
@@ -105,7 +105,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should deleteAll asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -119,7 +119,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
       val ops = for {
         _ <- farmers.putAll(dataSet)
-        _ <- farmers.deleteAll('name -> dataSet.map(_.name))
+        _ <- farmers.deleteAll("name" -> dataSet.map(_.name))
         fs <- farmers.scan
       } yield fs
 
@@ -128,13 +128,13 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should update asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
       val forecasts = Table[Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
-        _ <- forecasts.update('location -> "London", set('weather -> "Sun"))
+        _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
         fs <- forecasts.scan
       } yield fs
 
@@ -145,15 +145,15 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should update asynchronously if a condition holds") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
       val forecasts = Table[Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "London", set('equipment -> Some("umbrella")))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "Birmingham", set('equipment -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -164,7 +164,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should scan asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
       val bears = Table[Bear](t)
@@ -180,7 +180,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
       val lemmings = Table[Lemming](t)
       val ops = for {
@@ -195,7 +195,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("scans with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -211,7 +211,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -228,7 +228,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("Paginate scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -236,8 +236,8 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from('name -> "Graham" and ('alias -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from('name -> "Yogi" and ('alias -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
         } yield res2 ::: res3
       } yield bs
 
@@ -248,17 +248,17 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should query asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('species -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
       val animals = Table[Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
-        r1 <- animals.query('species -> "Pig")
-        r2 <- animals.query('species -> "Pig" and 'number < 3)
-        r3 <- animals.query('species -> "Pig" and 'number > 1)
-        r4 <- animals.query('species -> "Pig" and 'number <= 2)
-        r5 <- animals.query('species -> "Pig" and 'number >= 2)
+        r1 <- animals.query("species" -> "Pig")
+        r2 <- animals.query("species" -> "Pig" and "number" < 3)
+        r3 <- animals.query("species" -> "Pig" and "number" > 1)
+        r4 <- animals.query("species" -> "Pig" and "number" <= 2)
+        r5 <- animals.query("species" -> "Pig" and "number" >= 2)
       } yield (r1, r2, r3, r4, r5)
 
       scanamo
@@ -282,7 +282,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
       val transports = Table[Transport](t)
       val ops = for {
@@ -293,7 +293,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
             Transport("Underground", "Central")
           )
         )
-        ts <- transports.query('mode -> "Underground" and ('line beginsWith "C"))
+        ts <- transports.query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield ts
 
       scanamo.exec[List[Either[DynamoReadError, Transport]]](ops).unsafeRunSync should equal(
@@ -305,7 +305,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("queries with a limit asynchronously") {
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
       val transports = Table[Transport](t)
       val result = for {
         _ <- transports.putAll(
@@ -315,7 +315,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
             Transport("Underground", "Central")
           )
         )
-        rs <- transports.limit(1).query('mode -> "Underground" and ('line beginsWith "C"))
+        rs <- transports.limit(1).query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield rs
 
       scanamo.exec[List[Either[DynamoReadError, Transport]]](result).unsafeRunSync should equal(
@@ -327,7 +327,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("queries an index with a limit asynchronously") {
     case class Transport(mode: String, line: String, colour: String)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('mode -> S, 'colour -> S) {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
         val transports = Table[Transport](t)
         val result = for {
@@ -344,7 +344,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
             .index(i)
             .limit(1)
             .query(
-              'mode -> "Underground" and ('colour beginsWith "Bl")
+              "mode" -> "Underground" and ("colour" beginsWith "Bl")
             )
         } yield rs
 
@@ -354,12 +354,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     }
   }
 
-  it("queries an index asynchronously with 'between' sort-key condition") {
+  it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
     def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(('mode, 'name), stations.map(station => (station.mode, station.name))))
+        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -367,18 +367,18 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'name -> S)('mode -> S, 'zone -> N) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
       val stationTable = Table[Station](t)
       val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
       val ops = for {
         _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (1 and 1)))
+        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
       } yield (ts1, ts2, ts3, ts4, ts5)
 
       scanamo
@@ -406,12 +406,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("queries for items that are missing an attribute") {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
-    LocalDynamoDB.usingRandomTable(client)('firstName -> S, 'surname -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
-        farmerWithNoAge <- farmersTable.filter(attributeNotExists('age)).query('firstName -> "Fred")
+        farmerWithNoAge <- farmersTable.filter(attributeNotExists("age")).query("firstName" -> "Fred")
       } yield farmerWithNoAge
       scanamo.exec[List[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
         List(Right(Farmer("Fred", "Perry", None)))
@@ -422,7 +422,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("should put multiple items asynchronously") {
     case class Rabbit(name: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
@@ -434,7 +434,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   }
 
   it("should get multiple items asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
       val farmers = Table[Farmer](t)
@@ -448,8 +448,8 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
               Farmer("Bean", 55L, Farm(List("turkey")))
             )
           )
-          fs1 <- farmers.getAll(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
-          fs2 <- farmers.getAll('name -> Set("Boggis", "Bean"))
+          fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+          fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
         } yield (fs1, fs2))
         .unsafeRunSync should equal(
         (
@@ -459,21 +459,21 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
       val doctors = Table[Doctor](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Doctor]]](for {
           _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-          ds <- doctors.getAll(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+          ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
         } yield ds)
         .unsafeRunSync should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
 
   it("should get multiple items asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
@@ -481,14 +481,14 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       scanamo
         .exec[Set[Either[DynamoReadError, Farm]]](for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+          fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
         } yield fs)
         .unsafeRunSync should equal(farms.map(Right(_)))
     }
   }
 
   it("should get multiple items consistently asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
@@ -496,7 +496,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       scanamo
         .exec[Set[Either[DynamoReadError, Farm]]](for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+          fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
         } yield fs)
         .unsafeRunSync should equal(farms.map(Right(_)))
     }
@@ -506,7 +506,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -523,7 +523,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -539,14 +539,14 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
-        _ <- farmersTable.given('age -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
-        farmerWithNewStock <- farmersTable.get('name -> "McDonald")
+        _ <- farmersTable.given("age" -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
+        _ <- farmersTable.given("age" -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
+        farmerWithNewStock <- farmersTable.get("name" -> "McDonald")
       } yield farmerWithNewStock
 
       scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
@@ -555,20 +555,20 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     }
   }
 
-  it("conditionally put asynchronously with 'between' condition") {
+  it("conditionally put asynchronously with `between` condition") {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
         _ <- farmersTable.put(Farmer("Butch", 57, Farm(List("cattle"))))
         _ <- farmersTable.put(Farmer("Wade", 58, Farm(List("chicken", "sheep"))))
-        _ <- farmersTable.given('age between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
-        _ <- farmersTable.given('age between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
-        farmerButch <- farmersTable.get('name -> "Butch")
+        _ <- farmersTable.given("age" between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
+        _ <- farmersTable.given("age" between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
+        farmerButch <- farmersTable.get("name" -> "Butch")
       } yield farmerButch
       scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
         Some(Right(Farmer("Butch", 57, Farm(List("chicken")))))
@@ -579,13 +579,13 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("conditionally delete asynchronously") {
     case class Gremlin(number: Int, wet: Boolean)
 
-    LocalDynamoDB.usingRandomTable(client)('number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
       val gremlinsTable = Table[Gremlin](t)
 
       val ops: ScanamoOps[List[Either[DynamoReadError, Gremlin]]] = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 1)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 2)
         remainingGremlins <- gremlinsTable.scan()
       } yield remainingGremlins
 

--- a/docs/src/main/tut/asynchronous.md
+++ b/docs/src/main/tut/asynchronous.md
@@ -21,7 +21,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 val client = LocalDynamoDB.client()
 val scanamo = ScanamoAsync(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("farm")('name -> S)
+LocalDynamoDB.createTable(client)("farm")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
@@ -32,7 +32,7 @@ val ops = for {
     Farmer("Bunce", 52L, Farm(List("goose"))),
     Farmer("Bean", 55L, Farm(List("turkey")))
   ))
-  bunce <- farmTable.get('name -> "Bunce")
+  bunce <- farmTable.get("name" -> "Bunce")
 } yield bunce
 ```
 ```scala
@@ -81,7 +81,7 @@ val client = LocalDynamoDB.client()
 
 val scanamo = ScanamoAlpakka(alpakkaClient)
 
-LocalDynamoDB.createTable(client)("nursery-farmers")('name -> S)
+LocalDynamoDB.createTable(client)("nursery-farmers")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
@@ -92,7 +92,7 @@ val ops = for {
     Farmer("Bunce", 52L, Farm(List("goose"))),
     Farmer("Bean", 55L, Farm(List("turkey")))
   ))
-  bunce <- farmTable.get('name -> "Bunce")
+  bunce <- farmTable.get("name" -> "Bunce")
 } yield bunce
 
 // Use the Alpakka interpreter

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -20,7 +20,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("lemmings")('role -> S)
+LocalDynamoDB.createTable(client)("lemmings")("role" -> S)
 
 case class Lemming(role: String, number: Long)
 ```
@@ -31,8 +31,8 @@ val ops = for {
   _ <- lemmingsTable.putAll(Set(
     Lemming("Walker", 99), Lemming("Blocker", 42), Lemming("Builder", 180)
   ))
-  bLemmings <- lemmingsTable.getAll('role -> Set("Blocker", "Builder"))
-  _ <- lemmingsTable.deleteAll('role -> Set("Walker", "Blocker"))
+  bLemmings <- lemmingsTable.getAll("role" -> Set("Blocker", "Builder"))
+  _ <- lemmingsTable.deleteAll("role" -> Set("Walker", "Blocker"))
   survivors <- lemmingsTable.scan()
 } yield (bLemmings, survivors)
 val (bLemmings, survivors) = scanamo.exec(ops)

--- a/docs/src/main/tut/conditional-operations.md
+++ b/docs/src/main/tut/conditional-operations.md
@@ -22,24 +22,24 @@ case class Gremlin(number: Int, name: String, wet: Boolean, friendly: Boolean)
 ```
 ```tut:book
 val gremlinsTable = Table[Gremlin]("gremlins")
-LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
+LocalDynamoDB.withTable(client)("gremlins")("number" -> N) {
   val ops = for {
     _ <- gremlinsTable.putAll(
       Set(Gremlin(1, "Gizmo", false, true), Gremlin(2, "George", true, false)))
     // Only `put` Gremlins if not already one with the same number
-    _ <- gremlinsTable.given(not(attributeExists('number)))
+    _ <- gremlinsTable.given(not(attributeExists("number")))
       .put(Gremlin(2, "Stripe", false, true))
-    _ <- gremlinsTable.given(not(attributeExists('number)))
+    _ <- gremlinsTable.given(not(attributeExists("number")))
       .put(Gremlin(3, "Greta", true, true))
     allGremlins <- gremlinsTable.scan()  
-    _ <- gremlinsTable.given('wet -> true)
-      .delete('number -> 1)
-    _ <- gremlinsTable.given('wet -> true)
-      .delete('number -> 2)
-    _ <- gremlinsTable.given('wet -> true)
-      .update('number -> 1, set('friendly -> false))
-    _ <- gremlinsTable.given('wet -> true)
-      .update('number -> 3, set('friendly -> false))
+    _ <- gremlinsTable.given("wet" -> true)
+      .delete("number" -> 1)
+    _ <- gremlinsTable.given("wet" -> true)
+      .delete("number" -> 2)
+    _ <- gremlinsTable.given("wet" -> true)
+      .update("number" -> 1, set("friendly" -> false))
+    _ <- gremlinsTable.given("wet" -> true)
+      .update("number" -> 3, set("friendly" -> false))
     remainingGremlins <- gremlinsTable.scan()
   } yield (allGremlins, remainingGremlins)
   scanamo.exec(ops)

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -76,7 +76,7 @@ case class Foo(dateTime: DateTime)
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("foo")('dateTime -> S)
+LocalDynamoDB.createTable(client)("foo")("dateTime" -> S)
 ```
 ```tut:book
 implicit val jodaStringFormat = DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](
@@ -121,7 +121,7 @@ type PosInt = Int Refined Positive
 
 case class Customer(age: PosInt)
 
-LocalDynamoDB.createTable(client)("Customer")('age -> N)
+LocalDynamoDB.createTable(client)("Customer")("age" -> N)
 ```
 
 You just now use it like if the type `PosInt` was natively supported by `scanamo`:

--- a/docs/src/main/tut/filters.md
+++ b/docs/src/main/tut/filters.md
@@ -27,7 +27,7 @@ case class Station(line: String, name: String, zone: Int)
 val stationTable = Table[Station]("Station")
 ```
 ```tut:book
-LocalDynamoDB.withTable(client)("Station")('line -> S, 'name -> S) {
+LocalDynamoDB.withTable(client)("Station")("line" -> S, "name" -> S) {
   val ops = for {
     _ <- stationTable.putAll(Set(
       Station("Metropolitan", "Chalfont & Latimer", 8),
@@ -38,8 +38,8 @@ LocalDynamoDB.withTable(client)("Station")('line -> S, 'name -> S) {
     ))
     filteredStations <- 
       stationTable
-        .filter('zone < 8)
-        .query('line -> "Metropolitan" and ('name beginsWith "C"))
+        .filter("zone" < 8)
+        .query("line" -> "Metropolitan" and ("name" beginsWith "C"))
   } yield filteredStations
   scanamo.exec(ops)
 }

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -35,7 +35,7 @@ import org.scanamo.auto._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")('name -> S)
+val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
@@ -46,7 +46,7 @@ we can simply `put` and `get` items from Dynamo, without boilerplate or reflecti
 val table = Table[Farmer]("farmer")
 
 scanamo.exec(table.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow")))))
-scanamo.exec(table.get('name -> "McDonald"))
+scanamo.exec(table.get("name" -> "McDonald"))
 ```
 
 Scanamo supports most other DynamoDB [operations](operations.html), beyond

--- a/docs/src/main/tut/operations.md
+++ b/docs/src/main/tut/operations.md
@@ -33,7 +33,7 @@ import org.scanamo.auto._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("muppets")('name -> S)
+LocalDynamoDB.createTable(client)("muppets")("name" -> S)
 
 case class Muppet(name: String, species: String)
 ```
@@ -43,7 +43,7 @@ val operations = for {
   _ <- muppets.put(Muppet("Kermit", "Frog"))
   _ <- muppets.put(Muppet("Cookie Monster", "Monster"))
   _ <- muppets.put(Muppet("Miss Piggy", "Pig"))
-  kermit <- muppets.get('name -> "Kermit")
+  kermit <- muppets.get("name" -> "Kermit")
 } yield kermit
      
 scanamo.exec(operations)
@@ -53,7 +53,7 @@ Note that when using `Table` no operations are actually executed against DynamoD
 
 ### Delete
 
-To remove an item in it's entirety, we can use delete:
+To remove an item in its entirety, we can use delete:
 
 ```tut:silent
 import org.scanamo._
@@ -62,7 +62,7 @@ import org.scanamo.syntax._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("villains")('name -> S)
+LocalDynamoDB.createTable(client)("villains")("name" -> S)
 
 case class Villain(name: String, catchphrase: String)
 ```
@@ -71,7 +71,7 @@ val villains = Table[Villain]("villains")
 val operations = for {
   _ <- villains.put(Villain("Dalek", "EXTERMINATE!"))
   _ <- villains.put(Villain("Cyberman", "DELETE"))
-  _ <- villains.delete('name -> "Cyberman")
+  _ <- villains.delete("name" -> "Cyberman")
   survivors <- villains.scan()
 } yield survivors
      
@@ -80,7 +80,7 @@ scanamo.exec(operations)
 
 ### Update
 
-If you want to change some of the fields of an item, that don't form part of it's key,
+If you want to change some of the fields of an item, that don't form part of its key,
  without replacing the item entirely, you can use the `update` operation:
 
 ```tut:silent
@@ -90,13 +90,13 @@ import org.scanamo.syntax._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("teams")('name -> S)
+LocalDynamoDB.createTable(client)("teams")("name" -> S)
 case class Team(name: String, goals: Int, scorers: List[String], mascot: Option[String])
 val teamTable = Table[Team]("teams")
 val operations = for {
   _ <- teamTable.put(Team("Watford", 1, List("Blissett"), Some("Harry the Hornet")))
-  updated <- teamTable.update('name -> "Watford", 
-    set('goals -> 2) and append('scorers -> "Barnes") and remove('mascot))
+  updated <- teamTable.update("name" -> "Watford", 
+    set("goals" -> 2) and append("scorers" -> "Barnes") and remove("mascot"))
 } yield updated
 ```
 ```tut:book
@@ -112,7 +112,7 @@ import org.scanamo.ops.ScanamoOps
 import org.scanamo.error.DynamoReadError
 import org.scanamo.update.UpdateExpression
 
-LocalDynamoDB.createTable(client)("favourites")('name -> S)
+LocalDynamoDB.createTable(client)("favourites")("name" -> S)
 case class Favourites(name: String, colour: String, number: Long)
 val favouritesTable = Table[Favourites]("favourites")
 
@@ -121,11 +121,11 @@ scanamo.exec(favouritesTable.put(Favourites("Alice", "Blue", 42L)))
 case class FavouriteUpdate(name: String, colour: Option[String], number: Option[Long])
 def updateFavourite(fu: FavouriteUpdate): Option[ScanamoOps[Either[DynamoReadError, Favourites]]] = {
   val updates: List[UpdateExpression] = List(
-    fu.colour.map(c => set('colour -> c)), 
-    fu.number.map(n => set('number -> n))
+    fu.colour.map(c => set("colour" -> c)), 
+    fu.number.map(n => set("number" -> n))
   ).flatten
   NonEmptyList.fromList(updates).map(ups =>
-    favouritesTable.update('name -> fu.name, ups.reduce[UpdateExpression](_ and _))
+    favouritesTable.update("name" -> fu.name, ups.reduce[UpdateExpression](_ and _))
   )
 }
 ```
@@ -139,7 +139,7 @@ val updates = List(
 scanamo.exec(
   for {
     _ <- updates.flatMap(updateFavourite).sequence
-    result <- favouritesTable.get('name -> "Alice")
+    result <- favouritesTable.get("name" -> "Alice")
   } yield result
 )
 
@@ -160,7 +160,7 @@ import org.scanamo.syntax._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("lines")('mode -> S, 'line -> S)
+LocalDynamoDB.createTable(client)("lines")("mode" -> S, "line" -> S)
 
 case class Transport(mode: String, line: String)
 ```
@@ -190,7 +190,7 @@ import org.scanamo.syntax._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-LocalDynamoDB.createTable(client)("transports")('mode -> S, 'line -> S)
+LocalDynamoDB.createTable(client)("transports")("mode" -> S, "line" -> S)
 
 case class Transport(mode: String, line: String)
 val transportTable = Table[Transport]("transports")
@@ -200,7 +200,7 @@ val operations = for {
     Transport("Underground", "Metropolitan"),
     Transport("Underground", "Central")
   ))
-  tubesStartingWithC <- transportTable.query('mode -> "Underground" and ('line beginsWith "C"))
+  tubesStartingWithC <- transportTable.query("mode" -> "Underground" and ("line" beginsWith "C"))
 } yield tubesStartingWithC.toList
 ```
 ```tut:book

--- a/docs/src/main/tut/using-indexes.md
+++ b/docs/src/main/tut/using-indexes.md
@@ -25,13 +25,13 @@ val scanamo = Scanamo(client)
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 ```
 ```tut:book
-LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")('mode -> S, 'line -> S)('colour -> S) {
+LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")("mode" -> S, "line" -> S)("colour" -> S) {
   val operations = for {
     _ <- transport.putAll(Set(
       Transport("Underground", "Circle", "Yellow"),
       Transport("Underground", "Metropolitan", "Maroon"),
       Transport("Underground", "Central", "Red")))
-    maroonLine <- colourIndex.query('colour -> "Maroon")
+    maroonLine <- colourIndex.query("colour" -> "Maroon")
   } yield maroonLine.toList
   scanamo.exec(operations)
 }

--- a/formats/src/main/scala/org/scanamo/DerivedDynamoFormat.scala
+++ b/formats/src/main/scala/org/scanamo/DerivedDynamoFormat.scala
@@ -10,7 +10,6 @@ import shapeless.labelled._
 trait DerivedDynamoFormat {
   type FieldName = String
   type ValidatedPropertiesError[T] = ValidatedNel[(FieldName, DynamoReadError), T]
-  type NotSymbol[T] = |¬|[Symbol]#λ[T]
 
   trait ConstructedDynamoFormat[T] {
     def read(av: DynamoObject): ValidatedPropertiesError[T]
@@ -91,7 +90,7 @@ trait DerivedDynamoFormat {
       }
     }
 
-  implicit def genericProduct[T: NotSymbol, R](
+  implicit def genericProduct[T, R](
     implicit gen: LabelledGeneric.Aux[T, R],
     formatR: Lazy[ValidConstructedDynamoFormat[R]]
   ): Exported[DynamoFormat[T]] =

--- a/formats/src/test/scala/org/scanamo/DynamoFormatTest.scala
+++ b/formats/src/test/scala/org/scanamo/DynamoFormatTest.scala
@@ -15,7 +15,7 @@ class DynamoFormatTest extends FunSpec with Matchers with ScalaCheckDrivenProper
     val typeLabel = typeTag[A].tpe.toString
     it(s"should write and then read a $typeLabel from dynamo") {
       val client = LocalDynamoDB.client()
-      LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+      LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
         final case class Person(name: String, item: A)
         val format = DynamoFormat[Person]
         forAll(gen) { a: A =>

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -17,7 +17,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   import RTS._
 
   it("should put asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -25,7 +25,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        f <- farmers.get('name -> "McDonald")
+        f <- farmers.get("name" -> "McDonald")
       } yield f
 
       unsafeRun(zio.exec(result)) should equal(
@@ -35,7 +35,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should get asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -43,8 +43,8 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals('name, "Maggot")))
-        r2 <- farmers.get('name -> "Maggot")
+        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
+        r2 <- farmers.get("name" -> "Maggot")
       } yield (r1, r1 == r2)
 
       unsafeRun(zio.exec(result)) should equal(
@@ -52,14 +52,14 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
       val engines = Table[Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get('name -> "Thomas" and 'number -> 1)
+        e <- engines.get("name" -> "Thomas" and "number" -> 1)
       } yield e
 
       unsafeRun(zio.exec(result)) should equal(Some(Right(Engine("Thomas", 1))))
@@ -68,12 +68,12 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val cities = Table[City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
-        c <- cities.consistently.get('name -> "Nashville")
+        c <- cities.consistently.get("name" -> "Nashville")
       } yield c
 
       unsafeRun(zio.exec(result)) should equal(Some(Right(City("Nashville", "US"))))
@@ -81,7 +81,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should delete asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -90,15 +90,15 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       unsafeRun(zio.exec {
         for {
           _ <- farmers.put(Farmer("McGregor", 62L, Farm(List("rabbit"))))
-          _ <- farmers.delete('name -> "McGregor")
-          f <- farmers.get('name -> "McGregor")
+          _ <- farmers.delete("name" -> "McGregor")
+          f <- farmers.get("name" -> "McGregor")
         } yield f
       }) should equal(None)
     }
   }
 
   it("should deleteAll asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -112,7 +112,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
       val ops = for {
         _ <- farmers.putAll(dataSet)
-        _ <- farmers.deleteAll('name -> dataSet.map(_.name))
+        _ <- farmers.deleteAll("name" -> dataSet.map(_.name))
         fs <- farmers.scan
       } yield fs
 
@@ -121,13 +121,13 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should update asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
       val forecasts = Table[Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
-        _ <- forecasts.update('location -> "London", set('weather -> "Sun"))
+        _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
         fs <- forecasts.scan
       } yield fs
 
@@ -136,15 +136,15 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should update asynchronously if a condition holds") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
       val forecasts = Table[Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "London", set('equipment -> Some("umbrella")))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "Birmingham", set('equipment -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -155,7 +155,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should scan asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
       val bears = Table[Bear](t)
@@ -171,7 +171,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
       val lemmings = Table[Lemming](t)
       val ops = for {
@@ -186,7 +186,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("scans with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -200,7 +200,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -215,7 +215,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("Paginate scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -223,8 +223,8 @@ class ScanamoZioSpec extends FunSpec with Matchers {
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from('name -> "Graham" and ('alias -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from('name -> "Yogi" and ('alias -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
         } yield res2 ::: res3
       } yield bs
 
@@ -235,17 +235,17 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should query asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('species -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
       val animals = Table[Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
-        r1 <- animals.query('species -> "Pig")
-        r2 <- animals.query('species -> "Pig" and 'number < 3)
-        r3 <- animals.query('species -> "Pig" and 'number > 1)
-        r4 <- animals.query('species -> "Pig" and 'number <= 2)
-        r5 <- animals.query('species -> "Pig" and 'number >= 2)
+        r1 <- animals.query("species" -> "Pig")
+        r2 <- animals.query("species" -> "Pig" and "number" < 3)
+        r3 <- animals.query("species" -> "Pig" and "number" > 1)
+        r4 <- animals.query("species" -> "Pig" and "number" <= 2)
+        r5 <- animals.query("species" -> "Pig" and "number" >= 2)
       } yield (r1, r2, r3, r4, r5)
 
       unsafeRun(zio.exec(ops)) should equal(
@@ -259,7 +259,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
       val transports = Table[Transport](t)
       val ops = for {
@@ -270,7 +270,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
             Transport("Underground", "Central")
           )
         )
-        ts <- transports.query('mode -> "Underground" and ('line beginsWith "C"))
+        ts <- transports.query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield ts
 
       unsafeRun(zio.exec(ops)) should equal(
@@ -282,7 +282,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("queries with a limit asynchronously") {
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
       val transports = Table[Transport](t)
       val result = for {
         _ <- transports.putAll(
@@ -292,7 +292,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
             Transport("Underground", "Central")
           )
         )
-        rs <- transports.limit(1).query('mode -> "Underground" and ('line beginsWith "C"))
+        rs <- transports.limit(1).query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield rs
 
       unsafeRun(zio.exec(result)) should equal(List(Right(Transport("Underground", "Central"))))
@@ -302,7 +302,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("queries an index with a limit asynchronously") {
     case class Transport(mode: String, line: String, colour: String)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('mode -> S, 'colour -> S) {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
         val transports = Table[Transport](t)
         val result = for {
@@ -319,7 +319,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
             .index(i)
             .limit(1)
             .query(
-              'mode -> "Underground" and ('colour beginsWith "Bl")
+              "mode" -> "Underground" and ("colour" beginsWith "Bl")
             )
         } yield rs
 
@@ -329,12 +329,12 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     }
   }
 
-  it("queries an index asynchronously with 'between' sort-key condition") {
+  it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
     def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(('mode, 'name), stations.map(station => (station.mode, station.name))))
+        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -342,18 +342,18 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'name -> S)('mode -> S, 'zone -> N) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
       val stationTable = Table[Station](t)
       val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
       val ops = for {
         _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (1 and 1)))
+        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
       } yield (ts1, ts2, ts3, ts4, ts5)
 
       unsafeRun(zio.exec(ops)) should equal(
@@ -371,12 +371,12 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("queries for items that are missing an attribute") {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
-    LocalDynamoDB.usingRandomTable(client)('firstName -> S, 'surname -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
-        farmerWithNoAge <- farmersTable.filter(attributeNotExists('age)).query('firstName -> "Fred")
+        farmerWithNoAge <- farmersTable.filter(attributeNotExists("age")).query("firstName" -> "Fred")
       } yield farmerWithNoAge
       unsafeRun(zio.exec(farmerOps)) should equal(
         List(Right(Farmer("Fred", "Perry", None)))
@@ -387,7 +387,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("should put multiple items asynchronously") {
     case class Rabbit(name: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
@@ -399,7 +399,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should get multiple items asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
       val farmers = Table[Farmer](t)
@@ -412,8 +412,8 @@ class ScanamoZioSpec extends FunSpec with Matchers {
             Farmer("Bean", 55L, Farm(List("turkey")))
           )
         )
-        fs1 <- farmers.getAll(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
-        fs2 <- farmers.getAll('name -> Set("Boggis", "Bean"))
+        fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+        fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
       } yield (fs1, fs2))) should equal(
         (
           Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))),
@@ -422,39 +422,39 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
       val doctors = Table[Doctor](t)
 
       unsafeRun(zio.exec(for {
         _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-        ds <- doctors.getAll(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+        ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
       } yield ds)) should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
 
   it("should get multiple items asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmsTable.putAll(farms)
-        fs <- farmsTable.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+        fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
       } yield fs)) should equal(farms.map(Right(_)))
     }
   }
 
   it("should get multiple items consistently asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmsTable.putAll(farms)
-        fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+        fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
       } yield fs)) should equal(farms.map(Right(_)))
     }
   }
@@ -463,7 +463,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -480,7 +480,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -496,14 +496,14 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
-        _ <- farmersTable.given('age -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
-        farmerWithNewStock <- farmersTable.get('name -> "McDonald")
+        _ <- farmersTable.given("age" -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
+        _ <- farmersTable.given("age" -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
+        farmerWithNewStock <- farmersTable.get("name" -> "McDonald")
       } yield farmerWithNewStock
 
       unsafeRun(zio.exec(farmerOps)) should equal(
@@ -512,20 +512,20 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     }
   }
 
-  it("conditionally put asynchronously with 'between' condition") {
+  it("conditionally put asynchronously with `between` condition") {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
         _ <- farmersTable.put(Farmer("Butch", 57, Farm(List("cattle"))))
         _ <- farmersTable.put(Farmer("Wade", 58, Farm(List("chicken", "sheep"))))
-        _ <- farmersTable.given('age between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
-        _ <- farmersTable.given('age between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
-        farmerButch <- farmersTable.get('name -> "Butch")
+        _ <- farmersTable.given("age" between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
+        _ <- farmersTable.given("age" between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
+        farmerButch <- farmersTable.get("name" -> "Butch")
       } yield farmerButch
       unsafeRun(zio.exec(farmerOps)) should equal(
         Some(Right(Farmer("Butch", 57, Farm(List("chicken")))))
@@ -536,13 +536,13 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("conditionally delete asynchronously") {
     case class Gremlin(number: Int, wet: Boolean)
 
-    LocalDynamoDB.usingRandomTable(client)('number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
       val gremlinsTable = Table[Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 1)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 2)
         remainingGremlins <- gremlinsTable.scan()
       } yield remainingGremlins
 

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -144,7 +144,9 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
         _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
-        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
+        _ <- forecasts
+          .given("weather" -> "Rain")
+          .update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -342,29 +344,30 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
-      val stationTable = Table[Station](t)
-      val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
-      val ops = for {
-        _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
-      } yield (ts1, ts2, ts3, ts4, ts5)
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
+      (t, i) =>
+        val stationTable = Table[Station](t)
+        val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
+        val ops = for {
+          _ <- stationTable.putAll(stations)
+          ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(LiverpoolStreet))
+          ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(CamdenTown))
+          ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
+        } yield (ts1, ts2, ts3, ts4, ts5)
 
-      unsafeRun(zio.exec(ops)) should equal(
-        (
-          List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
-          List.empty,
-          List.empty,
-          List.empty,
-          List.empty
+        unsafeRun(zio.exec(ops)) should equal(
+          (
+            List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
+            List.empty,
+            List.empty,
+            List.empty,
+            List.empty
+          )
         )
-      )
     }
   }
 

--- a/scalaz/src/test/scala/org/scanamo/ScanamoScalazSpec.scala
+++ b/scalaz/src/test/scala/org/scanamo/ScanamoScalazSpec.scala
@@ -21,7 +21,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should put asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -29,7 +29,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        f <- farmers.get('name -> "McDonald")
+        f <- farmers.get("name" -> "McDonald")
       } yield f
 
       unsafePerformIO(scanamo.exec(result)) should equal(
@@ -39,7 +39,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should get asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -47,8 +47,8 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals('name, "Maggot")))
-        r2 <- farmers.get('name -> "Maggot")
+        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
+        r2 <- farmers.get("name" -> "Maggot")
       } yield (r1, r1 == r2)
 
       unsafePerformIO(scanamo.exec(result)) should equal(
@@ -56,14 +56,14 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
       val engines = Table[Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get('name -> "Thomas" and 'number -> 1)
+        e <- engines.get("name" -> "Thomas" and "number" -> 1)
       } yield e
 
       unsafePerformIO(scanamo.exec(result)) should equal(Some(Right(Engine("Thomas", 1))))
@@ -72,12 +72,12 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val cities = Table[City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
-        c <- cities.consistently.get('name -> "Nashville")
+        c <- cities.consistently.get("name" -> "Nashville")
       } yield c
 
       unsafePerformIO(scanamo.exec(result)) should equal(Some(Right(City("Nashville", "US"))))
@@ -85,7 +85,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should delete asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -94,15 +94,15 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       unsafePerformIO(scanamo.exec {
         for {
           _ <- farmers.put(Farmer("McGregor", 62L, Farm(List("rabbit"))))
-          _ <- farmers.delete('name -> "McGregor")
-          f <- farmers.get('name -> "McGregor")
+          _ <- farmers.delete("name" -> "McGregor")
+          f <- farmers.get("name" -> "McGregor")
         } yield f
       }) should equal(None)
     }
   }
 
   it("should deleteAll asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -116,7 +116,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
       val ops = for {
         _ <- farmers.putAll(dataSet)
-        _ <- farmers.deleteAll('name -> dataSet.map(_.name))
+        _ <- farmers.deleteAll("name" -> dataSet.map(_.name))
         fs <- farmers.scan
       } yield fs
 
@@ -125,13 +125,13 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should update asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
       val forecasts = Table[Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
-        _ <- forecasts.update('location -> "London", set('weather -> "Sun"))
+        _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
         fs <- forecasts.scan
       } yield fs
 
@@ -140,15 +140,15 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should update asynchronously if a condition holds") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
       val forecasts = Table[Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "London", set('equipment -> Some("umbrella")))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "Birmingham", set('equipment -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -159,7 +159,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should scan asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
       val bears = Table[Bear](t)
@@ -175,7 +175,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
       val lemmings = Table[Lemming](t)
       val ops = for {
@@ -192,7 +192,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("scans with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -206,7 +206,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -223,7 +223,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("Paginate scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -231,8 +231,8 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from('name -> "Graham" and ('alias -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from('name -> "Yogi" and ('alias -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
         } yield res2 ::: res3
       } yield bs
 
@@ -243,17 +243,17 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should query asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('species -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
       val animals = Table[Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
-        r1 <- animals.query('species -> "Pig")
-        r2 <- animals.query('species -> "Pig" and 'number < 3)
-        r3 <- animals.query('species -> "Pig" and 'number > 1)
-        r4 <- animals.query('species -> "Pig" and 'number <= 2)
-        r5 <- animals.query('species -> "Pig" and 'number >= 2)
+        r1 <- animals.query("species" -> "Pig")
+        r2 <- animals.query("species" -> "Pig" and "number" < 3)
+        r3 <- animals.query("species" -> "Pig" and "number" > 1)
+        r4 <- animals.query("species" -> "Pig" and "number" <= 2)
+        r5 <- animals.query("species" -> "Pig" and "number" >= 2)
       } yield (r1, r2, r3, r4, r5)
 
       unsafePerformIO(scanamo.exec(ops)) should equal(
@@ -267,7 +267,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
       val transports = Table[Transport](t)
       val ops = for {
@@ -278,7 +278,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
             Transport("Underground", "Central")
           )
         )
-        ts <- transports.query('mode -> "Underground" and ('line beginsWith "C"))
+        ts <- transports.query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield ts
 
       unsafePerformIO(scanamo.exec(ops)) should equal(
@@ -290,7 +290,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("queries with a limit asynchronously") {
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
       val transports = Table[Transport](t)
       val result = for {
         _ <- transports.putAll(
@@ -300,7 +300,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
             Transport("Underground", "Central")
           )
         )
-        rs <- transports.limit(1).query('mode -> "Underground" and ('line beginsWith "C"))
+        rs <- transports.limit(1).query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield rs
 
       unsafePerformIO(scanamo.exec(result)) should equal(List(Right(Transport("Underground", "Central"))))
@@ -310,7 +310,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("queries an index with a limit asynchronously") {
     case class Transport(mode: String, line: String, colour: String)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('mode -> S, 'colour -> S) {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
         val transports = Table[Transport](t)
         val result = for {
@@ -327,7 +327,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
             .index(i)
             .limit(1)
             .query(
-              'mode -> "Underground" and ('colour beginsWith "Bl")
+              "mode" -> "Underground" and ("colour" beginsWith "Bl")
             )
         } yield rs
 
@@ -337,12 +337,12 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     }
   }
 
-  it("queries an index asynchronously with 'between' sort-key condition") {
+  it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
     def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(('mode, 'name), stations.map(station => (station.mode, station.name))))
+        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -350,18 +350,18 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'name -> S)('mode -> S, 'zone -> N) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
       val stationTable = Table[Station](t)
       val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
       val ops = for {
         _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (1 and 1)))
+        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
       } yield (ts1, ts2, ts3, ts4, ts5)
 
       unsafePerformIO(scanamo.exec(ops)) should equal(
@@ -379,12 +379,12 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("queries for items that are missing an attribute") {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
-    LocalDynamoDB.usingRandomTable(client)('firstName -> S, 'surname -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
-        farmerWithNoAge <- farmersTable.filter(attributeNotExists('age)).query('firstName -> "Fred")
+        farmerWithNoAge <- farmersTable.filter(attributeNotExists("age")).query("firstName" -> "Fred")
       } yield farmerWithNoAge
       unsafePerformIO(scanamo.exec(farmerOps)) should equal(
         List(Right(Farmer("Fred", "Perry", None)))
@@ -395,7 +395,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("should put multiple items asynchronously") {
     case class Rabbit(name: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(scala.util.Random.nextString(500))).toSet)
@@ -407,7 +407,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   }
 
   it("should get multiple items asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
       val farmers = Table[Farmer](t)
@@ -420,8 +420,8 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
             Farmer("Bean", 55L, Farm(List("turkey")))
           )
         )
-        fs1 <- farmers.getAll(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
-        fs2 <- farmers.getAll('name -> Set("Boggis", "Bean"))
+        fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+        fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
       } yield (fs1, fs2))) should equal(
         (
           Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))),
@@ -430,39 +430,39 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
       val doctors = Table[Doctor](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-        ds <- doctors.getAll(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+        ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
       } yield ds)) should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
 
   it("should get multiple items asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- farmsTable.putAll(farms)
-        fs <- farmsTable.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+        fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
       } yield fs)) should equal(farms.map(Right(_)))
     }
   }
 
   it("should get multiple items consistently asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- farmsTable.putAll(farms)
-        fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+        fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
       } yield fs)) should equal(farms.map(Right(_)))
     }
   }
@@ -471,7 +471,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -488,7 +488,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -504,14 +504,14 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
-        _ <- farmersTable.given('age -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
-        farmerWithNewStock <- farmersTable.get('name -> "McDonald")
+        _ <- farmersTable.given("age" -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
+        _ <- farmersTable.given("age" -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
+        farmerWithNewStock <- farmersTable.get("name" -> "McDonald")
       } yield farmerWithNewStock
 
       unsafePerformIO(scanamo.exec(farmerOps)) should equal(
@@ -520,20 +520,20 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     }
   }
 
-  it("conditionally put asynchronously with 'between' condition") {
+  it("conditionally put asynchronously with `between` condition") {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
         _ <- farmersTable.put(Farmer("Butch", 57, Farm(List("cattle"))))
         _ <- farmersTable.put(Farmer("Wade", 58, Farm(List("chicken", "sheep"))))
-        _ <- farmersTable.given('age between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
-        _ <- farmersTable.given('age between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
-        farmerButch <- farmersTable.get('name -> "Butch")
+        _ <- farmersTable.given("age" between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
+        _ <- farmersTable.given("age" between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
+        farmerButch <- farmersTable.get("name" -> "Butch")
       } yield farmerButch
       unsafePerformIO(scanamo.exec(farmerOps)) should equal(
         Some(Right(Farmer("Butch", 57, Farm(List("chicken")))))
@@ -544,13 +544,13 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("conditionally delete asynchronously") {
     case class Gremlin(number: Int, wet: Boolean)
 
-    LocalDynamoDB.usingRandomTable(client)('number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
       val gremlinsTable = Table[Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 1)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 2)
         remainingGremlins <- gremlinsTable.scan()
       } yield remainingGremlins
 

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -26,14 +26,14 @@ class Scanamo private (client: AmazonDynamoDB) {
     * >>> val scanamo = Scanamo(client)
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
+    * >>> LocalDynamoDB.withTable(client)("transport")("mode" -> S, "line" -> S) {
     * ...   import org.scanamo.syntax._
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle"),
     * ...       Transport("Underground", "Metropolitan"),
     * ...       Transport("Underground", "Central")))
-    * ...     results <- transport.query('mode -> "Underground" and ('line beginsWith "C"))
+    * ...     results <- transport.query("mode" -> "Underground" and ("line" beginsWith "C"))
     * ...   } yield results.toList
     * ...   scanamo.exec(operations)
     * ... }

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -28,7 +28,7 @@ sealed abstract class SecondaryIndex[V] {
     *
     * >>> import org.scanamo.auto._
     *
-    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('antagonist -> S) { (t, i) =>
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("antagonist" -> S) { (t, i) =>
     * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey", None))
@@ -56,7 +56,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.auto._
     *
-    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('organisation -> S, 'repository -> S)('language -> S, 'license -> S) { (t, i) =>
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("organisation" -> S, "repository" -> S)("language" -> S, "license" -> S) { (t, i) =>
     * ...   val githubProjects = Table[GithubProject](t)
     * ...   val operations = for {
     * ...     _ <- githubProjects.putAll(Set(
@@ -65,7 +65,7 @@ sealed abstract class SecondaryIndex[V] {
     * ...       GithubProject("tpolecat", "tut", "Scala", "MIT"),
     * ...       GithubProject("guardian", "scanamo", "Scala", "Apache 2")
     * ...     ))
-    * ...     scalaMIT <- githubProjects.index(i).query('language -> "Scala" and ('license -> "MIT"))
+    * ...     scalaMIT <- githubProjects.index(i).query("language" -> "Scala" and ("license" -> "MIT"))
     * ...   } yield scalaMIT.toList
     * ...   scanamo.exec(operations)
     * ... }
@@ -87,7 +87,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
-    * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
+    * ...   "mode" -> S, "line" -> S)("mode" -> S, "colour" -> S
     * ... ) { (t, i) =>
     * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
@@ -98,7 +98,7 @@ sealed abstract class SecondaryIndex[V] {
     * ...       Transport("Underground", "Picadilly", "Blue"),
     * ...       Transport("Underground", "Northern", "Black")))
     * ...     somethingBeginningWithBl <- transport.index(i).limit(1).descending.query(
-    * ...       ('mode -> "Underground" and ('colour beginsWith "Bl"))
+    * ...       ("mode" -> "Underground" and ("colour" beginsWith "Bl"))
     * ...     )
     * ...   } yield somethingBeginningWithBl.toList
     * ...   scanamo.exec(operations)
@@ -122,7 +122,7 @@ sealed abstract class SecondaryIndex[V] {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
-    * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
+    * ...   "mode" -> S, "line" -> S)("mode" -> S, "colour" -> S
     * ... ) { (t, i) =>
     * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
@@ -133,8 +133,8 @@ sealed abstract class SecondaryIndex[V] {
     * ...       Transport("Underground", "Picadilly", "Blue"),
     * ...       Transport("Underground", "Northern", "Black")))
     * ...     somethingBeginningWithC <- transport.index(i)
-    * ...                                   .filter('line beginsWith ("C"))
-    * ...                                   .query('mode -> "Underground")
+    * ...                                   .filter("line" beginsWith ("C"))
+    * ...                                   .query("mode" -> "Underground")
     * ...   } yield somethingBeginningWithC.toList
     * ...   scanamo.exec(operations)
     * ... }

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -18,7 +18,7 @@ import org.scanamo.update.UpdateExpression
   * >>> val scanamo = Scanamo(client)
   * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
   *
-  * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+  * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
   * ...   import org.scanamo.syntax._
   * ...   import org.scanamo.auto._
   * ...   val transport = Table[Transport](t)
@@ -27,7 +27,7 @@ import org.scanamo.update.UpdateExpression
   * ...       Transport("Underground", "Circle"),
   * ...       Transport("Underground", "Metropolitan"),
   * ...       Transport("Underground", "Central")))
-  * ...     results <- transport.query('mode -> "Underground" and ('line beginsWith "C"))
+  * ...     results <- transport.query("mode" -> "Underground" and ("line" beginsWith "C"))
   * ...   } yield results.toList
   * ...   scanamo.exec(operations)
   * ... }
@@ -61,11 +61,11 @@ case class Table[V: DynamoFormat](name: String) {
     * ...   Farmer("Patty", 200L, Farm(List("unicorn"))),
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   val farm = Table[Farmer](t)
     * ...   val operations = for {
     * ...     _       <- farm.putAll(dataSet)
-    * ...     _       <- farm.deleteAll('name -> dataSet.map(_.name))
+    * ...     _       <- farm.deleteAll("name" -> dataSet.map(_.name))
     * ...     scanned <- farm.scan
     * ...   } yield scanned.toList
     * ...   scanamo.exec(operations)
@@ -87,14 +87,14 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.auto._
     *
-    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('colour -> S) { (t, i) =>
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("colour" -> S) { (t, i) =>
     * ...   val transport = Table[Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
     * ...       Transport("Underground", "Metropolitan", "Magenta"),
     * ...       Transport("Underground", "Central", "Red")))
-    * ...     MagentaLine <- transport.index(i).query('colour -> "Magenta")
+    * ...     MagentaLine <- transport.index(i).query("colour" -> "Magenta")
     * ...   } yield MagentaLine.toList
     * ...   scanamo.exec(operations)
     * ... }
@@ -106,7 +106,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import org.scanamo.auto._
     *
-    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('organisation -> S, 'repository -> S)('language -> S, 'license -> S) { (t, i) =>
+    * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("organisation" -> S, "repository" -> S)("language" -> S, "license" -> S) { (t, i) =>
     * ...   val githubProjects = Table[GithubProject](t)
     * ...   val operations = for {
     * ...     _ <- githubProjects.putAll(Set(
@@ -115,7 +115,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       GithubProject("tpolecat", "tut", "Scala", "MIT"),
     * ...       GithubProject("guardian", "scanamo", "Scala", "Apache 2")
     * ...     ))
-    * ...     scalaMIT <- githubProjects.index(i).query('language -> "Scala" and ('license -> "MIT"))
+    * ...     scalaMIT <- githubProjects.index(i).query("language" -> "Scala" and ("license" -> "MIT"))
     * ...   } yield scalaMIT.toList
     * ...   scanamo.exec(operations)
     * ... }
@@ -137,13 +137,13 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val scanamo = Scanamo(client)
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('location -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("location" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val forecast = Table[Forecast](t)
     * ...   val operations = for {
     * ...     _ <- forecast.put(Forecast("London", "Rain"))
-    * ...     updated <- forecast.update('location -> "London", set('weather -> "Sun"))
+    * ...     updated <- forecast.update("location" -> "London", set("weather" -> "Sun"))
     * ...   } yield updated
     * ...   scanamo.exec(operations)
     * ... }
@@ -155,14 +155,14 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Character(name: String, actors: List[String])
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val characters = Table[Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.put(Character("The Doctor", List("Ecclestone", "Tennant", "Smith")))
-    * ...     _ <- characters.update('name -> "The Doctor", append('actors -> "Capaldi"))
-    * ...     _ <- characters.update('name -> "The Doctor", prepend('actors -> "McCoy"))
+    * ...     _ <- characters.update("name" -> "The Doctor", append("actors" -> "Capaldi"))
+    * ...     _ <- characters.update("name" -> "The Doctor", prepend("actors" -> "McCoy"))
     * ...     results <- characters.scan()
     * ...   } yield results.toList
     * ...   scanamo.exec(operations)
@@ -173,13 +173,13 @@ case class Table[V: DynamoFormat](name: String) {
     * Appending or prepending creates the list if it does not yet exist:
     *
     * {{{
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val characters = Table[Character](t)
     * ...   val operations = for {
-    * ...     _ <- characters.update('name -> "James Bond", append('actors -> "Craig"))
-    * ...     results <- characters.query('name -> "James Bond")
+    * ...     _ <- characters.update("name" -> "James Bond", append("actors" -> "Craig"))
+    * ...     results <- characters.query("name" -> "James Bond")
     * ...   } yield results.toList
     * ...   scanamo.exec(operations)
     * ... }
@@ -191,15 +191,15 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Fruit(kind: String, sources: List[String])
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('kind -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("kind" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val fruits = Table[Fruit](t)
     * ...   val operations = for {
     * ...     _ <- fruits.put(Fruit("watermelon", List("USA")))
-    * ...     _ <- fruits.update('kind -> "watermelon", appendAll('sources -> List("China", "Turkey")))
-    * ...     _ <- fruits.update('kind -> "watermelon", prependAll('sources -> List("Brazil")))
-    * ...     results <- fruits.query('kind -> "watermelon")
+    * ...     _ <- fruits.update("kind" -> "watermelon", appendAll("sources" -> List("China", "Turkey")))
+    * ...     _ <- fruits.update("kind" -> "watermelon", prependAll("sources" -> List("Brazil")))
+    * ...     results <- fruits.query("kind" -> "watermelon")
     * ...   } yield results.toList
     * ...   scanamo.exec(operations)
     * ... }
@@ -210,33 +210,33 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Foo(name: String, bar: Int, l: List[String])
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val foos = Table[Foo](t)
     * ...   val operations = for {
     * ...     _ <- foos.put(Foo("x", 0, List("First")))
-    * ...     updated <- foos.update('name -> "x",
-    * ...       append('l -> "Second") and set('bar -> 1))
+    * ...     updated <- foos.update("name" -> "x",
+    * ...       append("l" -> "Second") and set("bar" -> 1))
     * ...   } yield updated
     * ...   scanamo.exec(operations)
     * ... }
     * Right(Foo(x,1,List(First, Second)))
     * }}}
     *
-    * It's also possible to perform `ADD` and `DELETE` updates
+    * It"s" also possible to perform `ADD` and `DELETE` updates
     * {{{
     * >>> case class Bar(name: String, counter: Long, set: Set[String])
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val bars = Table[Bar](t)
     * ...   val operations = for {
     * ...     _ <- bars.put(Bar("x", 1L, Set("First")))
-    * ...     _ <- bars.update('name -> "x",
-    * ...       add('counter -> 10L) and add('set -> Set("Second")))
-    * ...     updatedBar <- bars.update('name -> "x", delete('set -> Set("First")))
+    * ...     _ <- bars.update("name" -> "x",
+    * ...       add("counter" -> 10L) and add("set" -> Set("Second")))
+    * ...     updatedBar <- bars.update("name" -> "x", delete("set" -> Set("First")))
     * ...   } yield updatedBar
     * ...   scanamo.exec(operations)
     * ... }
@@ -249,15 +249,15 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class Middle(name: String, counter: Long, inner: Inner, list: List[Int])
     * >>> case class Outer(id: java.util.UUID, middle: Middle)
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('id -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("id" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val outers = Table[Outer](t)
     * ...   val id = java.util.UUID.fromString("a8345373-9a93-43be-9bcd-e3682c9197f4")
     * ...   val operations = for {
     * ...     _ <- outers.put(Outer(id, Middle("x", 1L, Inner("alpha"), List(1, 2))))
-    * ...     updatedOuter <- outers.update('id -> id,
-    * ...       set('middle \ 'inner \ 'session -> "beta") and add(('middle \ 'list)(1) ->  1)
+    * ...     updatedOuter <- outers.update("id" -> id,
+    * ...       set("middle" \ "inner" \ "session" -> "beta") and add(("middle" \ "list")(1) ->  1)
     * ...     )
     * ...   } yield updatedOuter
     * ...   scanamo.exec(operations)
@@ -265,17 +265,17 @@ case class Table[V: DynamoFormat](name: String) {
     * Right(Outer(a8345373-9a93-43be-9bcd-e3682c9197f4,Middle(x,1,Inner(beta),List(1, 3))))
     * }}}
     *
-    * It's possible to update one field to the value of another
+    * It"s" possible to update one field to the value of another
     * {{{
     * >>> case class Thing(id: String, mandatory: Int, optional: Option[Int])
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('id -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("id" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val things = Table[Thing](t)
     * ...   val operations = for {
     * ...     _ <- things.put(Thing("a1", 3, None))
-    * ...     updated <- things.update('id -> "a1", set('optional -> 'mandatory))
+    * ...     updated <- things.update("id" -> "a1", set("optional" -> "mandatory"))
     * ...   } yield updated
     * ...   scanamo.exec(operations)
     * ... }
@@ -294,7 +294,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val scanamo = Scanamo(client)
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val transport = Table[Transport](t)
@@ -303,7 +303,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       Transport("Underground", "Circle"),
     * ...       Transport("Underground", "Metropolitan"),
     * ...       Transport("Underground", "Central")))
-    * ...     results <- transport.limit(1).query('mode -> "Underground" and ('line beginsWith "C"))
+    * ...     results <- transport.limit(1).query("mode" -> "Underground" and ("line" beginsWith "C"))
     * ...   } yield results.toList
     * ...   scanamo.exec(operations)
     * ... }
@@ -324,16 +324,16 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)('country -> S, 'name -> S) { t =>
+    * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)("country" -> S, "name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   val cityTable = Table[City](t)
     * ...   val ops = for {
     * ...     _ <- cityTable.putAll(Set(
     * ...       City("US", "Nashville"), City("IT", "Rome"), City("IT", "Siena"), City("TZ", "Dar es Salaam")))
-    * ...     get <- cityTable.consistently.get('country -> "US" and 'name -> "Nashville")
+    * ...     get <- cityTable.consistently.get("country" -> "US" and "name" -> "Nashville")
     * ...     scan <- cityTable.consistently.scan()
-    * ...     query <- cityTable.consistently.query('country -> "IT")
+    * ...     query <- cityTable.consistently.query("country" -> "IT")
     * ...   } yield (get, scan, query)
     * ...   scanamo.exec(ops)
     * ... }
@@ -363,25 +363,25 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   val farmersTable = Table[Farmer](t)
     * ...   val farmerOps = for {
     * ...     _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
-    * ...     _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"), 30)))
-    * ...     _ <- farmersTable.given('age -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"), 30)))
-    * ...     farmerWithNewStock <- farmersTable.get('name -> "McDonald")
+    * ...     _ <- farmersTable.given("age" -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"), 30)))
+    * ...     _ <- farmersTable.given("age" -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"), 30)))
+    * ...     farmerWithNewStock <- farmersTable.get("name" -> "McDonald")
     * ...   } yield farmerWithNewStock
     * ...   scanamo.exec(farmerOps)
     * ... }
     * Some(Right(Farmer(McDonald,156,Farm(List(sheep, chicken),30))))
     *
     * >>> case class Letter(roman: String, greek: String)
-    * >>> LocalDynamoDB.withRandomTable(client)('roman -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("roman" -> S) { t =>
     * ...   val lettersTable = Table[Letter](t)
     * ...   val ops = for {
     * ...     _ <- lettersTable.putAll(Set(Letter("a", "alpha"), Letter("b", "beta"), Letter("c", "gammon")))
-    * ...     _ <- lettersTable.given('greek beginsWith "ale").put(Letter("a", "aleph"))
-    * ...     _ <- lettersTable.given('greek beginsWith "gam").put(Letter("c", "gamma"))
+    * ...     _ <- lettersTable.given("greek" beginsWith "ale").put(Letter("a", "aleph"))
+    * ...     _ <- lettersTable.given("greek" beginsWith "gam").put(Letter("c", "gamma"))
     * ...     letters <- lettersTable.scan()
     * ...   } yield letters
     * ...   scanamo.exec(ops).toList
@@ -390,13 +390,13 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import cats.implicits._
     * >>> case class Turnip(size: Int, description: Option[String])
-    * >>> LocalDynamoDB.withRandomTable(client)('size -> N) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("size" -> N) { t =>
     * ...   val turnipsTable = Table[Turnip](t)
     * ...   val ops = for {
     * ...     _ <- turnipsTable.putAll(Set(Turnip(1, None), Turnip(1000, None)))
     * ...     initialTurnips <- turnipsTable.scan()
     * ...     _ <- initialTurnips.flatMap(_.toOption).traverse(t =>
-    * ...       turnipsTable.given('size > 500).put(t.copy(description = Some("Big turnip in the country."))))
+    * ...       turnipsTable.given("size" > 500).put(t.copy(description = Some("Big turnip in the country."))))
     * ...     turnips <- turnipsTable.scan()
     * ...   } yield turnips
     * ...   scanamo.exec(ops).toList
@@ -408,14 +408,14 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Thing(a: String, maybe: Option[Int])
-    * >>> LocalDynamoDB.withRandomTable(client)('a -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("a" -> S) { t =>
     * ...   val thingTable = Table[Thing](t)
     * ...   val ops = for {
     * ...     _ <- thingTable.putAll(Set(Thing("a", None), Thing("b", Some(1)), Thing("c", None)))
-    * ...     _ <- thingTable.given(attributeExists('maybe)).put(Thing("a", Some(2)))
-    * ...     _ <- thingTable.given(attributeExists('maybe)).put(Thing("b", Some(3)))
-    * ...     _ <- thingTable.given(Not(attributeExists('maybe))).put(Thing("c", Some(42)))
-    * ...     _ <- thingTable.given(Not(attributeExists('maybe))).put(Thing("b", Some(42)))
+    * ...     _ <- thingTable.given(attributeExists("maybe")).put(Thing("a", Some(2)))
+    * ...     _ <- thingTable.given(attributeExists("maybe")).put(Thing("b", Some(3)))
+    * ...     _ <- thingTable.given(Not(attributeExists("maybe"))).put(Thing("c", Some(42)))
+    * ...     _ <- thingTable.given(Not(attributeExists("maybe"))).put(Thing("b", Some(42)))
     * ...     things <- thingTable.scan()
     * ...   } yield things
     * ...   scanamo.exec(ops).toList
@@ -427,13 +427,13 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Compound(a: String, maybe: Option[Int])
-    * >>> LocalDynamoDB.withRandomTable(client)('a -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("a" -> S) { t =>
     * ...   val compoundTable = Table[Compound](t)
     * ...   val ops = for {
     * ...     _ <- compoundTable.putAll(Set(Compound("alpha", None), Compound("beta", Some(1)), Compound("gamma", None)))
-    * ...     _ <- compoundTable.given(attributeExists('maybe) and 'a -> "alpha").put(Compound("alpha", Some(2)))
-    * ...     _ <- compoundTable.given(attributeExists('maybe) and 'a -> "beta").put(Compound("beta", Some(3)))
-    * ...     _ <- compoundTable.given(Condition('a -> "gamma") and attributeExists('maybe)).put(Compound("gamma", Some(42)))
+    * ...     _ <- compoundTable.given(attributeExists("maybe") and "a" -> "alpha").put(Compound("alpha", Some(2)))
+    * ...     _ <- compoundTable.given(attributeExists("maybe") and "a" -> "beta").put(Compound("beta", Some(3)))
+    * ...     _ <- compoundTable.given(Condition("a" -> "gamma") and attributeExists("maybe")).put(Compound("gamma", Some(42)))
     * ...     compounds <- compoundTable.scan()
     * ...   } yield compounds
     * ...   scanamo.exec(ops).toList
@@ -445,12 +445,12 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Choice(number: Int, description: String)
-    * >>> LocalDynamoDB.withRandomTable(client)('number -> N) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("number" -> N) { t =>
     * ...   val choicesTable = Table[Choice](t)
     * ...   val ops = for {
     * ...     _ <- choicesTable.putAll(Set(Choice(1, "cake"), Choice(2, "crumble"), Choice(3, "custard")))
-    * ...     _ <- choicesTable.given(Condition('description -> "cake") or Condition('description -> "death")).put(Choice(1, "victoria sponge"))
-    * ...     _ <- choicesTable.given(Condition('description -> "cake") or Condition('description -> "death")).put(Choice(2, "victoria sponge"))
+    * ...     _ <- choicesTable.given(Condition("description" -> "cake") or Condition("description" -> "death")).put(Choice(1, "victoria sponge"))
+    * ...     _ <- choicesTable.given(Condition("description" -> "cake") or Condition("description" -> "death")).put(Choice(2, "victoria sponge"))
     * ...     choices <- choicesTable.scan()
     * ...   } yield choices
     * ...   scanamo.exec(ops).toList
@@ -462,12 +462,12 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> case class Gremlin(number: Int, wet: Boolean, friendly: Boolean)
-    * >>> LocalDynamoDB.withRandomTable(client)('number -> N) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("number" -> N) { t =>
     * ...   val gremlinsTable = Table[Gremlin](t)
     * ...   val ops = for {
     * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, false)))
-    * ...     _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
-    * ...     _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
+    * ...     _ <- gremlinsTable.given("wet" -> true).delete("number" -> 1)
+    * ...     _ <- gremlinsTable.given("wet" -> true).delete("number" -> 2)
     * ...     remainingGremlins <- gremlinsTable.scan()
     * ...   } yield remainingGremlins
     * ...   scanamo.exec(ops).toList
@@ -478,12 +478,12 @@ case class Table[V: DynamoFormat](name: String) {
     * and updates
     *
     * {{{
-    * >>> LocalDynamoDB.withRandomTable(client)('number -> N) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("number" -> N) { t =>
     * ...   val gremlinsTable = Table[Gremlin](t)
     * ...   val ops = for {
     * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, true)))
-    * ...     _ <- gremlinsTable.given('wet -> true).update('number -> 1, set('friendly -> false))
-    * ...     _ <- gremlinsTable.given('wet -> true).update('number -> 2, set('friendly -> false))
+    * ...     _ <- gremlinsTable.given("wet" -> true).update("number" -> 1, set("friendly" -> false))
+    * ...     _ <- gremlinsTable.given("wet" -> true).update("number" -> 2, set("friendly" -> false))
     * ...     remainingGremlins <- gremlinsTable.scan()
     * ...   } yield remainingGremlins
     * ...   scanamo.exec(ops).toList
@@ -494,14 +494,14 @@ case class Table[V: DynamoFormat](name: String) {
     * Conditions can also be placed on nested attributes
     *
     * {{{
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   val smallscaleFarmersTable = Table[Farmer](t)
     * ...   val farmerOps = for {
     * ...     _ <- smallscaleFarmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
-    * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares < 40L).put(Farmer("McDonald", 156L, Farm(List("gerbil", "hamster"), 20)))
-    * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares > 40L).put(Farmer("McDonald", 156L, Farm(List("elephant"), 50)))
-    * ...     _ <- smallscaleFarmersTable.given('farm \ 'hectares -> 20L).update('name -> "McDonald", append('farm \ 'animals -> "squirrel"))
-    * ...     farmerWithNewStock <- smallscaleFarmersTable.get('name -> "McDonald")
+    * ...     _ <- smallscaleFarmersTable.given("farm" \ "hectares" < 40L).put(Farmer("McDonald", 156L, Farm(List("gerbil", "hamster"), 20)))
+    * ...     _ <- smallscaleFarmersTable.given("farm" \ "hectares" > 40L).put(Farmer("McDonald", 156L, Farm(List("elephant"), 50)))
+    * ...     _ <- smallscaleFarmersTable.given("farm" \ "hectares" -> 20L).update("name" -> "McDonald", append("farm" \ "animals" -> "squirrel"))
+    * ...     farmerWithNewStock <- smallscaleFarmersTable.get("name" -> "McDonald")
     * ...   } yield farmerWithNewStock
     * ...   scanamo.exec(farmerOps)
     * ... }
@@ -522,13 +522,13 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> case class Bear(name: String, favouriteFood: String)
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey"))
     * ...     _ <- table.put(Bear("Baloo", "ants"))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets"))
-    * ...     bears <- table.from('name -> "Baloo").scan()
+    * ...     bears <- table.from("name" -> "Baloo").scan()
     * ...   } yield bears
     * ...   scanamo.exec(ops)
     * ... }
@@ -540,7 +540,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Event(`type`: String, tag: String, count: Int)
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('type -> S, 'tag -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("type" -> S, "tag" -> S) { t =>
     * ...   val table = Table[Event](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
@@ -552,7 +552,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...            Event("click", "print", 300),
     * ...            Event("play", "paid", 900)
     * ...          ))
-    * ...     events <- table.from('type -> "play" and 'tag -> "politics").query('type -> "play" and ('tag beginsWith "p"))
+    * ...     events <- table.from("type" -> "play" and "tag" -> "politics").query("type" -> "play" and ("tag" beginsWith "p"))
     * ...   } yield events
     * ...   scanamo.exec(ops)
     * ... }
@@ -572,7 +572,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val scanamo = Scanamo(client)
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.auto._
     * ...   val table = Table[Bear](t)
     * ...   val ops = for {
@@ -608,7 +608,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.query._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   val table = Table[Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
@@ -618,7 +618,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...     ))
     * ...     res <- table.limit(1).scan0
     * ...     uniqueKeyCondition = UniqueKeyCondition[AndEqualsCondition[KeyEquals[String], KeyEquals[String]]]
-    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(('mode, 'line), DynamoObject(res.getLastEvaluatedKey))
+    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.getLastEvaluatedKey))
     * ...     ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(table.from(_).scan())
     * ...   } yield ts
     * ...   scanamo.exec(ops)
@@ -641,7 +641,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.auto._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   val table = Table[Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
@@ -649,7 +649,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       Transport("Underground", "Metropolitan"),
     * ...       Transport("Underground", "Central")
     * ...     ))
-    * ...     linesBeginningWithC <- table.query('mode -> "Underground" and ('line beginsWith "C"))
+    * ...     linesBeginningWithC <- table.query("mode" -> "Underground" and ("line" beginsWith "C"))
     * ...   } yield linesBeginningWithC
     * ...   scanamo.exec(ops)
     * ... }
@@ -679,7 +679,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.query._
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   val table = Table[Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
@@ -690,9 +690,9 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       Transport("Bus", "143"),
     * ...       Transport("Bus", "234")
     * ...     ))
-    * ...     res <- table.limit(1).query0('mode -> "Bus" and 'line -> "234")
+    * ...     res <- table.limit(1).query0("mode" -> "Bus" and "line" -> "234")
     * ...     uniqueKeyCondition = UniqueKeyCondition[AndEqualsCondition[KeyEquals[String], KeyEquals[String]]]
-    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(('mode, 'line), DynamoObject(res.getLastEvaluatedKey))
+    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.getLastEvaluatedKey))
     * ...     ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(table.from(_).scan())
     * ...   } yield ts
     * ...   scanamo.exec(ops)
@@ -715,13 +715,13 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.auto._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   val table = Table[Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey", None))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets", Some("Ranger Smith")))
-    * ...     honeyBears <- table.filter('favouriteFood -> "honey").scan()
-    * ...     competitiveBears <- table.filter(attributeExists('antagonist)).scan()
+    * ...     honeyBears <- table.filter("favouriteFood" -> "honey").scan()
+    * ...     competitiveBears <- table.filter(attributeExists("antagonist")).scan()
     * ...   } yield (honeyBears, competitiveBears)
     * ...   scanamo.exec(ops)
     * ... }
@@ -732,7 +732,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
-    * >>> LocalDynamoDB.withRandomTable(client)('line -> S, 'name -> S) { t =>
+    * >>> LocalDynamoDB.withRandomTable(client)("line" -> S, "name" -> S) { t =>
     * ...   val stationTable = Table[Station](t)
     * ...   val ops = for {
     * ...     _ <- stationTable.putAll(Set(
@@ -742,7 +742,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...       Station("Metropolitan", "Croxley", 7),
     * ...       Station("Jubilee", "Canons Park", 5)
     * ...     ))
-    * ...     filteredStations <- stationTable.filter('zone -> Set(8, 7)).query('line -> "Metropolitan" and ('name beginsWith "C"))
+    * ...     filteredStations <- stationTable.filter("zone" -> Set(8, 7)).query("line" -> "Metropolitan" and ("name" beginsWith "C"))
     * ...   } yield filteredStations
     * ...   scanamo.exec(ops)
     * ... }

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -275,7 +275,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...   val things = Table[Thing](t)
     * ...   val operations = for {
     * ...     _ <- things.put(Thing("a1", 3, None))
-    * ...     updated <- things.update("id" -> "a1", set("optional" -> "mandatory"))
+    * ...     updated <- things.update("id" -> "a1", set("optional", "mandatory"))
     * ...   } yield updated
     * ...   scanamo.exec(operations)
     * ... }
@@ -431,8 +431,8 @@ case class Table[V: DynamoFormat](name: String) {
     * ...   val compoundTable = Table[Compound](t)
     * ...   val ops = for {
     * ...     _ <- compoundTable.putAll(Set(Compound("alpha", None), Compound("beta", Some(1)), Compound("gamma", None)))
-    * ...     _ <- compoundTable.given(attributeExists("maybe") and "a" -> "alpha").put(Compound("alpha", Some(2)))
-    * ...     _ <- compoundTable.given(attributeExists("maybe") and "a" -> "beta").put(Compound("beta", Some(3)))
+    * ...     _ <- compoundTable.given(Condition(attributeExists("maybe")) and "a" -> "alpha").put(Compound("alpha", Some(2)))
+    * ...     _ <- compoundTable.given(Condition(attributeExists("maybe")) and "a" -> "beta").put(Compound("beta", Some(3)))
     * ...     _ <- compoundTable.given(Condition("a" -> "gamma") and attributeExists("maybe")).put(Compound("gamma", Some(42)))
     * ...     compounds <- compoundTable.scan()
     * ...   } yield compounds

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -54,7 +54,8 @@ package object scanamo {
     def set(to: String, from: String): UpdateExpression = UpdateExpression.setFromAttribute(from, to)
     def set[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.set(fieldValue)
     def append[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.append(fieldValue)
-    def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.prepend(fieldValue)
+    def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
+      UpdateExpression.prepend(fieldValue)
     def appendAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
       UpdateExpression.appendAll(fieldValue)
     def prependAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -6,27 +6,27 @@ import org.scanamo.update._
 package object scanamo {
 
   object syntax {
-    implicit class SymbolKeyCondition(s: Symbol) {
-      def and(other: Symbol) = HashAndRangeKeyNames(s, other)
+    implicit class StringKeyCondition(s: String) {
+      def and(other: String) = HashAndRangeKeyNames(s, other)
     }
 
-    case class HashAndRangeKeyNames(hash: Symbol, range: Symbol)
+    case class HashAndRangeKeyNames(hash: String, range: String)
 
-    implicit def symbolTupleToUniqueKey[V: DynamoFormat](pair: (Symbol, V)) =
+    implicit def stringTupleToUniqueKey[V: DynamoFormat](pair: (String, V)) =
       UniqueKey(KeyEquals(pair._1, pair._2))
 
-    implicit def symbolTupleToKeyCondition[V: DynamoFormat](pair: (Symbol, V)) =
+    implicit def stringTupleToKeyCondition[V: DynamoFormat](pair: (String, V)) =
       KeyEquals(pair._1, pair._2)
 
     implicit def toUniqueKey[T: UniqueKeyCondition](t: T) = UniqueKey(t)
 
-    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, Set[V])) =
+    implicit def stringListTupleToUniqueKeys[V: DynamoFormat](pair: (String, Set[V])) =
       UniqueKeys(KeyList(pair._1, pair._2))
 
     implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, Set[(H, R)])) =
       UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2))
 
-    implicit def symbolTupleToQuery[V: DynamoFormat](pair: (Symbol, V)) =
+    implicit def stringTupleToQuery[V: DynamoFormat](pair: (String, V)) =
       Query(KeyEquals(pair._1, pair._2))
 
     implicit def toQuery[T: QueryableKeyCondition](t: T) = Query(t)
@@ -37,9 +37,9 @@ package object scanamo {
       def and(upperBound: V) = Bounds(Bound(v), Bound(upperBound))
     }
 
-    def attributeExists(symbol: Symbol) = AttributeExists(AttributeName.of(symbol))
+    def attributeExists(string: String) = AttributeExists(AttributeName.of(string))
 
-    def attributeNotExists(symbol: Symbol) = AttributeNotExists(AttributeName.of(symbol))
+    def attributeNotExists(string: String) = AttributeNotExists(AttributeName.of(string))
 
     def not[T: ConditionExpression](t: T) = Not(t)
 
@@ -70,9 +70,9 @@ package object scanamo {
     def remove(field: AttributeName): UpdateExpression =
       UpdateExpression.remove(field)
 
-    implicit def symbolAttributeName(s: Symbol): AttributeName = AttributeName.of(s)
-    implicit def symbolAttributeNameValue[T](sv: (Symbol, T)): (AttributeName, T) = AttributeName.of(sv._1) -> sv._2
-    implicit def symbolTupleAttributeNameTuple(ss: (Symbol, Symbol)): (AttributeName, AttributeName) =
+    implicit def stringAttributeName(s: String): AttributeName = AttributeName.of(s)
+    implicit def stringAttributeNameValue[T](sv: (String, T)): (AttributeName, T) = AttributeName.of(sv._1) -> sv._2
+    implicit def stringTupleAttributeNameTuple(ss: (String, String)): (AttributeName, AttributeName) =
       AttributeName.of(ss._1) -> AttributeName.of(ss._2)
 
     implicit class AndUpdateExpression(x: UpdateExpression) {

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -6,28 +6,28 @@ import org.scanamo.update._
 package object scanamo {
 
   object syntax {
-    implicit class StringKeyCondition(s: String) {
-      def and(other: String) = HashAndRangeKeyNames(s, other)
+    implicit class AttributeNameKeyCondition(s: String) {
+      def and(other: String) = HashAndRangeKeyNames(AttributeName.of(s), AttributeName.of(other))
     }
 
-    case class HashAndRangeKeyNames(hash: String, range: String)
+    case class HashAndRangeKeyNames(hash: AttributeName, range: AttributeName)
 
     implicit def stringTupleToUniqueKey[V: DynamoFormat](pair: (String, V)) =
-      UniqueKey(KeyEquals(pair._1, pair._2))
+      UniqueKey(KeyEquals(AttributeName.of(pair._1), pair._2))
 
     implicit def stringTupleToKeyCondition[V: DynamoFormat](pair: (String, V)) =
-      KeyEquals(pair._1, pair._2)
+      KeyEquals(AttributeName.of(pair._1), pair._2)
 
     implicit def toUniqueKey[T: UniqueKeyCondition](t: T) = UniqueKey(t)
 
     implicit def stringListTupleToUniqueKeys[V: DynamoFormat](pair: (String, Set[V])) =
-      UniqueKeys(KeyList(pair._1, pair._2))
+      UniqueKeys(KeyList(AttributeName.of(pair._1), pair._2))
 
     implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, Set[(H, R)])) =
       UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2))
 
     implicit def stringTupleToQuery[V: DynamoFormat](pair: (String, V)) =
-      Query(KeyEquals(pair._1, pair._2))
+      Query(KeyEquals(AttributeName.of(pair._1), pair._2))
 
     implicit def toQuery[T: QueryableKeyCondition](t: T) = Query(t)
 
@@ -51,29 +51,20 @@ package object scanamo {
       def or[Y: ConditionExpression](y: Y) = OrCondition(x, y)
     }
 
-    def set(fields: (AttributeName, AttributeName)): UpdateExpression =
-      UpdateExpression.setFromAttribute(fields)
-    def set[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
-      UpdateExpression.set(fieldValue)
-    def append[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
-      UpdateExpression.append(fieldValue)
-    def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
-      UpdateExpression.prepend(fieldValue)
+    def set(to: String, from: String): UpdateExpression = UpdateExpression.setFromAttribute(from, to)
+    def set[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.set(fieldValue)
+    def append[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.append(fieldValue)
+    def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.prepend(fieldValue)
     def appendAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
       UpdateExpression.appendAll(fieldValue)
     def prependAll[V: DynamoFormat](fieldValue: (AttributeName, List[V])): UpdateExpression =
       UpdateExpression.prependAll(fieldValue)
-    def add[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
-      UpdateExpression.add(fieldValue)
-    def delete[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
-      UpdateExpression.delete(fieldValue)
-    def remove(field: AttributeName): UpdateExpression =
-      UpdateExpression.remove(field)
+    def add[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.add(fieldValue)
+    def delete[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression = UpdateExpression.delete(fieldValue)
+    def remove(field: AttributeName): UpdateExpression = UpdateExpression.remove(field)
 
     implicit def stringAttributeName(s: String): AttributeName = AttributeName.of(s)
     implicit def stringAttributeNameValue[T](sv: (String, T)): (AttributeName, T) = AttributeName.of(sv._1) -> sv._2
-    implicit def stringTupleAttributeNameTuple(ss: (String, String)): (AttributeName, AttributeName) =
-      AttributeName.of(ss._1) -> AttributeName.of(ss._2)
 
     implicit class AndUpdateExpression(x: UpdateExpression) {
       def and(y: UpdateExpression): UpdateExpression = AndUpdate(x, y)

--- a/scanamo/src/main/scala/org/scanamo/query/AttributeName.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/AttributeName.scala
@@ -3,18 +3,18 @@ package org.scanamo.query
 import org.scanamo.DynamoFormat
 import org.scanamo.syntax.Bounds
 
-case class AttributeName(components: List[Symbol], index: Option[Int]) {
+case class AttributeName(components: List[String], index: Option[Int]) {
   def placeholder(prefix: String): String =
     index.foldLeft(
-      components.map(s => s"$prefix${s.name}").mkString(".#")
+      components.map(s => s"$prefix$s").mkString(".#")
     )(
       (p, i) => s"$p[$i]"
     )
 
   def attributeNames(prefix: String): Map[String, String] =
-    Map(components.map(s => s"$prefix${s.name}" -> s.name): _*)
+    Map(components.map(s => s"$prefix$s" -> s): _*)
 
-  def \(component: Symbol) = copy(components = components :+ component)
+  def \(component: String) = copy(components = components :+ component)
 
   def apply(index: Int): AttributeName = copy(index = Some(index))
 
@@ -27,5 +27,5 @@ case class AttributeName(components: List[Symbol], index: Option[Int]) {
 }
 
 object AttributeName {
-  def of(s: Symbol): AttributeName = AttributeName(List(s), None)
+  def of(s: String): AttributeName = AttributeName(List(s), None)
 }

--- a/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
@@ -209,8 +209,8 @@ case class AndCondition[L: ConditionExpression, R: ConditionExpression](l: L, r:
 
 case class OrCondition[L: ConditionExpression, R: ConditionExpression](l: L, r: R)
 
-case class Condition[T: ConditionExpression](t: T) {
-  def apply = implicitly[ConditionExpression[T]].apply(t)
+case class Condition[T](t: T)(implicit T: ConditionExpression[T]) {
+  def apply = T.apply(t)
   def and[Y: ConditionExpression](other: Y) = AndCondition(t, other)
   def or[Y: ConditionExpression](other: Y) = OrCondition(t, other)
 }

--- a/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
@@ -49,8 +49,8 @@ case class ConditionalOperation[V, T](tableName: String, t: T)(
 }
 
 object ConditionExpression {
-  implicit def symbolValueEqualsCondition[V: DynamoFormat] = new ConditionExpression[(Symbol, V)] {
-    override def apply(pair: (Symbol, V)): RequestCondition =
+  implicit def stringValueEqualsCondition[V: DynamoFormat] = new ConditionExpression[(String, V)] {
+    override def apply(pair: (String, V)): RequestCondition =
       attributeValueEqualsCondition.apply((AttributeName.of(pair._1), pair._2))
   }
 
@@ -66,8 +66,8 @@ object ConditionExpression {
     }
   }
 
-  implicit def symbolValueInCondition[V: DynamoFormat] = new ConditionExpression[(Symbol, Set[V])] {
-    override def apply(pair: (Symbol, Set[V])): RequestCondition =
+  implicit def stringValueInCondition[V: DynamoFormat] = new ConditionExpression[(String, Set[V])] {
+    override def apply(pair: (String, Set[V])): RequestCondition =
       attributeValueInCondition.apply((AttributeName.of(pair._1), pair._2))
   }
 

--- a/scanamo/src/main/scala/org/scanamo/query/DynamoKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/DynamoKeyCondition.scala
@@ -3,7 +3,7 @@ package org.scanamo.query
 import org.scanamo.DynamoFormat
 import org.scanamo.syntax.Bounds
 
-case class KeyEquals[V: DynamoFormat](key: String, v: V) {
+case class KeyEquals[V: DynamoFormat](key: AttributeName, v: V) {
   def and[R: DynamoFormat](equalsKeyCondition: KeyEquals[R]) =
     AndEqualsCondition(this, equalsKeyCondition)
   def and[R: DynamoFormat](rangeKeyCondition: RangeKeyCondition[R]) =

--- a/scanamo/src/main/scala/org/scanamo/query/DynamoKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/DynamoKeyCondition.scala
@@ -3,7 +3,7 @@ package org.scanamo.query
 import org.scanamo.DynamoFormat
 import org.scanamo.syntax.Bounds
 
-case class KeyEquals[V: DynamoFormat](key: Symbol, v: V) {
+case class KeyEquals[V: DynamoFormat](key: String, v: V) {
   def and[R: DynamoFormat](equalsKeyCondition: KeyEquals[R]) =
     AndEqualsCondition(this, equalsKeyCondition)
   def and[R: DynamoFormat](rangeKeyCondition: RangeKeyCondition[R]) =

--- a/scanamo/src/main/scala/org/scanamo/query/QueryableKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/QueryableKeyCondition.scala
@@ -12,9 +12,9 @@ object QueryableKeyCondition {
   implicit def equalsKeyCondition[V: DynamoFormat] = new QueryableKeyCondition[KeyEquals[V]] {
     final def apply(t: KeyEquals[V]) =
       RequestCondition(
-        s"#K = :${t.key.name}",
-        Map("#K" -> t.key.name),
-        Some(DynamoObject(t.key.name -> t.v))
+        s"#K = :${t.key}",
+        Map("#K" -> t.key),
+        Some(DynamoObject(t.key -> t.v))
       )
   }
 
@@ -22,10 +22,10 @@ object QueryableKeyCondition {
     new QueryableKeyCondition[AndQueryCondition[H, R]] {
       final def apply(t: AndQueryCondition[H, R]) =
         RequestCondition(
-          s"#K = :${t.hashCondition.key.name} AND ${t.rangeCondition.keyConditionExpression("R")}",
-          Map("#K" -> t.hashCondition.key.name) ++ t.rangeCondition.key.attributeNames("#R"),
+          s"#K = :${t.hashCondition.key} AND ${t.rangeCondition.keyConditionExpression("R")}",
+          Map("#K" -> t.hashCondition.key) ++ t.rangeCondition.key.attributeNames("#R"),
           Some(
-            DynamoObject(t.hashCondition.key.name -> t.hashCondition.v) <> DynamoObject(
+            DynamoObject(t.hashCondition.key -> t.hashCondition.v) <> DynamoObject(
               t.rangeCondition.attributes.toSeq: _*
             )
           )

--- a/scanamo/src/main/scala/org/scanamo/query/QueryableKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/QueryableKeyCondition.scala
@@ -12,9 +12,9 @@ object QueryableKeyCondition {
   implicit def equalsKeyCondition[V: DynamoFormat] = new QueryableKeyCondition[KeyEquals[V]] {
     final def apply(t: KeyEquals[V]) =
       RequestCondition(
-        s"#K = :${t.key}",
-        Map("#K" -> t.key),
-        Some(DynamoObject(t.key -> t.v))
+        s"#K = :${t.key.placeholder("")}",
+        Map("#K" -> t.key.placeholder("")),
+        Some(DynamoObject(t.key.placeholder("") -> t.v))
       )
   }
 
@@ -22,10 +22,10 @@ object QueryableKeyCondition {
     new QueryableKeyCondition[AndQueryCondition[H, R]] {
       final def apply(t: AndQueryCondition[H, R]) =
         RequestCondition(
-          s"#K = :${t.hashCondition.key} AND ${t.rangeCondition.keyConditionExpression("R")}",
-          Map("#K" -> t.hashCondition.key) ++ t.rangeCondition.key.attributeNames("#R"),
+          s"#K = :${t.hashCondition.key.placeholder("")} AND ${t.rangeCondition.keyConditionExpression("R")}",
+          Map("#K" -> t.hashCondition.key.placeholder("")) ++ t.rangeCondition.key.attributeNames("#R"),
           Some(
-            DynamoObject(t.hashCondition.key -> t.hashCondition.v) <> DynamoObject(
+            DynamoObject(t.hashCondition.key.placeholder("") -> t.hashCondition.v) <> DynamoObject(
               t.rangeCondition.attributes.toSeq: _*
             )
           )

--- a/scanamo/src/main/scala/org/scanamo/query/UniqueKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/UniqueKeyCondition.scala
@@ -17,7 +17,8 @@ object UniqueKeyCondition {
     type K = AttributeName
     final def toDynamoObject(t: KeyEquals[V]) = DynamoObject(t.key.placeholder("") -> t.v)
     final def fromDynamoObject(key: K, dvs: DynamoObject) =
-      dvs(key.placeholder("")).flatMap(V.read(_).fold(_ => None, v => Some(KeyEquals(AttributeName.of(key.placeholder("")), v))))
+      dvs(key.placeholder(""))
+        .flatMap(V.read(_).fold(_ => None, v => Some(KeyEquals(AttributeName.of(key.placeholder("")), v))))
     final def key(t: KeyEquals[V]) = t.key
   }
 

--- a/scanamo/src/main/scala/org/scanamo/query/UniqueKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/UniqueKeyCondition.scala
@@ -14,10 +14,10 @@ import simulacrum.typeclass
 
 object UniqueKeyCondition {
   implicit def uniqueEqualsKey[V](implicit V: DynamoFormat[V]) = new UniqueKeyCondition[KeyEquals[V]] {
-    type K = String
-    final def toDynamoObject(t: KeyEquals[V]) = DynamoObject(t.key -> t.v)
+    type K = AttributeName
+    final def toDynamoObject(t: KeyEquals[V]) = DynamoObject(t.key.placeholder("") -> t.v)
     final def fromDynamoObject(key: K, dvs: DynamoObject) =
-      dvs(key).flatMap(V.read(_).fold(_ => None, v => Some(KeyEquals(key, v))))
+      dvs(key.placeholder("")).flatMap(V.read(_).fold(_ => None, v => Some(KeyEquals(AttributeName.of(key.placeholder("")), v))))
     final def key(t: KeyEquals[V]) = t.key
   }
 
@@ -48,7 +48,7 @@ case class UniqueKey[T](t: T)(implicit T: UniqueKeyCondition[T]) {
 object UniqueKeyConditions {
   implicit def keyList[V: DynamoFormat] = new UniqueKeyConditions[KeyList[V]] {
     final def toDynamoObject(kl: KeyList[V]) =
-      kl.values.map(v => DynamoObject(kl.key -> v))
+      kl.values.map(v => DynamoObject(kl.key.placeholder("") -> v))
   }
 
   implicit def multipleKeyList[H: DynamoFormat, R: DynamoFormat] =
@@ -57,7 +57,7 @@ object UniqueKeyConditions {
         val (hashKey, rangeKey) = mkl.keys
         mkl.values.map {
           case (h, r) =>
-            DynamoObject(hashKey -> h) <> DynamoObject(rangeKey -> r)
+            DynamoObject(hashKey.placeholder("") -> h) <> DynamoObject(rangeKey.placeholder("") -> r)
         }
       }
     }
@@ -67,5 +67,5 @@ case class UniqueKeys[T](t: T)(implicit K: UniqueKeyConditions[T]) {
   def toDynamoObject: Set[DynamoObject] = K.toDynamoObject(t)
 }
 
-case class KeyList[T: DynamoFormat](key: String, values: Set[T])
-case class MultipleKeyList[H: DynamoFormat, R: DynamoFormat](keys: (String, String), values: Set[(H, R)])
+case class KeyList[T: DynamoFormat](key: AttributeName, values: Set[T])
+case class MultipleKeyList[H: DynamoFormat, R: DynamoFormat](keys: (AttributeName, AttributeName), values: Set[(H, R)])

--- a/scanamo/src/main/scala/org/scanamo/update/UpdateExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/update/UpdateExpression.scala
@@ -66,10 +66,8 @@ object UpdateExpression {
 
   def set[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
     SetExpression(fieldValue._1, fieldValue._2)
-  def setFromAttribute(fields: (AttributeName, AttributeName)): UpdateExpression = {
-    val (to, from) = fields
+  def setFromAttribute(from: AttributeName, to: AttributeName): UpdateExpression =
     SetExpression.fromAttribute(from, to)
-  }
   def append[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
     AppendExpression(fieldValue._1, fieldValue._2)
   def prepend[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
@@ -82,8 +80,7 @@ object UpdateExpression {
     AddExpression(fieldValue._1, fieldValue._2)
   def delete[V: DynamoFormat](fieldValue: (AttributeName, V)): UpdateExpression =
     DeleteExpression(fieldValue._1, fieldValue._2)
-  def remove(field: AttributeName): UpdateExpression =
-    RemoveExpression(field)
+  def remove(field: AttributeName): UpdateExpression = RemoveExpression(field)
 }
 
 sealed private[update] trait UpdateType { val op: String }
@@ -213,7 +210,7 @@ object SetExpression {
 
 object AppendExpression {
   private val prefix = "updateAppend"
-  def apply[V](field: AttributeName, value: V)(implicit format: DynamoFormat[V]): UpdateExpression =
+  def apply[V: DynamoFormat](field: AttributeName, value: V): UpdateExpression =
     SimpleUpdate(
       LeafAppendExpression(
         field.placeholder(prefix),
@@ -226,7 +223,7 @@ object AppendExpression {
 
 object PrependExpression {
   private val prefix = "updatePrepend"
-  def apply[V](field: AttributeName, value: V)(implicit format: DynamoFormat[V]): UpdateExpression =
+  def apply[V: DynamoFormat](field: AttributeName, value: V): UpdateExpression =
     SimpleUpdate(
       LeafPrependExpression(
         field.placeholder(prefix),
@@ -239,7 +236,7 @@ object PrependExpression {
 
 object AppendAllExpression {
   private val prefix = "updateAppendAll"
-  def apply[V](field: AttributeName, value: List[V])(implicit format: DynamoFormat[V]): UpdateExpression =
+  def apply[V: DynamoFormat](field: AttributeName, value: List[V]): UpdateExpression =
     SimpleUpdate(
       LeafAppendExpression(
         field.placeholder(prefix),
@@ -252,7 +249,7 @@ object AppendAllExpression {
 
 object PrependAllExpression {
   private val prefix = "updatePrependAll"
-  def apply[V](field: AttributeName, value: List[V])(implicit format: DynamoFormat[V]): UpdateExpression =
+  def apply[V: DynamoFormat](field: AttributeName, value: List[V]): UpdateExpression =
     SimpleUpdate(
       LeafPrependExpression(
         field.placeholder(prefix),

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -23,7 +23,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should put asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -31,7 +31,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        f <- farmers.get('name -> "McDonald")
+        f <- farmers.get("name" -> "McDonald")
       } yield f
 
       scanamo.exec(result).futureValue should equal(
@@ -41,7 +41,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should get asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -49,8 +49,8 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals('name, "Maggot")))
-        r2 <- farmers.get('name -> "Maggot")
+        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
+        r2 <- farmers.get("name" -> "Maggot")
       } yield (r1, r1 == r2)
 
       scanamo.exec(result).futureValue should equal(
@@ -58,14 +58,14 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
       val engines = Table[Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get('name -> "Thomas" and 'number -> 1)
+        e <- engines.get("name" -> "Thomas" and "number" -> 1)
       } yield e
 
       scanamo.exec(result).futureValue should equal(Some(Right(Engine("Thomas", 1))))
@@ -74,12 +74,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val cities = Table[City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
-        c <- cities.consistently.get('name -> "Nashville")
+        c <- cities.consistently.get("name" -> "Nashville")
       } yield c
 
       scanamo.exec(result).futureValue should equal(Some(Right(City("Nashville", "US"))))
@@ -87,7 +87,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should delete asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -96,15 +96,15 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       scanamo.exec {
         for {
           _ <- farmers.put(Farmer("McGregor", 62L, Farm(List("rabbit"))))
-          _ <- farmers.delete('name -> "McGregor")
-          f <- farmers.get('name -> "McGregor")
+          _ <- farmers.delete("name" -> "McGregor")
+          f <- farmers.get("name" -> "McGregor")
         } yield f
       }.futureValue should equal(None)
     }
   }
 
   it("should deleteAll asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -118,7 +118,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
       val ops = for {
         _ <- farmers.putAll(dataSet)
-        _ <- farmers.deleteAll('name -> dataSet.map(_.name))
+        _ <- farmers.deleteAll("name" -> dataSet.map(_.name))
         fs <- farmers.scan
       } yield fs
 
@@ -127,13 +127,13 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should update asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
       val forecasts = Table[Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
-        _ <- forecasts.update('location -> "London", set('weather -> "Sun"))
+        _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
         fs <- forecasts.scan
       } yield fs
 
@@ -142,15 +142,15 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should update asynchronously if a condition holds") {
-    LocalDynamoDB.usingRandomTable(client)('location -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
       val forecasts = Table[Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "London", set('equipment -> Some("umbrella")))
-        _ <- forecasts.given('weather -> "Rain").update('location -> "Birmingham", set('equipment -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
+        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -161,7 +161,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should scan asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
       val bears = Table[Bear](t)
@@ -177,7 +177,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
       val lemmings = Table[Lemming](t)
       val ops = for {
@@ -192,7 +192,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("scans with a limit asynchronously") {
     case class Bear(name: String, favouriteFood: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -206,7 +206,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -223,7 +223,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("Paginate scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('name -> S)('alias -> S) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
       val bears = Table[Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
@@ -231,8 +231,8 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from('name -> "Graham" and ('alias -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from('name -> "Yogi" and ('alias -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
         } yield res2 ::: res3
       } yield bs
 
@@ -243,17 +243,17 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should query asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('species -> S, 'number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
       val animals = Table[Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
-        r1 <- animals.query('species -> "Pig")
-        r2 <- animals.query('species -> "Pig" and 'number < 3)
-        r3 <- animals.query('species -> "Pig" and 'number > 1)
-        r4 <- animals.query('species -> "Pig" and 'number <= 2)
-        r5 <- animals.query('species -> "Pig" and 'number >= 2)
+        r1 <- animals.query("species" -> "Pig")
+        r2 <- animals.query("species" -> "Pig" and "number" < 3)
+        r3 <- animals.query("species" -> "Pig" and "number" > 1)
+        r4 <- animals.query("species" -> "Pig" and "number" <= 2)
+        r5 <- animals.query("species" -> "Pig" and "number" >= 2)
       } yield (r1, r2, r3, r4, r5)
 
       scanamo.exec(ops).futureValue should equal(
@@ -267,7 +267,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
       val transports = Table[Transport](t)
       val ops = for {
@@ -278,7 +278,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
             Transport("Underground", "Central")
           )
         )
-        ts <- transports.query('mode -> "Underground" and ('line beginsWith "C"))
+        ts <- transports.query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield ts
 
       scanamo.exec(ops).futureValue should equal(
@@ -290,7 +290,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("queries with a limit asynchronously") {
     case class Transport(mode: String, line: String)
 
-    LocalDynamoDB.withRandomTable(client)('mode -> S, 'line -> S) { t =>
+    LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
       val transports = Table[Transport](t)
       val result = for {
         _ <- transports.putAll(
@@ -300,7 +300,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
             Transport("Underground", "Central")
           )
         )
-        rs <- transports.limit(1).query('mode -> "Underground" and ('line beginsWith "C"))
+        rs <- transports.limit(1).query("mode" -> "Underground" and ("line" beginsWith "C"))
       } yield rs
 
       scanamo.exec(result).futureValue should equal(List(Right(Transport("Underground", "Central"))))
@@ -310,7 +310,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("queries an index with a limit asynchronously") {
     case class Transport(mode: String, line: String, colour: String)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'line -> S)('mode -> S, 'colour -> S) {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
         val transports = Table[Transport](t)
         val result = for {
@@ -327,7 +327,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
             .index(i)
             .limit(1)
             .query(
-              'mode -> "Underground" and ('colour beginsWith "Bl")
+              "mode" -> "Underground" and ("colour" beginsWith "Bl")
             )
         } yield rs
 
@@ -337,12 +337,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     }
   }
 
-  it("queries an index asynchronously with 'between' sort-key condition") {
+  it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
     def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(('mode, 'name), stations.map(station => (station.mode, station.name))))
+        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -350,18 +350,18 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)('mode -> S, 'name -> S)('mode -> S, 'zone -> N) { (t, i) =>
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
       val stationTable = Table[Station](t)
       val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
       val ops = for {
         _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (2 and 4)))
+        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
         ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
         _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query('mode -> "Underground" and ('zone between (1 and 1)))
+        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
       } yield (ts1, ts2, ts3, ts4, ts5)
 
       scanamo.exec(ops).futureValue should equal(
@@ -379,12 +379,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("queries for items that are missing an attribute") {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
-    LocalDynamoDB.usingRandomTable(client)('firstName -> S, 'surname -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
-        farmerWithNoAge <- farmersTable.filter(attributeNotExists('age)).query('firstName -> "Fred")
+        farmerWithNoAge <- farmersTable.filter(attributeNotExists("age")).query("firstName" -> "Fred")
       } yield farmerWithNoAge
       scanamo.exec(farmerOps).futureValue should equal(
         List(Right(Farmer("Fred", "Perry", None)))
@@ -395,7 +395,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("should put multiple items asynchronously") {
     case class Rabbit(name: String)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
@@ -407,7 +407,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should get multiple items asynchronously") {
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
       val farmers = Table[Farmer](t)
@@ -421,8 +421,8 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
               Farmer("Bean", 55L, Farm(List("turkey")))
             )
           )
-          fs1 <- farmers.getAll(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
-          fs2 <- farmers.getAll('name -> Set("Boggis", "Bean"))
+          fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+          fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
         } yield (fs1, fs2))
         .futureValue should equal(
         (
@@ -432,21 +432,21 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       )
     }
 
-    LocalDynamoDB.usingRandomTable(client)('actor -> S, 'regeneration -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
       val doctors = Table[Doctor](t)
 
       scanamo
         .exec(for {
           _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-          ds <- doctors.getAll(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+          ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
         } yield ds)
         .futureValue should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
 
   it("should get multiple items asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
@@ -454,14 +454,14 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       scanamo
         .exec(for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+          fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
         } yield fs)
         .futureValue should equal(farms.map(Right(_)))
     }
   }
 
   it("should get multiple items consistently asynchronously (automatically handling batching)") {
-    LocalDynamoDB.usingRandomTable(client)('id -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
       val farmsTable = Table[Farm](t)
@@ -469,7 +469,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       scanamo
         .exec(for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList('id, farms.map(_.id))))
+          fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
         } yield fs)
         .futureValue should equal(farms.map(Right(_)))
     }
@@ -479,7 +479,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -496,7 +496,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -512,14 +512,14 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
-        _ <- farmersTable.given('age -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
-        _ <- farmersTable.given('age -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
-        farmerWithNewStock <- farmersTable.get('name -> "McDonald")
+        _ <- farmersTable.given("age" -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"))))
+        _ <- farmersTable.given("age" -> 15L).put(Farmer("McDonald", 156L, Farm(List("gnu", "chicken"))))
+        farmerWithNewStock <- farmersTable.get("name" -> "McDonald")
       } yield farmerWithNewStock
 
       scanamo.exec(farmerOps).futureValue should equal(
@@ -528,20 +528,20 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     }
   }
 
-  it("conditionally put asynchronously with 'between' condition") {
+  it("conditionally put asynchronously with `between` condition") {
     case class Farm(animals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val farmersTable = Table[Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
         _ <- farmersTable.put(Farmer("Butch", 57, Farm(List("cattle"))))
         _ <- farmersTable.put(Farmer("Wade", 58, Farm(List("chicken", "sheep"))))
-        _ <- farmersTable.given('age between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
-        _ <- farmersTable.given('age between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
-        farmerButch <- farmersTable.get('name -> "Butch")
+        _ <- farmersTable.given("age" between (56 and 57)).put(Farmer("Butch", 57, Farm(List("chicken"))))
+        _ <- farmersTable.given("age" between (58 and 59)).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
+        farmerButch <- farmersTable.get("name" -> "Butch")
       } yield farmerButch
       scanamo.exec(farmerOps).futureValue should equal(
         Some(Right(Farmer("Butch", 57, Farm(List("chicken")))))
@@ -552,13 +552,13 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("conditionally delete asynchronously") {
     case class Gremlin(number: Int, wet: Boolean)
 
-    LocalDynamoDB.usingRandomTable(client)('number -> N) { t =>
+    LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
       val gremlinsTable = Table[Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
-        _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 1)
+        _ <- gremlinsTable.given("wet" -> true).delete("number" -> 2)
         remainingGremlins <- gremlinsTable.scan()
       } yield remainingGremlins
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -150,7 +150,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
         _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
-        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
+        _ <- forecasts
+          .given("weather" -> "Rain")
+          .update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -350,29 +352,30 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
-      val stationTable = Table[Station](t)
-      val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
-      val ops = for {
-        _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
-      } yield (ts1, ts2, ts3, ts4, ts5)
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
+      (t, i) =>
+        val stationTable = Table[Station](t)
+        val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
+        val ops = for {
+          _ <- stationTable.putAll(stations)
+          ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(LiverpoolStreet))
+          ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(CamdenTown))
+          ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
+        } yield (ts1, ts2, ts3, ts4, ts5)
 
-      scanamo.exec(ops).futureValue should equal(
-        (
-          List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
-          List.empty,
-          List.empty,
-          List.empty,
-          List.empty
+        scanamo.exec(ops).futureValue should equal(
+          (
+            List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
+            List.empty,
+            List.empty,
+            List.empty,
+            List.empty
+          )
         )
-      )
     }
   }
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -141,7 +141,9 @@ class ScanamoTest extends FunSpec with Matchers {
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
         _ <- forecasts.given("weather" -> "Rain").update("location" -> "London", set("equipment" -> Some("umbrella")))
-        _ <- forecasts.given("weather" -> "Rain").update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
+        _ <- forecasts
+          .given("weather" -> "Rain")
+          .update("location" -> "Birmingham", set("equipment" -> Some("umbrella")))
         results <- forecasts.scan()
       } yield results
 
@@ -339,29 +341,30 @@ class ScanamoTest extends FunSpec with Matchers {
     val GoldersGreen = Station("Underground", "Golders Green", 3)
     val Hainault = Station("Underground", "Hainault", 4)
 
-    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) { (t, i) =>
-      val stationTable = Table[Station](t)
-      val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
-      val ops = for {
-        _ <- stationTable.putAll(stations)
-        ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(LiverpoolStreet))
-        ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
-        ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
-        _ <- stationTable.putAll(Set(CamdenTown))
-        ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
-      } yield (ts1, ts2, ts3, ts4, ts5)
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
+      (t, i) =>
+        val stationTable = Table[Station](t)
+        val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
+        val ops = for {
+          _ <- stationTable.putAll(stations)
+          ts1 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(LiverpoolStreet))
+          ts3 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (2 and 4)))
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          _ <- stationTable.putAll(Set(CamdenTown))
+          ts5 <- stationTable.index(i).query("mode" -> "Underground" and ("zone" between (1 and 1)))
+        } yield (ts1, ts2, ts3, ts4, ts5)
 
-      scanamo.exec(ops) should equal(
-        (
-          List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
-          List.empty,
-          List.empty,
-          List.empty,
-          List.empty
+        scanamo.exec(ops) should equal(
+          (
+            List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
+            List.empty,
+            List.empty,
+            List.empty,
+            List.empty
+          )
         )
-      )
     }
   }
 

--- a/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
@@ -7,11 +7,11 @@ import org.scanamo.DynamoFormat
 
 class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matchers with org.scalatest.prop.Checkers {
 
-  implicit lazy val arbSymbol: Arbitrary[Symbol] = Arbitrary(Gen.alphaNumStr.map(Symbol(_)))
+  implicit lazy val arbString: Arbitrary[String] = Arbitrary(Gen.alphaNumStr)
 
   def leaf: Gen[UpdateExpression] =
     for {
-      s <- arbitrary[Symbol]
+      s <- arbString
       i <- arbitrary[Int]
       si <- arbitrary[Set[Int]]
       l <- arbitrary[List[String]]
@@ -61,14 +61,14 @@ class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matc
   }
 
   it("append/prepend should wrap scalar values in a list") {
-    check { (s: Symbol, v: String) =>
+    check { (s: String, v: String) =>
       append(s -> v).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(List(v)))
       prepend(s -> v).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(List(v)))
     }
   }
 
   it("appendAll/prependAll should take the value as a list") {
-    check { (s: Symbol, l: List[String]) =>
+    check { (s: String, l: List[String]) =>
       appendAll(s -> l).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(l))
       prependAll(s -> l).unprefixedAttributeValues.get("update").exists(stringList.read(_) == Right(l))
     }

--- a/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
@@ -11,7 +11,7 @@ class UpdateExpressionTest extends org.scalatest.FunSpec with org.scalatest.Matc
 
   def leaf: Gen[UpdateExpression] =
     for {
-      s <- arbString
+      s <- arbitrary[String]
       i <- arbitrary[Int]
       si <- arbitrary[Set[Int]]
       l <- arbitrary[List[String]]


### PR DESCRIPTION
Close #390 

Symbols don't get a fancy syntactic treatment in Scala 2.13, as that notation doesn't generally play ball in IDEs. It was the only reason to use symbols in the first place, but even in real life when attribute names are not static, they're awkward to work with.

Note that 2.13 supports singleton types, in a future version of the API we may want to leverage that somehow.