### PR TITLE
Allow streaming in constant space

### DIFF
--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -5,7 +5,7 @@ import akka.NotUsed
 import akka.stream.alpakka.dynamodb.DynamoClient
 import akka.stream.scaladsl.{ Sink, Source }
 import org.scanamo.ops.AlpakkaInterpreter.Alpakka
-import org.scanamo.ops.{ AlpakkaInterpreter, ScanamoOps }
+import org.scanamo.ops.{ AlpakkaInterpreter, ScanamoOps, ScanamoOpsT }
 import org.scanamo.ops.retrypolicy.RetryPolicy
 
 import scala.concurrent.Future

--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -1,9 +1,9 @@
 package org.scanamo
 
+import cats.{ ~>, Monad }
 import akka.NotUsed
 import akka.stream.alpakka.dynamodb.DynamoClient
 import akka.stream.scaladsl.{ Sink, Source }
-import cats.Monad
 import org.scanamo.ops.AlpakkaInterpreter.Alpakka
 import org.scanamo.ops.{ AlpakkaInterpreter, ScanamoOps }
 import org.scanamo.ops.retrypolicy.RetryPolicy
@@ -24,6 +24,9 @@ class ScanamoAlpakka private (client: DynamoClient, retryPolicy: RetryPolicy) {
 
   def exec[A](op: ScanamoOps[A]): Alpakka[A] =
     run(op)
+
+  final def execT[M[_]: Monad, A](hoist: Alpakka ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
 
   def execFuture[A](op: ScanamoOps[A]): Future[A] =
     run(op).runWith(Sink.head[A])(client.materializer)

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val catsEffectVersion = "1.3.1"
 val scalazVersion = "7.2.27" // Bump as needed for io-effect compat
 val scalazIOEffectVersion = "2.10.1"
 val shimsVersion = "1.7.0"
-val zioVersion = "1.0-RC4"
+val zioVersion = "1.0.0-RC8-4"
 
 lazy val stdOptions = Seq(
   "-deprecation",
@@ -204,13 +204,13 @@ lazy val zio = (project in file("scalaz-zio"))
     publishingSettings,
     libraryDependencies ++= List(
       awsDynamoDB,
-      "org.typelevel"  %% "cats-core"               % catsVersion,
-      "org.typelevel"  %% "cats-effect"             % catsEffectVersion,
-      "org.scalaz"     %% "scalaz-zio"              % zioVersion,
-      "org.scalaz"     %% "scalaz-zio-streams"      % zioVersion % Provided,
-      "org.scalaz"     %% "scalaz-zio-interop-cats" % zioVersion,
-      "org.scalatest"  %% "scalatest"               % "3.0.8" % Test,
-      "org.scalacheck" %% "scalacheck"              % "1.14.0" % Test
+      "org.typelevel"  %% "cats-core"        % catsVersion,
+      "org.typelevel"  %% "cats-effect"      % catsEffectVersion,
+      "dev.zio"        %% "zio"              % zioVersion,
+      "dev.zio"        %% "zio-streams"      % zioVersion % Provided,
+      "dev.zio"        %% "zio-interop-cats" % zioVersion,
+      "org.scalatest"  %% "scalatest"        % "3.0.8" % Test,
+      "org.scalacheck" %% "scalacheck"       % "1.14.0" % Test
     ),
     fork in Test := true,
     scalacOptions in (Compile, doc) += "-no-link-warnings"

--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,7 @@ lazy val zio = (project in file("scalaz-zio"))
       "org.typelevel"  %% "cats-core"               % catsVersion,
       "org.typelevel"  %% "cats-effect"             % catsEffectVersion,
       "org.scalaz"     %% "scalaz-zio"              % zioVersion,
+      "org.scalaz"     %% "scalaz-zio-streams"      % zioVersion % Provided,
       "org.scalaz"     %% "scalaz-zio-interop-cats" % zioVersion,
       "org.scalatest"  %% "scalatest"               % "3.0.8" % Test,
       "org.scalacheck" %% "scalacheck"              % "1.14.0" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,8 @@ lazy val catsEffect = (project in file("cats"))
       "org.typelevel"  %% "cats-free"   % catsVersion,
       "org.typelevel"  %% "cats-core"   % catsVersion,
       "org.typelevel"  %% "cats-effect" % catsEffectVersion,
+      "io.monix"       %% "monix"       % "3.0.0-RC2" % Provided,
+      "co.fs2"         %% "fs2-core"    % "1.0.4" % Provided,
       "org.scalatest"  %% "scalatest"   % "3.0.8" % Test,
       "org.scalacheck" %% "scalacheck"  % "1.14.0" % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,8 @@ lazy val catsEffect = (project in file("cats"))
       "org.typelevel"  %% "cats-effect" % catsEffectVersion,
       "io.monix"       %% "monix"       % "3.0.0-RC2" % Provided,
       "co.fs2"         %% "fs2-core"    % "1.0.4" % Provided,
+      "io.monix"       %% "monix"       % "3.0.0-RC2" % Test,
+      "co.fs2"         %% "fs2-core"    % "1.0.4" % Test,
       "org.scalatest"  %% "scalatest"   % "3.0.8" % Test,
       "org.scalacheck" %% "scalacheck"  % "1.14.0" % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 scalaVersion in ThisBuild := "2.12.8"
 crossScalaVersions in ThisBuild := Seq("2.11.12", scalaVersion.value)
 
-val catsVersion = "1.6.1"
+val catsVersion = "2.0.0-M3"
 val catsEffectVersion = "1.3.1"
 val scalazVersion = "7.2.27" // Bump as needed for io-effect compat
 val scalazIOEffectVersion = "2.10.1"

--- a/cats/src/main/scala/org/scanamo/ScanamoCats.scala
+++ b/cats/src/main/scala/org/scanamo/ScanamoCats.scala
@@ -3,7 +3,7 @@ package org.scanamo
 import cats.{ ~>, Monad }
 import cats.effect.Async
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import org.scanamo.ops.{ CatsInterpreter, ScanamoOps }
+import org.scanamo.ops.{ CatsInterpreter, ScanamoOps, ScanamoOpsT }
 
 class ScanamoCats[F[_]: Async](client: AmazonDynamoDBAsync) {
 
@@ -11,7 +11,7 @@ class ScanamoCats[F[_]: Async](client: AmazonDynamoDBAsync) {
 
   final def exec[A](op: ScanamoOps[A]): F[A] = op.foldMap(interpreter)
 
-  final def execT[M[_]: Monad, A](hoist: F ~> M])(op: ScanamoOpsT[M, A]): M[A] =
+  final def execT[M[_]: Monad, A](hoist: F ~> M)(op: ScanamoOpsT[M, A]): M[A] =
     op.foldMap(interpreter andThen hoist)
 }
 

--- a/cats/src/main/scala/org/scanamo/ScanamoCats.scala
+++ b/cats/src/main/scala/org/scanamo/ScanamoCats.scala
@@ -25,7 +25,7 @@ object ScanamoCats {
       def apply[A](fa: F[A]): Iterant[F, A] = Iterant.liftF(fa)
     }
 
-  def toStream[F[_]: Async]: F ~> Stream[F, ?] =
+  def ToStream[F[_]: Async]: F ~> Stream[F, ?] =
     new (F ~> Stream[F, ?]) {
       def apply[A](fa: F[A]): Stream[F, A] = Stream.eval(fa)
     }

--- a/cats/src/main/scala/org/scanamo/ScanamoCats.scala
+++ b/cats/src/main/scala/org/scanamo/ScanamoCats.scala
@@ -1,5 +1,6 @@
 package org.scanamo
 
+import cats.{ ~>, Monad }
 import cats.effect.Async
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import org.scanamo.ops.{ CatsInterpreter, ScanamoOps }
@@ -10,6 +11,8 @@ class ScanamoCats[F[_]: Async](client: AmazonDynamoDBAsync) {
 
   final def exec[A](op: ScanamoOps[A]): F[A] = op.foldMap(interpreter)
 
+  final def execT[M[_]: Monad, A](hoist: F ~> M])(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
 }
 
 object ScanamoCats {

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -210,6 +210,62 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     }
   }
 
+  it("should stream full table scan to a Monix Iterant") {
+    import monix.tail.Iterant
+
+    type SIO[A] = Iterant[IO, A]
+
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
+      case class Item(name: String)
+
+      val list = List(
+        Item("item #1"),
+        Item("item #2"),
+        Item("item #3"),
+        Item("item #4"),
+        Item("item #5"),
+        Item("item #6")
+      )
+      val expected = list.map(i => List(Right(i)))
+
+      val items = Table[Item](t)
+      val ops = for {
+        _ <- items.putAll(list.toSet).toFreeT[SIO]
+        list <- items.scanPaginatedM[SIO](1)
+      } yield list
+
+      scanamo.execT(ScanamoCats.ToIterant)(ops).toListL.unsafeRunSync should contain theSameElementsAs expected
+    }
+  }
+
+  it("should stream full table scan to an FS2 stream") {
+    import fs2.Stream
+
+    type SIO[A] = Stream[IO, A]
+
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
+      case class Item(name: String)
+
+      val list = List(
+        Item("item #1"),
+        Item("item #2"),
+        Item("item #3"),
+        Item("item #4"),
+        Item("item #5"),
+        Item("item #6")
+      )
+      val expected = list.map(i => List(Right(i)))
+
+      val items = Table[Item](t)
+      val ops = for {
+        _ <- items.putAll(list.toSet).toFreeT[SIO]
+        list <- items.scanPaginatedM[SIO](1)
+      } yield list
+
+      scanamo.execT(ScanamoCats.ToStream)(ops).compile.toList.unsafeRunSync should contain theSameElementsAs expected
+    }
+  }
+
   it("scanIndexWithLimit") {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 

--- a/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -4,9 +4,9 @@ import cats.{ ~>, Alternative, Monad }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import org.scanamo.ops._
-import scalaz.zio.IO
-import scalaz.zio.interop.catz._
-import scalaz.zio.stream.Stream
+import zio.IO
+import zio.interop.catz._
+import zio.stream.{ Stream, ZStream }
 
 class ScanamoZio private (client: AmazonDynamoDBAsync) {
   final private val interpreter: ScanamoOpsA ~> IO[AmazonDynamoDBException, ?] =
@@ -39,6 +39,6 @@ object ScanamoZio {
 
   val IoToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =
     new (IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?]) {
-      def apply[A](fa: IO[AmazonDynamoDBException, A]): Stream[AmazonDynamoDBException, A] = Stream.fromEffect(fa)
+      def apply[A](fa: IO[AmazonDynamoDBException, A]): Stream[AmazonDynamoDBException, A] = ZStream.fromEffect(fa)
     }
 }

--- a/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -1,11 +1,12 @@
 package org.scanamo
 
-import cats.{ ~>, Monad }
+import cats.{ ~>, Alternative, Monad }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import org.scanamo.ops._
-import scalaz.zio.interop.catz._
 import scalaz.zio.IO
+import scalaz.zio.interop.catz._
+import scalaz.zio.stream.Stream
 
 class ScanamoZio private (client: AmazonDynamoDBAsync) {
   final private val interpreter: ScanamoOpsA ~> IO[AmazonDynamoDBException, ?] =
@@ -18,5 +19,26 @@ class ScanamoZio private (client: AmazonDynamoDBAsync) {
 }
 
 object ScanamoZio {
+  implicit def streamInstances[E] = new Monad[Stream[E, ?]] with Alternative[Stream[E, ?]] {
+    def combineK[A](x: Stream[E, A], y: Stream[E, A]): Stream[E, A] =
+      x ++ y
+
+    def empty[A]: Stream[E, A] = Stream.empty
+
+    def flatMap[A, B](fa: Stream[E, A])(f: A => Stream[E, B]): Stream[E, B] = fa flatMap f
+
+    def pure[A](x: A): Stream[E, A] = Stream.succeed(x)
+
+    def tailRecM[A, B](a: A)(f: A => Stream[E, Either[A, B]]): Stream[E, B] = f(a) flatMap {
+      case Left(a)  => tailRecM(a)(f)
+      case Right(b) => Stream.succeed(b)
+    }
+  }
+
   def apply(client: AmazonDynamoDBAsync): ScanamoZio = new ScanamoZio(client)
+
+  val IoToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =
+    new (IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?]) {
+      def apply[A](fa: IO[AmazonDynamoDBException, A]): Stream[AmazonDynamoDBException, A] = Stream.fromEffect(fa)
+    }
 }

--- a/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -1,6 +1,6 @@
 package org.scanamo
 
-import cats.~>
+import cats.{ ~>, Monad }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import org.scanamo.ops._

--- a/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -1,6 +1,6 @@
 package org.scanamo
 
-import cats.{ ~>, Alternative, Monad }
+import cats.{ ~>, Monad, MonoidK }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import org.scanamo.ops._
@@ -19,7 +19,7 @@ class ScanamoZio private (client: AmazonDynamoDBAsync) {
 }
 
 object ScanamoZio {
-  implicit def streamInstances[E] = new Monad[Stream[E, ?]] with Alternative[Stream[E, ?]] {
+  implicit def streamInstances[E] = new Monad[Stream[E, ?]] with MonoidK[Stream[E, ?]] {
     def combineK[A](x: Stream[E, A], y: Stream[E, A]): Stream[E, A] =
       x ++ y
 

--- a/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -37,7 +37,7 @@ object ScanamoZio {
 
   def apply(client: AmazonDynamoDBAsync): ScanamoZio = new ScanamoZio(client)
 
-  val IoToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =
+  val ToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =
     new (IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?]) {
       def apply[A](fa: IO[AmazonDynamoDBException, A]): Stream[AmazonDynamoDBException, A] = ZStream.fromEffect(fa)
     }

--- a/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -12,6 +12,9 @@ class ScanamoZio private (client: AmazonDynamoDBAsync) {
     new ZioInterpreter(client)
 
   final def exec[A](op: ScanamoOps[A]): IO[AmazonDynamoDBException, A] = op.foldMap(interpreter)
+
+  final def execT[M[_]: Monad, A](hoist: IO[AmazonDynamoDBException, ?] ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
 }
 
 object ScanamoZio {

--- a/scalaz-zio/src/main/scala/org/scanamo/ops/ZioInterpreter.scala
+++ b/scalaz-zio/src/main/scala/org/scanamo/ops/ZioInterpreter.scala
@@ -5,7 +5,7 @@ import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model._
-import scalaz.zio.IO
+import zio.IO
 
 private[scanamo] class ZioInterpreter(client: AmazonDynamoDBAsync)
     extends (ScanamoOpsA ~> IO[AmazonDynamoDBException, ?]) {
@@ -13,7 +13,7 @@ private[scanamo] class ZioInterpreter(client: AmazonDynamoDBAsync)
     f: (A, AsyncHandler[A, B]) => java.util.concurrent.Future[B],
     req: A
   ): IO[AmazonDynamoDBException, B] =
-    IO.effectAsync[AmazonDynamoDBException, B] { cb =>
+    IO.effectAsync[Any, AmazonDynamoDBException, B] { cb =>
       val handler = new AsyncHandler[A, B] {
         def onError(exception: Exception): Unit =
           exception match {

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -6,7 +6,7 @@ import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.auto._
 import cats.implicits._
-import scalaz.zio.DefaultRuntime
+import zio.DefaultRuntime
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 
 class ScanamoZioSpec extends FunSpec with Matchers {
@@ -201,7 +201,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should stream full table scan") {
-    import scalaz.zio.stream.{ Sink, Stream }
+    import zio.stream.{ Sink, Stream }
     import org.scanamo.error.DynamoReadError
     import ScanamoZio._
 

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -201,7 +201,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should stream full table scan") {
-    import scalaz.zio.stream.{Stream, Sink}
+    import scalaz.zio.stream.{ Sink, Stream }
     import org.scanamo.error.DynamoReadError
     import ScanamoZio._
 

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -226,7 +226,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
         list <- items.scanToPaged[SIO](1)
       } yield list
 
-      unsafeRun(zio.execT(ScanamoZio.IoToStream)(ops).run(Sink.collectAll[List[Either[DynamoReadError, Item]]])) should contain theSameElementsAs expected
+      unsafeRun(zio.execT(ScanamoZio.ToStream)(ops).run(Sink.collectAll[List[Either[DynamoReadError, Item]]])) should contain theSameElementsAs expected
     }
   }
 

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -7,6 +7,7 @@ import org.scanamo.syntax._
 import org.scanamo.auto._
 import cats.implicits._
 import scalaz.zio.DefaultRuntime
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 
 class ScanamoZioSpec extends FunSpec with Matchers {
 
@@ -196,6 +197,36 @@ class ScanamoZioSpec extends FunSpec with Matchers {
         bs <- bears.limit(1).scan
       } yield bs
       unsafeRun(zio.exec(ops)) should equal(List(Right(Bear("Pooh", "honey"))))
+    }
+  }
+
+  it("should stream full table scan") {
+    import scalaz.zio.stream.{Stream, Sink}
+    import org.scanamo.error.DynamoReadError
+    import ScanamoZio._
+
+    type SIO[A] = Stream[AmazonDynamoDBException, A]
+
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
+      case class Item(name: String)
+
+      val list = List(
+        Item("item #1"),
+        Item("item #2"),
+        Item("item #3"),
+        Item("item #4"),
+        Item("item #5"),
+        Item("item #6")
+      )
+      val expected = list.map(i => List(Right(i)))
+
+      val items = Table[Item](t)
+      val ops = for {
+        _ <- items.putAll(list.toSet).toFreeT[SIO]
+        list <- items.scanToPaged[SIO](1)
+      } yield list
+
+      unsafeRun(zio.execT(ScanamoZio.IoToStream)(ops).run(Sink.collect[List[Either[DynamoReadError, Item]]])) should contain theSameElementsAs expected
     }
   }
 

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -7,6 +7,8 @@ import org.scanamo.syntax._
 import org.scanamo.auto._
 import cats.implicits._
 import zio.DefaultRuntime
+import zio.stream.{ Sink, Stream }
+import org.scanamo.error.DynamoReadError
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 
 class ScanamoZioSpec extends FunSpec with Matchers {
@@ -201,8 +203,6 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should stream full table scan") {
-    import zio.stream.{ Sink, Stream }
-    import org.scanamo.error.DynamoReadError
     import ScanamoZio._
 
     type SIO[A] = Stream[AmazonDynamoDBException, A]
@@ -226,7 +226,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
         list <- items.scanToPaged[SIO](1)
       } yield list
 
-      unsafeRun(zio.execT(ScanamoZio.IoToStream)(ops).run(Sink.collect[List[Either[DynamoReadError, Item]]])) should contain theSameElementsAs expected
+      unsafeRun(zio.execT(ScanamoZio.IoToStream)(ops).run(Sink.collectAll[List[Either[DynamoReadError, Item]]])) should contain theSameElementsAs expected
     }
   }
 

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -223,7 +223,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       val items = Table[Item](t)
       val ops = for {
         _ <- items.putAll(list.toSet).toFreeT[SIO]
-        list <- items.scanToPaged[SIO](1)
+        list <- items.scanPaginatedM[SIO](1)
       } yield list
 
       unsafeRun(zio.execT(ScanamoZio.ToStream)(ops).run(Sink.collectAll[List[Either[DynamoReadError, Item]]])) should contain theSameElementsAs expected

--- a/scalaz/src/main/scala/org/scanamo/ScanamoScalaz.scala
+++ b/scalaz/src/main/scala/org/scanamo/ScanamoScalaz.scala
@@ -1,5 +1,6 @@
 package org.scanamo
 
+import cats.{ ~>, Monad }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import org.scanamo.ops.{ ScalazInterpreter, ScanamoOps }
 import scalaz.ioeffect.Task
@@ -11,6 +12,8 @@ class ScanamoScalaz(client: AmazonDynamoDBAsync) {
 
   final def exec[A](op: ScanamoOps[A]): Task[A] = op.asScalaz.foldMap(interpreter)
 
+  final def execT[M[_]: Monad, A](hoist: Task ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
 }
 
 object ScanamoScalaz {

--- a/scalaz/src/main/scala/org/scanamo/ScanamoScalaz.scala
+++ b/scalaz/src/main/scala/org/scanamo/ScanamoScalaz.scala
@@ -1,12 +1,14 @@
 package org.scanamo
 
-import cats.{ ~>, Monad }
+import cats.arrow.FunctionK
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import org.scanamo.ops.{ ScalazInterpreter, ScanamoOps }
+import org.scanamo.ops.{ ScalazInterpreter, ScanamoOps, ScanamoOpsT }
+import scalaz.{ ~>, Monad }
 import scalaz.ioeffect.Task
 import shims._
 
 class ScanamoScalaz(client: AmazonDynamoDBAsync) {
+  import ScanamoScalaz._
 
   final private val interpreter = new ScalazInterpreter(client)
 
@@ -17,5 +19,9 @@ class ScanamoScalaz(client: AmazonDynamoDBAsync) {
 }
 
 object ScanamoScalaz {
+  implicit def natToNat[F[_], G[_]](f: F ~> G): FunctionK[F, G] = new FunctionK[F, G] {
+    def apply[A](a: F[A]): G[A] = f(a)
+  }
+
   def apply(client: AmazonDynamoDBAsync): ScanamoScalaz = new ScanamoScalaz(client)
 }

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -57,9 +57,9 @@ private[scanamo] trait DynamoResultStream[Req, Res] {
         if (results.isEmpty)
           FreeT.liftT(M.empty)
         else {
-          val l1 = limit(req).map(_ - results.length).fold(pageSize)(Math.min(pageSize, _))
+          val l1 = limit(req).fold(pageSize)(l => Math.min(pageSize, l - results.length))
           lastEvaluatedKey(res)
-            .filterNot(_.isEmpty || l1 <= 0)
+            .filterNot(_ => l1 <= 0)
             .foldLeft(FreeT.pure[ScanamoOpsA, M, List[Either[DynamoReadError, T]]](results))(
               (res, k) => res <+> streamMore(withExclusiveStartKey(k)(req), l1)
             )

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -1,9 +1,12 @@
 package org.scanamo
 
-import cats.free.Free
+import cats.Alternative
+import cats.Alternative.ops._
+import cats.free.{ Free, FreeT }
+import cats.syntax.semigroupk._
 import com.amazonaws.services.dynamodbv2.model.{ QueryResult, ScanResult }
 import org.scanamo.error.DynamoReadError
-import org.scanamo.ops.{ ScanamoOps, ScanamoOpsA }
+import org.scanamo.ops.{ ScanamoOps, ScanamoOpsA, ScanamoOpsT }
 import org.scanamo.request.{ ScanamoQueryRequest, ScanamoScanRequest }
 
 private[scanamo] trait DynamoResultStream[Req, Res] {
@@ -42,6 +45,27 @@ private[scanamo] trait DynamoResultStream[Req, Res] {
           )
       } yield result
     streamMore(req)
+  }
+
+  def streamTo[M[_], T: DynamoFormat](
+    req: Req,
+    pageSize: Int
+  )(implicit M: Alternative[M]): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] = {
+    def streamMore(req: Req, l: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
+      exec(withLimit(l)(req)).toFreeT[M].flatMap { res =>
+        val results = items(res).map(ScanamoFree.read[T])
+        if (results.isEmpty)
+          FreeT.liftT(M.empty)
+        else {
+          val l1 = limit(req).map(_ - results.length).fold(pageSize)(Math.min(pageSize, _))
+          lastEvaluatedKey(res)
+            .filterNot(_.isEmpty || l1 <= 0)
+            .foldLeft(FreeT.pure[ScanamoOpsA, M, List[Either[DynamoReadError, T]]](results))(
+              (res, k) => res <+> streamMore(withExclusiveStartKey(k)(req), l1)
+            )
+        }
+      }
+    streamMore(req, limit(req).fold(pageSize)(Math.min(_, pageSize)))
   }
 }
 

--- a/scanamo/src/main/scala/org/scanamo/ScanamoAsync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoAsync.scala
@@ -1,5 +1,7 @@
 package org.scanamo
 
+import cats.Monad
+import cats.~>
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import org.scanamo.ops._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -22,6 +24,8 @@ class ScanamoAsync private (client: AmazonDynamoDBAsync)(implicit ec: ExecutionC
     */
   final def exec[A](op: ScanamoOps[A]): Future[A] = op.foldMap(interpreter)
 
+  final def execT[M[_]: Monad, A](hoist: Future ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
 }
 
 object ScanamoAsync {

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -95,7 +95,7 @@ object ScanamoFree {
   def scan[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default)).map(_._1)
 
-  def scanTo[M[_]: Alternative, T: DynamoFormat](tableName: String,
+  def scanM[M[_]: Alternative, T: DynamoFormat](tableName: String,
                                                  pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
     ScanResultStream.streamTo[M, T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default), pageSize)
 
@@ -105,7 +105,7 @@ object ScanamoFree {
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default)).map(_._1)
 
-  def queryTo[M[_]: Alternative, T: DynamoFormat](
+  def queryM[M[_]: Alternative, T: DynamoFormat](
     tableName: String
   )(query: Query[_], pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
     QueryResultStream.streamTo[M, T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default), pageSize)

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -1,6 +1,6 @@
 package org.scanamo
 
-import cats.Alternative
+import cats.{ Monad, MonoidK }
 import com.amazonaws.services.dynamodbv2.model.{ PutRequest, WriteRequest, _ }
 import java.util.{ List => JList, Map => JMap }
 import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
@@ -95,8 +95,8 @@ object ScanamoFree {
   def scan[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default)).map(_._1)
 
-  def scanM[M[_]: Alternative, T: DynamoFormat](tableName: String,
-                                                 pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
+  def scanM[M[_]: Monad: MonoidK, T: DynamoFormat](tableName: String,
+                                                   pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
     ScanResultStream.streamTo[M, T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default), pageSize)
 
   def scan0[T: DynamoFormat](tableName: String): ScanamoOps[ScanResult] =
@@ -105,7 +105,7 @@ object ScanamoFree {
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default)).map(_._1)
 
-  def queryM[M[_]: Alternative, T: DynamoFormat](
+  def queryM[M[_]: Monad: MonoidK, T: DynamoFormat](
     tableName: String
   )(query: Query[_], pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
     QueryResultStream.streamTo[M, T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default), pageSize)

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -1,10 +1,11 @@
 package org.scanamo
 
+import cats.Alternative
 import com.amazonaws.services.dynamodbv2.model.{ PutRequest, WriteRequest, _ }
 import java.util.{ List => JList, Map => JMap }
 import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
 import org.scanamo.error.DynamoReadError
-import org.scanamo.ops.ScanamoOps
+import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query._
 import org.scanamo.request._
 import org.scanamo.update.UpdateExpression
@@ -94,11 +95,20 @@ object ScanamoFree {
   def scan[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default)).map(_._1)
 
+  def scanTo[M[_]: Alternative, T: DynamoFormat](tableName: String,
+                                                 pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
+    ScanResultStream.streamTo[M, T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default), pageSize)
+
   def scan0[T: DynamoFormat](tableName: String): ScanamoOps[ScanResult] =
     ScanamoOps.scan(ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default))
 
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default)).map(_._1)
+
+  def queryTo[M[_]: Alternative, T: DynamoFormat](
+    tableName: String
+  )(query: Query[_], pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
+    QueryResultStream.streamTo[M, T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default), pageSize)
 
   def query0[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[QueryResult] =
     ScanamoOps.query(ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default))

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -50,11 +50,11 @@ class Scanamo private (client: AmazonDynamoDB) {
 object Scanamo {
   def apply(client: AmazonDynamoDB): Scanamo = new Scanamo(client)
 
-  val IdToList: Id ~> List = new (Id ~> List) {
+  val ToList: Id ~> List = new (Id ~> List) {
     def apply[A](fa: Id[A]): List[A] = fa :: Nil
   }
 
-  val IdToStream: Id ~> Stream = new (Id ~> Stream) {
+  val ToStream: Id ~> Stream = new (Id ~> Stream) {
     def apply[A](fa: Id[A]): Stream[A] = Stream(fa)
   }
 }

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -1,5 +1,6 @@
 package org.scanamo
 
+import cats.{ ~>, Id, Monad }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.scanamo.ops._
 
@@ -41,6 +42,9 @@ class Scanamo private (client: AmazonDynamoDB) {
     * }}}
     */
   final def exec[A](op: ScanamoOps[A]): A = op.foldMap(interpreter)
+
+  final def execT[M[_]: Monad, A](hoist: Id ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
 }
 
 object Scanamo {

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -49,4 +49,12 @@ class Scanamo private (client: AmazonDynamoDB) {
 
 object Scanamo {
   def apply(client: AmazonDynamoDB): Scanamo = new Scanamo(client)
+
+  val IdToList: Id ~> List = new (Id ~> List) {
+    def apply[A](fa: Id[A]): List[A] = fa :: Nil
+  }
+
+  val IdToStream: Id ~> Stream = new (Id ~> Stream) {
+    def apply[A](fa: Id[A]): Stream[A] = Stream(fa)
+  }
 }

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -45,22 +45,22 @@ sealed abstract class SecondaryIndex[V] {
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]]
 
   /**
-   * Performs a scan with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page.
-   * 
-   * To control how many maximum items to load at once, use [[scanToPaged]]
-   */
+    * Performs a scan with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page.
+    *
+    * To control how many maximum items to load at once, use [[scanToPaged]]
+    */
   final def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanToPaged(Int.MaxValue)
 
   /**
-   * Performs a scan with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page, with a maximum of `pageSize` items per page..
-   * 
-   * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
-   * upper bound.
-   */
+    * Performs a scan with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page, with a maximum of `pageSize` items per page..
+    *
+    * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
+    * upper bound.
+    */
   def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]]
 
   /**
@@ -95,23 +95,23 @@ sealed abstract class SecondaryIndex[V] {
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]]
 
   /**
-   * Performs a query with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page.
-   * 
-   * To control how many maximum items to load at once, use [[queryToPaged]]
-   */
+    * Performs a query with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page.
+    *
+    * To control how many maximum items to load at once, use [[queryToPaged]]
+    */
   final def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     queryToPaged(query, Int.MaxValue)
 
   /**
-   * Performs a scan with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page, with a maximum of `pageSize` items per page.
-   * 
-   * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
-   * upper bound.
-   */
+    * Performs a scan with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page, with a maximum of `pageSize` items per page.
+    *
+    * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
+    * upper bound.
+    */
   def queryToPaged[M[_]: Alternative](query: Query[_], pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]]
 
   /**

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -42,7 +42,6 @@ sealed abstract class SecondaryIndex[V] {
     * List(Right(Bear(Paddington,marmalade sandwiches,Some(Mr Curry))), Right(Bear(Yogi,picnic baskets,Some(Ranger Smith))))
     * }}}
     */
-
   final def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanToPaged(Int.MaxValue)
 
   def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]]

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -44,8 +44,23 @@ sealed abstract class SecondaryIndex[V] {
     */
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]]
 
+  /**
+   * Performs a scan with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page.
+   * 
+   * To control how many maximum items to load at once, use [[scanToPaged]]
+   */
   final def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanToPaged(Int.MaxValue)
 
+  /**
+   * Performs a scan with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page, with a maximum of `pageSize` items per page..
+   * 
+   * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
+   * upper bound.
+   */
   def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]]
 
   /**
@@ -79,9 +94,24 @@ sealed abstract class SecondaryIndex[V] {
     */
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]]
 
+  /**
+   * Performs a query with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page.
+   * 
+   * To control how many maximum items to load at once, use [[queryToPaged]]
+   */
   final def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     queryToPaged(query, Int.MaxValue)
 
+  /**
+   * Performs a scan with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page, with a maximum of `pageSize` items per page.
+   * 
+   * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
+   * upper bound.
+   */
   def queryToPaged[M[_]: Alternative](query: Query[_], pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]]
 
   /**

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -778,6 +778,8 @@ private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](tableName: St
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.from(key)
   def filter[T](c: Condition[T]): TableWithOptions[V] =
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.filter(c)
+  def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] =
+    TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.scan()
   def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     scanToPaged(Int.MaxValue)
   def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -588,8 +588,23 @@ case class Table[V: DynamoFormat](name: String) {
     */
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] = ScanamoFree.scan[V](name)
 
+  /**
+   * Performs a scan with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page.
+   * 
+   * To control how many maximum items to load at once, use [[scanToPaged]]
+   */
   final def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanToPaged(Int.MaxValue)
 
+  /**
+   * Performs a scan with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page, with a maximum of `pageSize` items per page..
+   * 
+   * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
+   * upper bound.
+   */
   def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     ScanamoFree.scanTo[M, V](name, pageSize)
 
@@ -664,9 +679,24 @@ case class Table[V: DynamoFormat](name: String) {
     */
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] = ScanamoFree.query[V](name)(query)
 
+  /**
+   * Performs a query with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page.
+   * 
+   * To control how many maximum items to load at once, use [[queryToPaged]]
+   */
   final def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     queryToPaged(query, Int.MaxValue)
 
+  /**
+   * Performs a scan with the ability to introduce effects into the computation. This is
+   * useful for huge tables when you don't want to load the whole of it in memory, but 
+   * scan it page by page, with a maximum of `pageSize` items per page.
+   * 
+   * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
+   * upper bound.
+   */
   def queryToPaged[M[_]: Alternative](query: Query[_],
                                       pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     ScanamoFree.queryTo[M, V](name)(query, pageSize)

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -4,7 +4,7 @@ import cats.Alternative
 import com.amazonaws.services.dynamodbv2.model.{ BatchWriteItemResult, DeleteItemResult, QueryResult, ScanResult }
 import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
 import org.scanamo.error.DynamoReadError
-import org.scanamo.ops.{ScanamoOps, ScanamoOpsT}
+import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query._
 import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
 import org.scanamo.update.UpdateExpression

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -589,22 +589,22 @@ case class Table[V: DynamoFormat](name: String) {
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] = ScanamoFree.scan[V](name)
 
   /**
-   * Performs a scan with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page.
-   * 
-   * To control how many maximum items to load at once, use [[scanToPaged]]
-   */
+    * Performs a scan with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page.
+    *
+    * To control how many maximum items to load at once, use [[scanToPaged]]
+    */
   final def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanToPaged(Int.MaxValue)
 
   /**
-   * Performs a scan with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page, with a maximum of `pageSize` items per page..
-   * 
-   * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
-   * upper bound.
-   */
+    * Performs a scan with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page, with a maximum of `pageSize` items per page..
+    *
+    * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
+    * upper bound.
+    */
   def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     ScanamoFree.scanTo[M, V](name, pageSize)
 
@@ -680,23 +680,23 @@ case class Table[V: DynamoFormat](name: String) {
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] = ScanamoFree.query[V](name)(query)
 
   /**
-   * Performs a query with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page.
-   * 
-   * To control how many maximum items to load at once, use [[queryToPaged]]
-   */
+    * Performs a query with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page.
+    *
+    * To control how many maximum items to load at once, use [[queryToPaged]]
+    */
   final def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     queryToPaged(query, Int.MaxValue)
 
   /**
-   * Performs a scan with the ability to introduce effects into the computation. This is
-   * useful for huge tables when you don't want to load the whole of it in memory, but 
-   * scan it page by page, with a maximum of `pageSize` items per page.
-   * 
-   * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
-   * upper bound.
-   */
+    * Performs a scan with the ability to introduce effects into the computation. This is
+    * useful for huge tables when you don't want to load the whole of it in memory, but
+    * scan it page by page, with a maximum of `pageSize` items per page.
+    *
+    * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
+    * upper bound.
+    */
   def queryToPaged[M[_]: Alternative](query: Query[_],
                                       pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     ScanamoFree.queryTo[M, V](name)(query, pageSize)

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -593,9 +593,9 @@ case class Table[V: DynamoFormat](name: String) {
     * useful for huge tables when you don't want to load the whole of it in memory, but
     * scan it page by page.
     *
-    * To control how many maximum items to load at once, use [[scanToPaged]]
+    * To control how many maximum items to load at once, use [[scanPaginatedM]]
     */
-  final def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanToPaged(Int.MaxValue)
+  final def scanM[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] = scanPaginatedM(Int.MaxValue)
 
   /**
     * Performs a scan with the ability to introduce effects into the computation. This is
@@ -605,8 +605,8 @@ case class Table[V: DynamoFormat](name: String) {
     * @note DynamoDB will only ever return maximum 1MB of data per scan, so `pageSize` is an
     * upper bound.
     */
-  def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    ScanamoFree.scanTo[M, V](name, pageSize)
+  def scanPaginatedM[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    ScanamoFree.scanM[M, V](name, pageSize)
 
   /**
     * Scans the table and returns the raw DynamoDB result. Sometimes, one might want to
@@ -684,10 +684,10 @@ case class Table[V: DynamoFormat](name: String) {
     * useful for huge tables when you don't want to load the whole of it in memory, but
     * scan it page by page.
     *
-    * To control how many maximum items to load at once, use [[queryToPaged]]
+    * To control how many maximum items to load at once, use [[queryPaginatedM]]
     */
-  final def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    queryToPaged(query, Int.MaxValue)
+  final def queryM[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    queryPaginatedM(query, Int.MaxValue)
 
   /**
     * Performs a scan with the ability to introduce effects into the computation. This is
@@ -697,9 +697,9 @@ case class Table[V: DynamoFormat](name: String) {
     * @note DynamoDB will only ever return maximum 1MB of data per query, so `pageSize` is an
     * upper bound.
     */
-  def queryToPaged[M[_]: Alternative](query: Query[_],
+  def queryPaginatedM[M[_]: Alternative](query: Query[_],
                                       pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    ScanamoFree.queryTo[M, V](name)(query, pageSize)
+    ScanamoFree.queryM[M, V](name)(query, pageSize)
 
   /**
     * Queries the table and returns the raw DynamoDB result. Sometimes, one might want to
@@ -810,17 +810,17 @@ private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](tableName: St
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.filter(c)
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] =
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.scan()
-  def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    scanToPaged(Int.MaxValue)
-  def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.scanToPaged[M](pageSize)
+  def scanM[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    scanPaginatedM(Int.MaxValue)
+  def scanPaginatedM[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.scanPaginatedM[M](pageSize)
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =
     TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.query(query)
-  def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    queryToPaged(query, Int.MaxValue)
-  def queryToPaged[M[_]: Alternative](query: Query[_],
+  def queryM[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    queryPaginatedM(query, Int.MaxValue)
+  def queryPaginatedM[M[_]: Alternative](query: Query[_],
                                       pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.queryToPaged(query, pageSize)
+    TableWithOptions(tableName, ScanamoQueryOptions.default).consistently.queryPaginatedM(query, pageSize)
 
   def get(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] =
     ScanamoFree.get[V](tableName)(key, true)
@@ -839,17 +839,17 @@ private[scanamo] case class TableWithOptions[V: DynamoFormat](tableName: String,
 
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] =
     ScanResultStream.stream[V](ScanamoScanRequest(tableName, None, queryOptions)).map(_._1)
-  def scanTo[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    scanToPaged(Int.MaxValue)
-  def scanToPaged[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+  def scanM[M[_]: Alternative]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    scanPaginatedM(Int.MaxValue)
+  def scanPaginatedM[M[_]: Alternative](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     ScanResultStream.streamTo[M, V](ScanamoScanRequest(tableName, None, queryOptions), pageSize)
   def scan0: ScanamoOps[ScanResult] =
     ScanamoOps.scan(ScanamoScanRequest(tableName, None, queryOptions))
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =
     QueryResultStream.stream[V](ScanamoQueryRequest(tableName, None, query, queryOptions)).map(_._1)
-  def queryTo[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    queryToPaged(query, Int.MaxValue)
-  def queryToPaged[M[_]: Alternative](query: Query[_],
+  def queryM[M[_]: Alternative](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
+    queryPaginatedM(query, Int.MaxValue)
+  def queryPaginatedM[M[_]: Alternative](query: Query[_],
                                       pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     QueryResultStream.streamTo[M, V](ScanamoQueryRequest(tableName, None, query, queryOptions), pageSize)
   def query0(query: Query[_]): ScanamoOps[QueryResult] =

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -1,9 +1,10 @@
 package org.scanamo
 
+import cats.Alternative
 import com.amazonaws.services.dynamodbv2.model.{ BatchWriteItemResult, DeleteItemResult, QueryResult, ScanResult }
 import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
 import org.scanamo.error.DynamoReadError
-import org.scanamo.ops.ScanamoOps
+import org.scanamo.ops.{ScanamoOps, ScanamoOpsT}
 import org.scanamo.query._
 import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
 import org.scanamo.update.UpdateExpression

--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -1,7 +1,8 @@
 package org.scanamo
 
-import cats.free.Free
 import cats.data.NonEmptyList
+import cats.free.Free
+import cats.free.FreeT
 import cats.instances.option._
 import cats.syntax.apply._
 import com.amazonaws.services.dynamodbv2.model._
@@ -9,6 +10,7 @@ import org.scanamo.request._
 
 package object ops {
   type ScanamoOps[A] = Free[ScanamoOpsA, A]
+  type ScanamoOpsT[M[_], A] = FreeT[ScanamoOpsA, M, A]
 
   private[ops] object JavaRequests {
     import collection.JavaConverters._

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -245,13 +245,13 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   }
 
   it("should stream full table scan") {
-    import cats.{ ~>, Alternative, Apply, Monad, MonoidK }
+    import cats.{ ~>, Apply, Monad, MonoidK }
     import cats.instances.future._
     import scala.concurrent.Future
 
     type SFuture[A] = Future[Stream[A]]
 
-    implicit val applicative = new Alternative[SFuture] with MonoidK[SFuture] with Monad[SFuture] {
+    implicit val applicative = new MonoidK[SFuture] with Monad[SFuture] {
       def combineK[A](x: SFuture[A], y: SFuture[A]): SFuture[A] = Apply[Future].map2(x, y)(_ ++ _)
 
       def empty[A]: SFuture[A] = Future.successful(Stream.empty)

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -255,16 +255,19 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       def combineK[A](x: SFuture[A], y: SFuture[A]): SFuture[A] = Apply[Future].map2(x, y)(_ ++ _)
 
       def empty[A]: SFuture[A] = Future.successful(Stream.empty)
-      
-      def flatMap[A, B](fa: SFuture[A])(f: A => SFuture[B]): SFuture[B] = fa flatMap { as => Future.traverse(as)(f) } map (_.flatten)
 
-      def tailRecM[A, B](a: A)(f: A => SFuture[Either[A,B]]): SFuture[B] = f(a) flatMap { eas =>
+      def flatMap[A, B](fa: SFuture[A])(f: A => SFuture[B]): SFuture[B] =
+        fa flatMap { as =>
+          Future.traverse(as)(f)
+        } map (_.flatten)
+
+      def tailRecM[A, B](a: A)(f: A => SFuture[Either[A, B]]): SFuture[B] = f(a) flatMap { eas =>
         Future.traverse(eas) {
-          case Left(a) => tailRecM(a)(f)
+          case Left(a)  => tailRecM(a)(f)
           case Right(b) => Future.successful(Stream(b))
         } map (_.flatten)
       }
-      
+
       def pure[A](x: A): SFuture[A] = Future.successful(Stream(x))
     }
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -287,7 +287,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       val items = Table[Item](t)
       val ops = for {
         _ <- items.putAll(list.toSet).toFreeT[SFuture]
-        list <- items.scanToPaged[SFuture](1)
+        list <- items.scanPaginatedM[SFuture](1)
       } yield list
 
       val f = new (Future ~> SFuture) {

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -235,7 +235,7 @@ class ScanamoTest extends FunSpec with Matchers {
 
   it("should stream full table scan") {
     import cats.{ ~>, Id }
-    LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
+    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Item(name: String)
 
       val list = List(

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -232,7 +232,7 @@ class ScanamoTest extends FunSpec with Matchers {
   }
 
   it("should stream full table scan") {
-    import cats.{ Id, ~> }
+    import cats.{ ~>, Id }
     LocalDynamoDB.usingRandomTable(client)('name -> S) { t =>
       case class Item(name: String)
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -251,7 +251,7 @@ class ScanamoTest extends FunSpec with Matchers {
       val items = Table[Item](t)
       val ops = for {
         _ <- items.putAll(list.toSet).toFreeT[Stream]
-        list <- items.scanToPaged[Stream](1)
+        list <- items.scanPaginatedM[Stream](1)
       } yield list
 
       val f = new (Id ~> Stream) {


### PR DESCRIPTION
Closes #275 
Closes #181 

Adds `[scan|query]To` and `[scan|query]toPaged` that thread in an effect type with monoid properties (`Alternative <: Applicative with MonoidK`). Actually we need a stronger constraint, `MonadPlus`, as this is [required in the interpreter](https://github.com/scanamo/scanamo/pull/432), but that class is missing in cats.

- [x] add default `F ~> G` for the various interpreters
- [x] add more tests
- [x] add documentation
- ~~rewrite `scan` and `query` with `[scan|query]To`~~