### PR TITLE
Introduce `Key`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ scala> val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("nam
 
 scala> case class Farm(animals: List[String])
 scala> case class Farmer(name: String, age: Long, farm: Farm)
-scala> val table = Table[Simple, String, Farmer]("farmer")
+scala> val table = Table[String, Farmer]("farmer")
 
 scala> val ops = for {
      |   _ <- table.putAll(Set(

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ scala> val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("nam
 
 scala> case class Farm(animals: List[String])
 scala> case class Farmer(name: String, age: Long, farm: Farm)
-scala> val table = Table[Farmer]("farmer")
+scala> val table = Table[Simple, String, Farmer]("farmer")
 
 scala> val ops = for {
      |   _ <- table.putAll(Set(

--- a/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
@@ -42,7 +42,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -64,7 +64,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -83,7 +83,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Composite, (String, Int), Engine](t)
+      val engines = Table[String, Int, Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
@@ -97,7 +97,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[Simple, String, City](t)
+      val cities = Table[String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -113,7 +113,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo.exec {
         for {
@@ -130,7 +130,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -152,7 +152,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -167,7 +167,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -192,7 +192,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -211,7 +211,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Simple, String, Lemming](t)
+      val lemmings = Table[String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -225,7 +225,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -239,7 +239,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -260,7 +260,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
@@ -285,7 +285,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Composite, (String, Int), Animal](t)
+      val animals = Table[String, Int, Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -313,7 +313,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -339,7 +339,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -366,7 +366,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Composite, (String, String), Transport](t)
+        val transports = Table[String, String, Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -398,7 +398,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[String, String, Station], stations: Set[Station]) =
       stationTable.deleteAll(
         stations.map(s => "mode" -> s.mode && "name" -> s.name)
       )
@@ -410,7 +410,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Composite, (String, String), Station](t)
+        val stationTable = Table[String, String, Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -443,7 +443,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -463,7 +463,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Simple, String, Rabbit](t)
+      val rabbits = Table[String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -477,7 +477,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo
         .exec(for {
@@ -503,7 +503,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Composite, (String, Int), Doctor](t)
+      val doctors = Table[String, Int, Doctor](t)
 
       scanamo
         .exec(for {
@@ -518,7 +518,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo
         .exec(for {
@@ -533,7 +533,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo
         .exec(for {
@@ -549,7 +549,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -570,7 +570,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -590,7 +590,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -614,7 +614,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -638,7 +638,7 @@ class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matcher
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Simple, Int, Gremlin](t)
+      val gremlinsTable = Table[Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ lazy val stdOptions = Seq(
 )
 
 lazy val std2xOptions = Seq(
-  "-Xfatal-warnings",
   "-language:higherKinds",
   "-language:existentials",
   "-language:implicitConversions",

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -6,7 +6,6 @@ import org.scalatest.{ FunSpec, Matchers }
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import org.scanamo.error.DynamoReadError
 import org.scanamo.ops.ScanamoOps
-import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.auto._
 
@@ -20,7 +19,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -38,29 +37,28 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
-        r2 <- farmers.get("name" -> "Maggot")
-      } yield (r1, r1 == r2)
+        r <- farmers.get("name" ->"Maggot")
+      } yield r
 
       scanamo
-        .exec[(Option[Either[DynamoReadError, Farmer]], Boolean)](result)
+        .exec[Option[Either[DynamoReadError, Farmer]]](result)
         .unsafeRunSync should equal(
-        (Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))), true)
+        Some(Right(Farmer("Maggot", 75, Farm(List("dog")))))
       )
     }
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Engine](t)
+      val engines = Table[Composite, (String, Int), Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get("name" -> "Thomas" and "number" -> 1)
+        e <- engines.get("name" -> "Thomas" && "number" -> 1)
       } yield e
 
       scanamo.exec[Option[Either[DynamoReadError, Engine]]](result).unsafeRunSync should equal(
@@ -72,7 +70,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[City](t)
+      val cities = Table[Simple, String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -90,7 +88,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       scanamo
         .exec[Option[Either[DynamoReadError, Farmer]]] {
@@ -109,7 +107,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -131,7 +129,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Forecast](t)
+      val forecasts = Table[Simple, String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -148,7 +146,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Forecast](t)
+      val forecasts = Table[Simple, String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -169,7 +167,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -184,7 +182,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Lemming](t)
+      val lemmings = Table[Simple, String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -198,7 +196,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -214,7 +212,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -231,15 +229,15 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" && "alias" -> "Guardianista").scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" && "alias" -> "Kanga").scan
         } yield res2 ::: res3
       } yield bs
 
@@ -252,7 +250,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Animal](t)
+      val animals = Table[Composite, (String, Int), Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -286,7 +284,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Transport](t)
+      val transports = Table[Composite, (String, String), Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -308,7 +306,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Transport](t)
+      val transports = Table[Composite, (String, String), Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -331,7 +329,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Transport](t)
+        val transports = Table[Composite, (String, String), Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -359,9 +357,9 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
+        stations.map(s => "mode" -> s.mode && "name" -> s.name)
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -371,7 +369,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Station](t)
+        val stationTable = Table[Composite, (String, String), Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -410,7 +408,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -426,7 +424,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Rabbit](t)
+      val rabbits = Table[Simple, String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -440,7 +438,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       scanamo
         .exec[(Set[Either[DynamoReadError, Farmer]], Set[Either[DynamoReadError, Farmer]])](for {
@@ -451,7 +449,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
               Farmer("Bean", 55L, Farm(List("turkey")))
             )
           )
-          fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+          fs1 <- farmers.getAll(List("name" -> "Boggis", "name" -> "Bean"))
           fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
         } yield (fs1, fs2))
         .unsafeRunSync should equal(
@@ -464,12 +462,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Doctor](t)
+      val doctors = Table[Composite, (String, Int), Doctor](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Doctor]]](for {
           _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-          ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+          ds <- doctors.getAll(List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone" && "regeneration" -> 11))
         } yield ds)
         .unsafeRunSync should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
@@ -479,12 +477,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Farm](t)
+      val farmsTable = Table[Simple, Int, Farm](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Farm]]](for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
+          fs <- farmsTable.getAll(farms.map(f => Key("id", f.id)))
         } yield fs)
         .unsafeRunSync should equal(farms.map(Right(_)))
     }
@@ -494,12 +492,12 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Farm](t)
+      val farmsTable = Table[Simple, Int, Farm](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Farm]]](for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
+          fs <- farmsTable.consistently.getAll(farms.map(f => Key("id", f.id)))
         } yield fs)
         .unsafeRunSync should equal(farms.map(Right(_)))
     }
@@ -510,7 +508,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -527,7 +525,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -543,7 +541,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -563,7 +561,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -583,7 +581,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Gremlin](t)
+      val gremlinsTable = Table[Simple, Int, Gremlin](t)
 
       val ops: ScanamoOps[List[Either[DynamoReadError, Gremlin]]] = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -19,7 +19,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -37,7 +37,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -54,7 +54,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Composite, (String, Int), Engine](t)
+      val engines = Table[String, Int, Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
@@ -70,7 +70,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[Simple, String, City](t)
+      val cities = Table[String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -88,7 +88,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo
         .exec[Option[Either[DynamoReadError, Farmer]]] {
@@ -107,7 +107,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -129,7 +129,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -146,7 +146,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -167,7 +167,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -182,7 +182,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Simple, String, Lemming](t)
+      val lemmings = Table[String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -196,7 +196,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -212,7 +212,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -229,7 +229,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
@@ -250,7 +250,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Composite, (String, Int), Animal](t)
+      val animals = Table[String, Int, Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -284,7 +284,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -306,7 +306,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -329,7 +329,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Composite, (String, String), Transport](t)
+        val transports = Table[String, String, Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -357,7 +357,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[String, String, Station], stations: Set[Station]) =
       stationTable.deleteAll(
         stations.map(s => "mode" -> s.mode && "name" -> s.name)
       )
@@ -369,7 +369,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Composite, (String, String), Station](t)
+        val stationTable = Table[String, String, Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -408,7 +408,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -424,7 +424,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Simple, String, Rabbit](t)
+      val rabbits = Table[String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -438,7 +438,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo
         .exec[(Set[Either[DynamoReadError, Farmer]], Set[Either[DynamoReadError, Farmer]])](for {
@@ -462,7 +462,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Composite, (String, Int), Doctor](t)
+      val doctors = Table[String, Int, Doctor](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Doctor]]](for {
@@ -477,7 +477,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Farm]]](for {
@@ -492,7 +492,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo
         .exec[Set[Either[DynamoReadError, Farm]]](for {
@@ -508,7 +508,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -525,7 +525,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -541,7 +541,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -561,7 +561,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -581,7 +581,7 @@ class ScanamoCatsSpec extends FunSpec with Matchers {
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Simple, Int, Gremlin](t)
+      val gremlinsTable = Table[Int, Gremlin](t)
 
       val ops: ScanamoOps[List[Either[DynamoReadError, Gremlin]]] = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/docs/src/main/tut/asynchronous.md
+++ b/docs/src/main/tut/asynchronous.md
@@ -25,7 +25,7 @@ LocalDynamoDB.createTable(client)("farm")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
-val farmTable = Table[Farmer]("farm")
+val farmTable = Table[Simple, String, Farmer]("farm")
 val ops = for {
   _ <- farmTable.putAll(Set(
     Farmer("Boggis", 43L, Farm(List("chicken"))),
@@ -85,7 +85,7 @@ LocalDynamoDB.createTable(client)("nursery-farmers")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
-val farmTable = Table[Farmer]("farm")
+val farmTable = Table[Simple, String, Farmer]("farm")
 val ops = for {
   _ <- farmTable.putAll(Set(
     Farmer("Boggis", 43L, Farm(List("chicken"))),

--- a/docs/src/main/tut/asynchronous.md
+++ b/docs/src/main/tut/asynchronous.md
@@ -25,7 +25,7 @@ LocalDynamoDB.createTable(client)("farm")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
-val farmTable = Table[Simple, String, Farmer]("farm")
+val farmTable = Table[String, Farmer]("farm")
 val ops = for {
   _ <- farmTable.putAll(Set(
     Farmer("Boggis", 43L, Farm(List("chicken"))),
@@ -85,7 +85,7 @@ LocalDynamoDB.createTable(client)("nursery-farmers")("name" -> S)
 
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
-val farmTable = Table[Simple, String, Farmer]("farm")
+val farmTable = Table[String, Farmer]("farm")
 val ops = for {
   _ <- farmTable.putAll(Set(
     Farmer("Boggis", 43L, Farm(List("chicken"))),

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -26,7 +26,7 @@ case class Lemming(role: String, number: Long)
 ```
 
 ```tut:book
-val lemmingsTable = Table[Simple, String, Lemming]("lemmings")
+val lemmingsTable = Table[String, Lemming]("lemmings")
 val ops = for {
   _ <- lemmingsTable.putAll(Set(
     Lemming("Walker", 99), Lemming("Blocker", 42), Lemming("Builder", 180)

--- a/docs/src/main/tut/batch-operations.md
+++ b/docs/src/main/tut/batch-operations.md
@@ -26,7 +26,7 @@ case class Lemming(role: String, number: Long)
 ```
 
 ```tut:book
-val lemmingsTable = Table[Lemming]("lemmings")
+val lemmingsTable = Table[Simple, String, Lemming]("lemmings")
 val ops = for {
   _ <- lemmingsTable.putAll(Set(
     Lemming("Walker", 99), Lemming("Blocker", 42), Lemming("Builder", 180)

--- a/docs/src/main/tut/conditional-operations.md
+++ b/docs/src/main/tut/conditional-operations.md
@@ -21,7 +21,7 @@ val scanamo = Scanamo(client)
 case class Gremlin(number: Int, name: String, wet: Boolean, friendly: Boolean)
 ```
 ```tut:book
-val gremlinsTable = Table[Gremlin]("gremlins")
+val gremlinsTable = Table[Simple, Int, Gremlin]("gremlins")
 LocalDynamoDB.withTable(client)("gremlins")("number" -> N) {
   val ops = for {
     _ <- gremlinsTable.putAll(

--- a/docs/src/main/tut/conditional-operations.md
+++ b/docs/src/main/tut/conditional-operations.md
@@ -21,7 +21,7 @@ val scanamo = Scanamo(client)
 case class Gremlin(number: Int, name: String, wet: Boolean, friendly: Boolean)
 ```
 ```tut:book
-val gremlinsTable = Table[Simple, Int, Gremlin]("gremlins")
+val gremlinsTable = Table[Int, Gremlin]("gremlins")
 LocalDynamoDB.withTable(client)("gremlins")("number" -> N) {
   val ops = for {
     _ <- gremlinsTable.putAll(

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -84,7 +84,7 @@ implicit val jodaStringFormat = DynamoFormat.coercedXmap[DateTime, String, Illeg
 )(
   _.toString
 )
-val fooTable = Table[Simple, DateTime, Foo]("foo")
+val fooTable = Table[PartitionType, DateTime, Foo]("foo")
 val operations = for {
   _           <- fooTable.put(Foo(new DateTime(0)))
   results     <- fooTable.scan()

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -28,7 +28,7 @@ import org.scanamo.auto._
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
 
-val table = Table[Farmer]("farmer")
+val table = Table[Simple, String, Farmer]("farmer")
 table.putAll(
     Set(
         Farmer("McDonald", 156L, Farm(List("sheep", "cow"))),
@@ -84,7 +84,7 @@ implicit val jodaStringFormat = DynamoFormat.coercedXmap[DateTime, String, Illeg
 )(
   _.toString
 )
-val fooTable = Table[Foo]("foo")
+val fooTable = Table[Simple, DateTime, Foo]("foo")
 val operations = for {
   _           <- fooTable.put(Foo(new DateTime(0)))
   results     <- fooTable.scan()

--- a/docs/src/main/tut/dynamo-format.md
+++ b/docs/src/main/tut/dynamo-format.md
@@ -28,7 +28,7 @@ import org.scanamo.auto._
 case class Farm(animals: List[String])
 case class Farmer(name: String, age: Long, farm: Farm)
 
-val table = Table[Simple, String, Farmer]("farmer")
+val table = Table[String, Farmer]("farmer")
 table.putAll(
     Set(
         Farmer("McDonald", 156L, Farm(List("sheep", "cow"))),

--- a/docs/src/main/tut/filters.md
+++ b/docs/src/main/tut/filters.md
@@ -24,7 +24,7 @@ val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 
 case class Station(line: String, name: String, zone: Int)
-val stationTable = Table[Station]("Station")
+val stationTable = Table[Composite, (String, String), Station]("Station")
 ```
 ```tut:book
 LocalDynamoDB.withTable(client)("Station")("line" -> S, "name" -> S) {

--- a/docs/src/main/tut/filters.md
+++ b/docs/src/main/tut/filters.md
@@ -24,7 +24,7 @@ val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 
 case class Station(line: String, name: String, zone: Int)
-val stationTable = Table[Composite, (String, String), Station]("Station")
+val stationTable = Table[String, String, Station]("Station")
 ```
 ```tut:book
 LocalDynamoDB.withTable(client)("Station")("line" -> S, "name" -> S) {

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -43,7 +43,7 @@ case class Farmer(name: String, age: Long, farm: Farm)
 we can simply `put` and `get` items from Dynamo, without boilerplate or reflection
 
 ```tut:book
-val table = Table[Simple, String, Farmer]("farmer")
+val table = Table[String, Farmer]("farmer")
 
 scanamo.exec(table.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow")))))
 scanamo.exec(table.get("name" -> "McDonald"))

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -43,7 +43,7 @@ case class Farmer(name: String, age: Long, farm: Farm)
 we can simply `put` and `get` items from Dynamo, without boilerplate or reflection
 
 ```tut:book
-val table = Table[Farmer]("farmer")
+val table = Table[Simple, String, Farmer]("farmer")
 
 scanamo.exec(table.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow")))))
 scanamo.exec(table.get("name" -> "McDonald"))

--- a/docs/src/main/tut/operations.md
+++ b/docs/src/main/tut/operations.md
@@ -165,7 +165,7 @@ LocalDynamoDB.createTable(client)("lines")("mode" -> S, "line" -> S)
 case class Transport(mode: String, line: String)
 ```
 ```tut:book
-val transportTable = Table[Transport]("lines")
+val transportTable = Table[Composite, (String, String), Transport]("lines")
 val operations = for {
   _ <- transportTable.putAll(Set(
     Transport("Underground", "Circle"),
@@ -193,7 +193,7 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 LocalDynamoDB.createTable(client)("transports")("mode" -> S, "line" -> S)
 
 case class Transport(mode: String, line: String)
-val transportTable = Table[Transport]("transports")
+val transportTable = Table[Composite, (String, String), Transport]("transports")
 val operations = for {
   _ <- transportTable.putAll(Set(
     Transport("Underground", "Circle"),

--- a/docs/src/main/tut/operations.md
+++ b/docs/src/main/tut/operations.md
@@ -165,7 +165,7 @@ LocalDynamoDB.createTable(client)("lines")("mode" -> S, "line" -> S)
 case class Transport(mode: String, line: String)
 ```
 ```tut:book
-val transportTable = Table[Composite, (String, String), Transport]("lines")
+val transportTable = Table[String, String, Transport]("lines")
 val operations = for {
   _ <- transportTable.putAll(Set(
     Transport("Underground", "Circle"),
@@ -193,7 +193,7 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 LocalDynamoDB.createTable(client)("transports")("mode" -> S, "line" -> S)
 
 case class Transport(mode: String, line: String)
-val transportTable = Table[Composite, (String, String), Transport]("transports")
+val transportTable = Table[String, String, Transport]("transports")
 val operations = for {
   _ <- transportTable.putAll(Set(
     Transport("Underground", "Circle"),

--- a/docs/src/main/tut/using-indexes.md
+++ b/docs/src/main/tut/using-indexes.md
@@ -17,7 +17,7 @@ import org.scanamo.syntax._
 import org.scanamo.auto._
 
 case class Transport(mode: String, line: String, colour: String)
-val transport = Table[Transport]("transport")
+val transport = Table[Composite, (String, String), Transport]("transport")
 val colourIndex = transport.index("colour-index")
 
 val client = LocalDynamoDB.client()

--- a/docs/src/main/tut/using-indexes.md
+++ b/docs/src/main/tut/using-indexes.md
@@ -17,7 +17,7 @@ import org.scanamo.syntax._
 import org.scanamo.auto._
 
 case class Transport(mode: String, line: String, colour: String)
-val transport = Table[Composite, (String, String), Transport]("transport")
+val transport = Table[String, String, Transport]("transport")
 val colourIndex = transport.index("colour-index")
 
 val client = LocalDynamoDB.client()

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -21,7 +21,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -39,7 +39,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -54,7 +54,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Composite, (String, Int), Engine](t)
+      val engines = Table[String, Int, Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
@@ -68,7 +68,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[Simple, String, City](t)
+      val cities = Table[String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -84,7 +84,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       unsafeRun(zio.exec {
         for {
@@ -101,7 +101,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -123,7 +123,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -138,7 +138,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -159,7 +159,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -174,7 +174,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Simple, String, Lemming](t)
+      val lemmings = Table[String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -188,7 +188,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -202,7 +202,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -217,7 +217,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
@@ -238,7 +238,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Composite, (String, Int), Animal](t)
+      val animals = Table[String, Int, Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -262,7 +262,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -284,7 +284,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -305,7 +305,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Composite, (String, String), Transport](t)
+        val transports = Table[String, String, Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -333,7 +333,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[String, String, Station], stations: Set[Station]) =
       stationTable.deleteAll(
         stations.map(s => "mode" -> s.mode && "name" -> s.name)
       )
@@ -345,7 +345,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Composite, (String, String), Station](t)
+        val stationTable = Table[String, String, Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -374,7 +374,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -390,7 +390,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Simple, String, Rabbit](t)
+      val rabbits = Table[String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -404,7 +404,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmers.putAll(
@@ -426,7 +426,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Composite, (String, Int), Doctor](t)
+      val doctors = Table[String, Int, Doctor](t)
 
       unsafeRun(zio.exec(for {
         _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
@@ -439,7 +439,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmsTable.putAll(farms)
@@ -452,7 +452,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmsTable.putAll(farms)
@@ -466,7 +466,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -483,7 +483,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -499,7 +499,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -519,7 +519,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -539,7 +539,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Simple, Int, Gremlin](t)
+      val gremlinsTable = Table[Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/scalaz-zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -21,7 +21,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -39,27 +39,26 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
-        r2 <- farmers.get("name" -> "Maggot")
-      } yield (r1, r1 == r2)
+        r <- farmers.get("name" -> "Maggot")
+      } yield r
 
       unsafeRun(zio.exec(result)) should equal(
-        (Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))), true)
+        Some(Right(Farmer("Maggot", 75, Farm(List("dog")))))
       )
     }
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Engine](t)
+      val engines = Table[Composite, (String, Int), Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get("name" -> "Thomas" and "number" -> 1)
+        e <- engines.get("name" -> "Thomas" && "number" -> 1)
       } yield e
 
       unsafeRun(zio.exec(result)) should equal(Some(Right(Engine("Thomas", 1))))
@@ -69,7 +68,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[City](t)
+      val cities = Table[Simple, String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -85,7 +84,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       unsafeRun(zio.exec {
         for {
@@ -102,7 +101,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -124,7 +123,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Forecast](t)
+      val forecasts = Table[Simple, String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -139,7 +138,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Forecast](t)
+      val forecasts = Table[Simple, String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -160,7 +159,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -175,7 +174,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Lemming](t)
+      val lemmings = Table[Simple, String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -189,7 +188,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -203,7 +202,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -218,15 +217,15 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" && "alias" -> "Guardianista").scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" && "alias" -> "Kanga").scan
         } yield res2 ::: res3
       } yield bs
 
@@ -239,7 +238,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Animal](t)
+      val animals = Table[Composite, (String, Int), Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -263,7 +262,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Transport](t)
+      val transports = Table[Composite, (String, String), Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -285,7 +284,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Transport](t)
+      val transports = Table[Composite, (String, String), Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -306,7 +305,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Transport](t)
+        val transports = Table[Composite, (String, String), Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -334,9 +333,9 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
+        stations.map(s => "mode" -> s.mode && "name" -> s.name)
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -346,7 +345,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Station](t)
+        val stationTable = Table[Composite, (String, String), Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -375,7 +374,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -391,7 +390,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Rabbit](t)
+      val rabbits = Table[Simple, String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -405,7 +404,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmers.putAll(
@@ -415,7 +414,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
             Farmer("Bean", 55L, Farm(List("turkey")))
           )
         )
-        fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+        fs1 <- farmers.getAll(List("name" -> "Boggis", "name" -> "Bean"))
         fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
       } yield (fs1, fs2))) should equal(
         (
@@ -427,11 +426,11 @@ class ScanamoZioSpec extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Doctor](t)
+      val doctors = Table[Composite, (String, Int), Doctor](t)
 
       unsafeRun(zio.exec(for {
         _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-        ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+        ds <- doctors.getAll(List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone" && "regeneration" -> 11))
       } yield ds)) should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
@@ -440,11 +439,11 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Farm](t)
+      val farmsTable = Table[Simple, Int, Farm](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmsTable.putAll(farms)
-        fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
+        fs <- farmsTable.getAll(farms.map(f => Key("id", f.id)))
       } yield fs)) should equal(farms.map(Right(_)))
     }
   }
@@ -453,11 +452,11 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Farm](t)
+      val farmsTable = Table[Simple, Int, Farm](t)
 
       unsafeRun(zio.exec(for {
         _ <- farmsTable.putAll(farms)
-        fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
+        fs <- farmsTable.consistently.getAll(farms.map(f => Key("id", f.id)))
       } yield fs)) should equal(farms.map(Right(_)))
     }
   }
@@ -467,7 +466,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -484,7 +483,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -500,7 +499,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -520,7 +519,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -540,7 +539,7 @@ class ScanamoZioSpec extends FunSpec with Matchers {
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Gremlin](t)
+      val gremlinsTable = Table[Simple, Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/scalaz/src/test/scala/org/scanamo/ScanamoScalazSpec.scala
+++ b/scalaz/src/test/scala/org/scanamo/ScanamoScalazSpec.scala
@@ -25,7 +25,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -43,7 +43,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -58,7 +58,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Composite, (String, Int), Engine](t)
+      val engines = Table[String, Int, Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
@@ -72,7 +72,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[Simple, String, City](t)
+      val cities = Table[String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -88,7 +88,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       unsafePerformIO(scanamo.exec {
         for {
@@ -105,7 +105,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -127,7 +127,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -142,7 +142,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -163,7 +163,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -178,7 +178,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Simple, String, Lemming](t)
+      val lemmings = Table[String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(
           List.fill(100)(Lemming(scala.util.Random.nextString(500), scala.util.Random.nextString(5000))).toSet
@@ -194,7 +194,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -208,7 +208,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -225,7 +225,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
@@ -246,7 +246,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Composite, (String, Int), Animal](t)
+      val animals = Table[String, Int, Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -270,7 +270,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -292,7 +292,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -313,7 +313,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Composite, (String, String), Transport](t)
+        val transports = Table[String, String, Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -341,7 +341,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[String, String, Station], stations: Set[Station]) =
       stationTable.deleteAll(
         stations.map(s => "mode" -> s.mode && "name" -> s.name)
       )
@@ -353,7 +353,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Composite, (String, String), Station](t)
+        val stationTable = Table[String, String, Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -382,7 +382,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -398,7 +398,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Simple, String, Rabbit](t)
+      val rabbits = Table[String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(scala.util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -412,7 +412,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- farmers.putAll(
@@ -434,7 +434,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Composite, (String, Int), Doctor](t)
+      val doctors = Table[String, Int, Doctor](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
@@ -447,7 +447,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- farmsTable.putAll(farms)
@@ -460,7 +460,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       unsafePerformIO(scanamo.exec(for {
         _ <- farmsTable.putAll(farms)
@@ -474,7 +474,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -491,7 +491,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -507,7 +507,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -527,7 +527,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -547,7 +547,7 @@ class ScanamoScalazSpec extends FunSpec with Matchers with BeforeAndAfterAll wit
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Simple, Int, Gremlin](t)
+      val gremlinsTable = Table[Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/scanamo/src/main/scala/org/scanamo/IsSimpleKey.scala
+++ b/scanamo/src/main/scala/org/scanamo/IsSimpleKey.scala
@@ -1,0 +1,20 @@
+package org.scanamo
+
+import java.nio.ByteBuffer
+
+trait IsSimpleKey[A]
+
+object IsSimpleKey {
+  implicit case object BooleanSimpleKey extends IsSimpleKey[Boolean]
+  implicit case object StringSimpleKey extends IsSimpleKey[String]
+  implicit case object ByteSimpleKey extends IsSimpleKey[Byte]
+  implicit case object ShortSimpleKey extends IsSimpleKey[Short]
+  implicit case object IntSimpleKey extends IsSimpleKey[Int]
+  implicit case object LongSimpleKey extends IsSimpleKey[Long]
+  implicit case object FloatSimpleKey extends IsSimpleKey[Float]
+  implicit case object DoubleSimpleKey extends IsSimpleKey[Double]
+  implicit case object ByteBufferSimpleKey extends IsSimpleKey[ByteBuffer]
+  implicit case object IntListSimpleKey extends IsSimpleKey[List[Int]]
+  implicit case object StringListSimpleKey extends IsSimpleKey[List[String]]
+  implicit case object ByteBufferListSimpleKey extends IsSimpleKey[List[ByteBuffer]]
+}

--- a/scanamo/src/main/scala/org/scanamo/IsSimpleKey.scala
+++ b/scanamo/src/main/scala/org/scanamo/IsSimpleKey.scala
@@ -2,19 +2,19 @@ package org.scanamo
 
 import java.nio.ByteBuffer
 
-trait IsSimpleKey[A]
+trait SimpleKey[A]
 
-object IsSimpleKey {
-  implicit case object BooleanSimpleKey extends IsSimpleKey[Boolean]
-  implicit case object StringSimpleKey extends IsSimpleKey[String]
-  implicit case object ByteSimpleKey extends IsSimpleKey[Byte]
-  implicit case object ShortSimpleKey extends IsSimpleKey[Short]
-  implicit case object IntSimpleKey extends IsSimpleKey[Int]
-  implicit case object LongSimpleKey extends IsSimpleKey[Long]
-  implicit case object FloatSimpleKey extends IsSimpleKey[Float]
-  implicit case object DoubleSimpleKey extends IsSimpleKey[Double]
-  implicit case object ByteBufferSimpleKey extends IsSimpleKey[ByteBuffer]
-  implicit case object IntListSimpleKey extends IsSimpleKey[List[Int]]
-  implicit case object StringListSimpleKey extends IsSimpleKey[List[String]]
-  implicit case object ByteBufferListSimpleKey extends IsSimpleKey[List[ByteBuffer]]
+object SimpleKey {
+  implicit case object BooleanSimpleKey extends SimpleKey[Boolean]
+  implicit case object StringSimpleKey extends SimpleKey[String]
+  implicit case object ByteSimpleKey extends SimpleKey[Byte]
+  implicit case object ShortSimpleKey extends SimpleKey[Short]
+  implicit case object IntSimpleKey extends SimpleKey[Int]
+  implicit case object LongSimpleKey extends SimpleKey[Long]
+  implicit case object FloatSimpleKey extends SimpleKey[Float]
+  implicit case object DoubleSimpleKey extends SimpleKey[Double]
+  implicit case object ByteBufferSimpleKey extends SimpleKey[ByteBuffer]
+  implicit case object IntListSimpleKey extends SimpleKey[List[Int]]
+  implicit case object StringListSimpleKey extends SimpleKey[List[String]]
+  implicit case object ByteBufferListSimpleKey extends SimpleKey[List[ByteBuffer]]
 }

--- a/scanamo/src/main/scala/org/scanamo/Key.scala
+++ b/scanamo/src/main/scala/org/scanamo/Key.scala
@@ -5,40 +5,54 @@ import cats.syntax.apply._
 import org.scanamo.query.AttributeName
 
 sealed trait KeyType
-sealed trait Simple extends KeyType
-sealed trait Composite extends KeyType
+sealed trait PartitionType extends KeyType
+sealed trait SortType extends KeyType
 
 sealed abstract class Key[KT <: KeyType, +A] extends Product with Serializable { self =>
   def toDynamoObject: DynamoObject
 
-  final def &&[A1 >: A: DynamoFormat, B: DynamoFormat](
-    that: Key[Simple, B]
-  )(implicit ev: Key[KT, A] <:< Key[Simple, A1]): Key[Composite, (A1, B)] =
+  final def &&[A1 >: A: DynamoFormat: SimpleKey, B: DynamoFormat: SimpleKey](
+    that: (AttributeName, B)
+  )(implicit ev: Key[KT, A] <:< Key[PartitionType, A1]): Key[PartitionType with SortType, (A1, B)] =
+    Key.And(ev(self), Key.sort(that._1, that._2))
+
+  final def &&[A1 >: A: DynamoFormat: SimpleKey, B: DynamoFormat: SimpleKey](
+    that: Key[SortType, B]
+  )(implicit ev: Key[KT, A] <:< Key[PartitionType, A1]): Key[PartitionType with SortType, (A1, B)] =
     Key.And(ev(self), that)
 }
 
 object Key {
-  final private case class Equals[A](k: AttributeName, v: A)(implicit D: DynamoFormat[A]) extends Key[Simple, A] {
+  final private case class Partition[A: DynamoFormat: SimpleKey](k: AttributeName, v: A) extends Key[PartitionType, A] {
     final def toDynamoObject: DynamoObject = DynamoObject(k.toString -> v)
   }
 
-  final private case class And[A: DynamoFormat, B: DynamoFormat](p: Key[Simple, A], s: Key[Simple, B])
-      extends Key[Composite, (A, B)] {
+  final private case class Sort[A: DynamoFormat: SimpleKey](k: AttributeName, v: A) extends Key[SortType, A] {
+    final def toDynamoObject: DynamoObject = DynamoObject(k.toString -> v)
+  }
+
+  final private case class And[A: DynamoFormat, B: DynamoFormat](p: Key[PartitionType, A], s: Key[SortType, B])
+      extends Key[PartitionType with SortType, (A, B)] {
     final def toDynamoObject: DynamoObject = p.toDynamoObject <> s.toDynamoObject
   }
 
-  def apply[A: DynamoFormat: SimpleKey](k: AttributeName, v: A): Key[Simple, A] = Equals(k, v)
+  def apply[A: DynamoFormat: SimpleKey](k: AttributeName, v: A): Key[PartitionType, A] = Partition(k, v)
 
-  def fromDynamoObject[A: DynamoFormat: SimpleKey](key: AttributeName, obj: DynamoObject): Option[Key[Simple, A]] =
+  def partition[A: DynamoFormat: SimpleKey](k: AttributeName, v: A): Key[PartitionType, A] = apply(k, v)
+
+  def sort[A: DynamoFormat: SimpleKey](k: AttributeName, v: A): Key[SortType, A] = Sort(k, v)
+
+  def fromDynamoObject[A: DynamoFormat: SimpleKey](key: AttributeName,
+                                                   obj: DynamoObject): Option[Key[PartitionType, A]] =
     obj(key.toString).flatMap(_.as[A].toOption).map(Key(key, _))
 
   def fromDynamoObject[A: DynamoFormat: SimpleKey, B: DynamoFormat: SimpleKey](
     keys: (AttributeName, AttributeName),
     obj: DynamoObject
-  ): Option[Key[Composite, (A, B)]] =
+  ): Option[Key[PartitionType with SortType, (A, B)]] =
     (
       obj(keys._1.toString).flatMap(_.as[A].toOption),
       obj(keys._2.toString).flatMap(_.as[B].toOption)
-    ).mapN(Key(keys._1, _) && Key(keys._2, _))
+    ).mapN(Key(keys._1, _) && Key.sort(keys._2, _))
 
 }

--- a/scanamo/src/main/scala/org/scanamo/Key.scala
+++ b/scanamo/src/main/scala/org/scanamo/Key.scala
@@ -27,12 +27,12 @@ object Key {
     final def toDynamoObject: DynamoObject = p.toDynamoObject <> s.toDynamoObject
   }
 
-  def apply[A: DynamoFormat: IsSimpleKey](k: AttributeName, v: A): Key[Simple, A] = Equals(k, v)
+  def apply[A: DynamoFormat: SimpleKey](k: AttributeName, v: A): Key[Simple, A] = Equals(k, v)
 
-  def fromDynamoObject[A: DynamoFormat: IsSimpleKey](key: AttributeName, obj: DynamoObject): Option[Key[Simple, A]] =
+  def fromDynamoObject[A: DynamoFormat: SimpleKey](key: AttributeName, obj: DynamoObject): Option[Key[Simple, A]] =
     obj(key.toString).flatMap(_.as[A].toOption).map(Key(key, _))
 
-  def fromDynamoObject[A: DynamoFormat: IsSimpleKey, B: DynamoFormat: IsSimpleKey](
+  def fromDynamoObject[A: DynamoFormat: SimpleKey, B: DynamoFormat: SimpleKey](
     keys: (AttributeName, AttributeName),
     obj: DynamoObject
   ): Option[Key[Composite, (A, B)]] =

--- a/scanamo/src/main/scala/org/scanamo/Key.scala
+++ b/scanamo/src/main/scala/org/scanamo/Key.scala
@@ -1,0 +1,38 @@
+package org.scanamo
+
+import cats.instances.option._
+import cats.syntax.apply._
+import org.scanamo.query.AttributeName
+
+sealed trait KeyType
+sealed trait Simple extends KeyType
+sealed trait Composite extends KeyType
+
+sealed abstract class Key[KT <: KeyType, +A] extends Product with Serializable { self =>
+  def toDynamoObject: DynamoObject
+
+  final def &&[A1 >: A: DynamoFormat, B: DynamoFormat](that: Key[Simple, B])(implicit ev: Key[KT, A] <:< Key[Simple, A1]): Key[Composite, (A1, B)] =
+    Key.And(ev(self), that)
+}
+
+object Key {
+  final case class Equals[A](k: AttributeName, v: A)(implicit D: DynamoFormat[A]) extends Key[Simple, A] {
+    final def toDynamoObject: DynamoObject = DynamoObject(k.toString -> v)
+  }
+
+  final case class And[A: DynamoFormat, B: DynamoFormat](p: Key[Simple, A], s: Key[Simple, B]) extends Key[Composite, (A, B)] {
+    final def toDynamoObject: DynamoObject = p.toDynamoObject <> s.toDynamoObject
+  }
+
+  def apply[A: DynamoFormat](k: AttributeName, v: A): Key[Simple, A] = Equals(k, v)
+
+  def fromDynamoObject[A: DynamoFormat](key: AttributeName, obj: DynamoObject): Option[Key[Simple, A]] = 
+    obj(key.toString).flatMap(_.as[A].toOption).map(Key(key, _))
+
+  def fromDynamoObject[A: DynamoFormat, B: DynamoFormat](keys: (AttributeName, AttributeName), obj: DynamoObject): Option[Key[Composite, (A, B)]] =
+    (
+      obj(keys._1.toString).flatMap(_.as[A].toOption),
+      obj(keys._2.toString).flatMap(_.as[B].toOption)
+    ).mapN(Key(keys._1, _) && Key(keys._2, _))
+
+}

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -38,7 +38,9 @@ object ScanamoFree {
         ScanamoOps.batchWrite(new BatchWriteItemRequest().withRequestItems(map))
       }
 
-  def deleteAll[KT <: KeyType, K](tableName: String)(items: Iterable[Key[KT, K]]): ScanamoOps[List[BatchWriteItemResult]] =
+  def deleteAll[KT <: KeyType, K](
+    tableName: String
+  )(items: Iterable[Key[KT, K]]): ScanamoOps[List[BatchWriteItemResult]] =
     items
       .map(_.toDynamoObject)
       .grouped(batchSize)

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -20,7 +20,7 @@ class Scanamo private (client: AmazonDynamoDB) {
     * >>> import org.scanamo.auto._
     *
     * >>> case class Transport(mode: String, line: String)
-    * >>> val transport = Table[Composite, (String, String), Transport]("transport")
+    * >>> val transport = Table[String, String, Transport]("transport")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -20,7 +20,7 @@ class Scanamo private (client: AmazonDynamoDB) {
     * >>> import org.scanamo.auto._
     *
     * >>> case class Transport(mode: String, line: String)
-    * >>> val transport = Table[Transport]("transport")
+    * >>> val transport = Table[Composite, (String, String), Transport]("transport")
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -29,7 +29,7 @@ sealed abstract class SecondaryIndex[KT <: KeyType, K, V] {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("antagonist" -> S) { (t, i) =>
-    * ...   val table = Table[Simple, String, Bear](t)
+    * ...   val table = Table[String, Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey", None))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets", Some("Ranger Smith")))
@@ -57,7 +57,7 @@ sealed abstract class SecondaryIndex[KT <: KeyType, K, V] {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("organisation" -> S, "repository" -> S)("language" -> S, "license" -> S) { (t, i) =>
-    * ...   val githubProjects = Table[Composite, (String, String), GithubProject](t)
+    * ...   val githubProjects = Table[String, String, GithubProject](t)
     * ...   val operations = for {
     * ...     _ <- githubProjects.putAll(Set(
     * ...       GithubProject("typelevel", "cats", "Scala", "MIT"),
@@ -89,7 +89,7 @@ sealed abstract class SecondaryIndex[KT <: KeyType, K, V] {
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   "mode" -> S, "line" -> S)("mode" -> S, "colour" -> S
     * ... ) { (t, i) =>
-    * ...   val transport = Table[Composite, (String, String), Transport](t)
+    * ...   val transport = Table[String, String, Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
@@ -124,7 +124,7 @@ sealed abstract class SecondaryIndex[KT <: KeyType, K, V] {
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)(
     * ...   "mode" -> S, "line" -> S)("mode" -> S, "colour" -> S
     * ... ) { (t, i) =>
-    * ...   val transport = Table[Composite, (String, String), Transport](t)
+    * ...   val transport = Table[String, String, Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -123,7 +123,10 @@ class Table[KT <: KeyType, K, V: DynamoFormat] private (name: String) {
     * List(Right(GithubProject(typelevel,cats,Scala,MIT)), Right(GithubProject(tpolecat,tut,Scala,MIT)), Right(GithubProject(localytics,sbt-dynamodb,Scala,MIT)))
     * }}}
     */
-  def index[KTI <: KeyType, KI](indexName: String): SecondaryIndex[KTI, KI, V] =
+  def index[KI: SimpleKey](indexName: String): SecondaryIndex[Simple, KI, V] =
+    SecondaryIndexWithOptions(name, indexName, ScanamoQueryOptions.default)
+
+  def index[KPI: SimpleKey, KSI: SimpleKey](indexName: String): SecondaryIndex[Composite, (KPI, KSI), V] =
     SecondaryIndexWithOptions(name, indexName, ScanamoQueryOptions.default)
 
   /**
@@ -254,7 +257,7 @@ class Table[KT <: KeyType, K, V: DynamoFormat] private (name: String) {
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
     * ...   import java.util.UUID
-    * ...   implicit val UUIDSimpleKey = new IsSimpleKey[UUID] {}
+    * ...   implicit val UUIDSimpleKey = new SimpleKey[UUID] {}
     * ...   val outers = Table[UUID, Outer](t)
     * ...   val id = UUID.fromString("a8345373-9a93-43be-9bcd-e3682c9197f4")
     * ...   val operations = for {
@@ -759,10 +762,10 @@ class Table[KT <: KeyType, K, V: DynamoFormat] private (name: String) {
 }
 
 object Table {
-  def apply[K: IsSimpleKey, V: DynamoFormat](tableName: String): Table[Simple, K, V] =
+  def apply[K: SimpleKey, V: DynamoFormat](tableName: String): Table[Simple, K, V] =
     new Table[Simple, K, V](tableName)
 
-  def apply[PK: IsSimpleKey, SK: IsSimpleKey, V: DynamoFormat](tableName: String): Table[Composite, (PK, SK), V] =
+  def apply[PK: SimpleKey, SK: SimpleKey, V: DynamoFormat](tableName: String): Table[Composite, (PK, SK), V] =
     new Table[Composite, (PK, SK), V](tableName)
 }
 

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -21,7 +21,7 @@ import org.scanamo.update.UpdateExpression
   * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
   * ...   import org.scanamo.syntax._
   * ...   import org.scanamo.auto._
-  * ...   val transport = Table[Composite, (String, String), Transport](t)
+  * ...   val transport = Table[String, String, Transport](t)
   * ...   val operations = for {
   * ...     _ <- transport.putAll(Set(
   * ...       Transport("Underground", "Circle"),
@@ -34,7 +34,7 @@ import org.scanamo.update.UpdateExpression
   * List(Right(Transport(Underground,Central)), Right(Transport(Underground,Circle)))
   * }}}
   */
-case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
+class Table[KT <: KeyType, K, V: DynamoFormat] private (name: String) {
 
   def put(v: V): ScanamoOps[Option[Either[DynamoReadError, V]]] = ScanamoFree.put(name)(v)
   def putAll(vs: Set[V]): ScanamoOps[List[BatchWriteItemResult]] = ScanamoFree.putAll(name)(vs)
@@ -62,7 +62,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * ...   Farmer("Ted", 40L, Farm(List("T-Rex"))),
     * ...   Farmer("Jack", 2L, Farm(List("velociraptor"))))
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
-    * ...   val farm = Table[Simple, String, Farmer](t)
+    * ...   val farm = Table[String, Farmer](t)
     * ...   val operations = for {
     * ...     _       <- farm.putAll(dataSet)
     * ...     _       <- farm.deleteAll("name" -> dataSet.map(_.name))
@@ -89,7 +89,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("colour" -> S) { (t, i) =>
-    * ...   val transport = Table[Composite, (String, String), Transport](t)
+    * ...   val transport = Table[String, String, Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
@@ -108,7 +108,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("organisation" -> S, "repository" -> S)("language" -> S, "license" -> S) { (t, i) =>
-    * ...   val githubProjects = Table[Composite, (String, String), GithubProject](t)
+    * ...   val githubProjects = Table[String, String, GithubProject](t)
     * ...   val operations = for {
     * ...     _ <- githubProjects.putAll(Set(
     * ...       GithubProject("typelevel", "cats", "Scala", "MIT"),
@@ -141,7 +141,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("location" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val forecast = Table[Simple, String, Forecast](t)
+    * ...   val forecast = Table[String, Forecast](t)
     * ...   val operations = for {
     * ...     _ <- forecast.put(Forecast("London", "Rain"))
     * ...     updated <- forecast.update("location" -> "London", set("weather" -> "Sun"))
@@ -159,7 +159,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val characters = Table[Simple, String, Character](t)
+    * ...   val characters = Table[String, Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.put(Character("The Doctor", List("Ecclestone", "Tennant", "Smith")))
     * ...     _ <- characters.update("name" -> "The Doctor", append("actors" -> "Capaldi"))
@@ -177,7 +177,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val characters = Table[Simple, String, Character](t)
+    * ...   val characters = Table[String, Character](t)
     * ...   val operations = for {
     * ...     _ <- characters.update("name" -> "James Bond", append("actors" -> "Craig"))
     * ...     results <- characters.query("name" -> "James Bond")
@@ -195,7 +195,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("kind" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val fruits = Table[Simple, String, Fruit](t)
+    * ...   val fruits = Table[String, Fruit](t)
     * ...   val operations = for {
     * ...     _ <- fruits.put(Fruit("watermelon", List("USA")))
     * ...     _ <- fruits.update("kind" -> "watermelon", appendAll("sources" -> List("China", "Turkey")))
@@ -214,7 +214,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val foos = Table[Simple, String, Foo](t)
+    * ...   val foos = Table[String, Foo](t)
     * ...   val operations = for {
     * ...     _ <- foos.put(Foo("x", 0, List("First")))
     * ...     updated <- foos.update("name" -> "x",
@@ -232,7 +232,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val bars = Table[Simple, String, Bar](t)
+    * ...   val bars = Table[String, Bar](t)
     * ...   val operations = for {
     * ...     _ <- bars.put(Bar("x", 1L, Set("First")))
     * ...     _ <- bars.update("name" -> "x",
@@ -253,8 +253,10 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("id" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val outers = Table[Simple, java.util.UUID, Outer](t)
-    * ...   val id = java.util.UUID.fromString("a8345373-9a93-43be-9bcd-e3682c9197f4")
+    * ...   import java.util.UUID
+    * ...   implicit val UUIDSimpleKey = new IsSimpleKey[UUID] {}
+    * ...   val outers = Table[UUID, Outer](t)
+    * ...   val id = UUID.fromString("a8345373-9a93-43be-9bcd-e3682c9197f4")
     * ...   val operations = for {
     * ...     _ <- outers.put(Outer(id, Middle("x", 1L, Inner("alpha"), List(1, 2))))
     * ...     updatedOuter <- outers.update("id" -> id,
@@ -273,7 +275,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("id" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val things = Table[Simple, String, Thing](t)
+    * ...   val things = Table[String, Thing](t)
     * ...   val operations = for {
     * ...     _ <- things.put(Thing("a1", 3, None))
     * ...     updated <- things.update("id" -> "a1", set("optional", "mandatory"))
@@ -298,7 +300,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val transport = Table[Composite, (String, String), Transport](t)
+    * ...   val transport = Table[String, String, Transport](t)
     * ...   val operations = for {
     * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle"),
@@ -328,7 +330,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)("country" -> S, "name" -> S) { t =>
     * ...   import org.scanamo.syntax._
     * ...   import org.scanamo.auto._
-    * ...   val cityTable = Table[Composite, (String, String), City](t)
+    * ...   val cityTable = Table[String, String, City](t)
     * ...   val ops = for {
     * ...     _ <- cityTable.putAll(Set(
     * ...       City("US", "Nashville"), City("IT", "Rome"), City("IT", "Siena"), City("TZ", "Dar es Salaam")))
@@ -365,7 +367,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> val scanamo = Scanamo(client)
     *
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
-    * ...   val farmersTable = Table[Simple, String, Farmer](t)
+    * ...   val farmersTable = Table[String, Farmer](t)
     * ...   val farmerOps = for {
     * ...     _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
     * ...     _ <- farmersTable.given("age" -> 156L).put(Farmer("McDonald", 156L, Farm(List("sheep", "chicken"), 30)))
@@ -378,7 +380,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     *
     * >>> case class Letter(roman: String, greek: String)
     * >>> LocalDynamoDB.withRandomTable(client)("roman" -> S) { t =>
-    * ...   val lettersTable = Table[Simple, String, Letter](t)
+    * ...   val lettersTable = Table[String, Letter](t)
     * ...   val ops = for {
     * ...     _ <- lettersTable.putAll(Set(Letter("a", "alpha"), Letter("b", "beta"), Letter("c", "gammon")))
     * ...     _ <- lettersTable.given("greek" beginsWith "ale").put(Letter("a", "aleph"))
@@ -392,7 +394,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import cats.implicits._
     * >>> case class Turnip(size: Int, description: Option[String])
     * >>> LocalDynamoDB.withRandomTable(client)("size" -> N) { t =>
-    * ...   val turnipsTable = Table[Simple, Int, Turnip](t)
+    * ...   val turnipsTable = Table[Int, Turnip](t)
     * ...   val ops = for {
     * ...     _ <- turnipsTable.putAll(Set(Turnip(1, None), Turnip(1000, None)))
     * ...     initialTurnips <- turnipsTable.scan()
@@ -410,7 +412,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Thing(a: String, maybe: Option[Int])
     * >>> LocalDynamoDB.withRandomTable(client)("a" -> S) { t =>
-    * ...   val thingTable = Table[Simple, String, Thing](t)
+    * ...   val thingTable = Table[String, Thing](t)
     * ...   val ops = for {
     * ...     _ <- thingTable.putAll(Set(Thing("a", None), Thing("b", Some(1)), Thing("c", None)))
     * ...     _ <- thingTable.given(attributeExists("maybe")).put(Thing("a", Some(2)))
@@ -429,7 +431,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Compound(a: String, maybe: Option[Int])
     * >>> LocalDynamoDB.withRandomTable(client)("a" -> S) { t =>
-    * ...   val compoundTable = Table[Simple, String, Compound](t)
+    * ...   val compoundTable = Table[String, Compound](t)
     * ...   val ops = for {
     * ...     _ <- compoundTable.putAll(Set(Compound("alpha", None), Compound("beta", Some(1)), Compound("gamma", None)))
     * ...     _ <- compoundTable.given(Condition(attributeExists("maybe")) and "a" -> "alpha").put(Compound("alpha", Some(2)))
@@ -447,7 +449,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Choice(number: Int, description: String)
     * >>> LocalDynamoDB.withRandomTable(client)("number" -> N) { t =>
-    * ...   val choicesTable = Table[Simple, Int, Choice](t)
+    * ...   val choicesTable = Table[Int, Choice](t)
     * ...   val ops = for {
     * ...     _ <- choicesTable.putAll(Set(Choice(1, "cake"), Choice(2, "crumble"), Choice(3, "custard")))
     * ...     _ <- choicesTable.given(Condition("description" -> "cake") or Condition("description" -> "death")).put(Choice(1, "victoria sponge"))
@@ -464,7 +466,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Gremlin(number: Int, wet: Boolean, friendly: Boolean)
     * >>> LocalDynamoDB.withRandomTable(client)("number" -> N) { t =>
-    * ...   val gremlinsTable = Table[Simple, Int, Gremlin](t)
+    * ...   val gremlinsTable = Table[Int, Gremlin](t)
     * ...   val ops = for {
     * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, false)))
     * ...     _ <- gremlinsTable.given("wet" -> true).delete("number" -> 1)
@@ -480,7 +482,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> LocalDynamoDB.withRandomTable(client)("number" -> N) { t =>
-    * ...   val gremlinsTable = Table[Simple, Int, Gremlin](t)
+    * ...   val gremlinsTable = Table[Int, Gremlin](t)
     * ...   val ops = for {
     * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, true)))
     * ...     _ <- gremlinsTable.given("wet" -> true).update("number" -> 1, set("friendly" -> false))
@@ -496,7 +498,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     *
     * {{{
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
-    * ...   val smallscaleFarmersTable = Table[Simple, String, Farmer](t)
+    * ...   val smallscaleFarmersTable = Table[String, Farmer](t)
     * ...   val farmerOps = for {
     * ...     _ <- smallscaleFarmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"), 30)))
     * ...     _ <- smallscaleFarmersTable.given("farm" \ "hectares" < 40L).put(Farmer("McDonald", 156L, Farm(List("gerbil", "hamster"), 20)))
@@ -525,7 +527,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> case class Bear(name: String, favouriteFood: String)
     *
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
-    * ...   val table = Table[Simple, String, Bear](t)
+    * ...   val table = Table[String, Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey"))
     * ...     _ <- table.put(Bear("Baloo", "ants"))
@@ -543,7 +545,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> case class Event(`type`: String, tag: String, count: Int)
     *
     * >>> LocalDynamoDB.withRandomTable(client)("type" -> S, "tag" -> S) { t =>
-    * ...   val table = Table[Composite, (String, String), Event](t)
+    * ...   val table = Table[String, String, Event](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
     * ...            Event("click", "paid", 600),
@@ -576,7 +578,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo.auto._
-    * ...   val table = Table[Simple, String, Bear](t)
+    * ...   val table = Table[String, Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey"))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets"))
@@ -611,7 +613,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-    * ...   val table = Table[Composite, (String, String), Transport](t)
+    * ...   val table = Table[String, String, Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
     * ...       Transport("Underground", "Circle"),
@@ -643,7 +645,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-    * ...   val table = Table[Composite, (String, String), Transport](t)
+    * ...   val table = Table[String, String, Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
     * ...       Transport("Underground", "Circle"),
@@ -681,7 +683,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-    * ...   val table = Table[Composite, (String, String), Transport](t)
+    * ...   val table = Table[String, String, Transport](t)
     * ...   val ops = for {
     * ...     _ <- table.putAll(Set(
     * ...       Transport("Underground", "Circle"),
@@ -716,7 +718,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import org.scanamo.auto._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
-    * ...   val table = Table[Simple, String, Bear](t)
+    * ...   val table = Table[String, Bear](t)
     * ...   val ops = for {
     * ...     _ <- table.put(Bear("Pooh", "honey", None))
     * ...     _ <- table.put(Bear("Yogi", "picnic baskets", Some("Ranger Smith")))
@@ -733,7 +735,7 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("line" -> S, "name" -> S) { t =>
-    * ...   val stationTable = Table[Composite, (String, String), Station](t)
+    * ...   val stationTable = Table[String, String, Station](t)
     * ...   val ops = for {
     * ...     _ <- stationTable.putAll(Set(
     * ...       Station("Metropolitan", "Chalfont & Latimer", 8),
@@ -754,6 +756,14 @@ case class Table[KT <: KeyType, K, V: DynamoFormat](name: String) {
 
   def descending: TableWithOptions[KT, K, V] =
     TableWithOptions(name, ScanamoQueryOptions.default).descending
+}
+
+object Table {
+  def apply[K: IsSimpleKey, V: DynamoFormat](tableName: String): Table[Simple, K, V] =
+    new Table[Simple, K, V](tableName)
+
+  def apply[PK: IsSimpleKey, SK: IsSimpleKey, V: DynamoFormat](tableName: String): Table[Composite, (PK, SK), V] =
+    new Table[Composite, (PK, SK), V](tableName)
 }
 
 private[scanamo] case class ConsistentlyReadTable[KT <: KeyType, K, V: DynamoFormat](tableName: String) {

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -12,10 +12,10 @@ package object scanamo {
 
     case class HashAndRangeKeyNames(hash: AttributeName, range: AttributeName)
 
-    implicit def stringTupleToKey[V: DynamoFormat: IsSimpleKey](pair: (String, V)): Key[Simple, V] =
+    implicit def stringTupleToKey[V: DynamoFormat: SimpleKey](pair: (String, V)): Key[Simple, V] =
       Key(AttributeName.of(pair._1), pair._2)
 
-    implicit def stringListTupleToKeys[V: DynamoFormat: IsSimpleKey](
+    implicit def stringListTupleToKeys[V: DynamoFormat: SimpleKey](
       pair: (String, Iterable[V])
     ): List[Key[Simple, V]] =
       pair._2.foldLeft[List[Key[Simple, V]]](Nil)((acc, v) => (pair._1 -> v) :: acc)

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -12,13 +12,13 @@ package object scanamo {
 
     case class HashAndRangeKeyNames(hash: AttributeName, range: AttributeName)
 
-    implicit def stringTupleToKey[V: DynamoFormat: SimpleKey](pair: (String, V)): Key[Simple, V] =
+    implicit def stringTupleToKey[V: DynamoFormat: SimpleKey](pair: (String, V)): Key[PartitionType, V] =
       Key(AttributeName.of(pair._1), pair._2)
 
     implicit def stringListTupleToKeys[V: DynamoFormat: SimpleKey](
       pair: (String, Iterable[V])
-    ): List[Key[Simple, V]] =
-      pair._2.foldLeft[List[Key[Simple, V]]](Nil)((acc, v) => (pair._1 -> v) :: acc)
+    ): List[Key[PartitionType, V]] =
+      pair._2.foldLeft[List[Key[PartitionType, V]]](Nil)((acc, v) => (pair._1 -> v) :: acc)
 
     implicit def stringTupleToKeyCondition[V: DynamoFormat](pair: (String, V)): KeyEquals[V] =
       KeyEquals(AttributeName.of(pair._1), pair._2)

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -12,10 +12,12 @@ package object scanamo {
 
     case class HashAndRangeKeyNames(hash: AttributeName, range: AttributeName)
 
-    implicit def stringTupleToKey[V: DynamoFormat](pair: (String, V)): Key[Simple, V] =
+    implicit def stringTupleToKey[V: DynamoFormat: IsSimpleKey](pair: (String, V)): Key[Simple, V] =
       Key(AttributeName.of(pair._1), pair._2)
 
-    implicit def stringListTupleToKeys[V: DynamoFormat](pair: (String, Iterable[V])): List[Key[Simple, V]] =
+    implicit def stringListTupleToKeys[V: DynamoFormat: IsSimpleKey](
+      pair: (String, Iterable[V])
+    ): List[Key[Simple, V]] =
       pair._2.foldLeft[List[Key[Simple, V]]](Nil)((acc, v) => (pair._1 -> v) :: acc)
 
     implicit def stringTupleToKeyCondition[V: DynamoFormat](pair: (String, V)): KeyEquals[V] =

--- a/scanamo/src/main/scala/org/scanamo/query/AttributeName.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/AttributeName.scala
@@ -24,6 +24,8 @@ case class AttributeName(components: List[String], index: Option[Int]) {
   def >=[V: DynamoFormat](v: V) = KeyIs(this, GTE, v)
   def beginsWith[V: DynamoFormat](v: V) = BeginsWith(this, v)
   def between[V: DynamoFormat](bounds: Bounds[V]) = Between(this, bounds)
+
+  override def toString(): String = index.foldLeft(components.mkString("."))((x, y) => x ++ "[" ++ y.toString ++ "]")
 }
 
 object AttributeName {

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -27,7 +27,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -45,27 +45,26 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
-        r1 <- farmers.get(UniqueKey(KeyEquals("name", "Maggot")))
-        r2 <- farmers.get("name" -> "Maggot")
-      } yield (r1, r1 == r2)
+        r <- farmers.get("name" -> "Maggot")
+      } yield r
 
       scanamo.exec(result).futureValue should equal(
-        (Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))), true)
+        Some(Right(Farmer("Maggot", 75, Farm(List("dog")))))
       )
     }
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Engine](t)
+      val engines = Table[Composite, (String, Int), Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
-        e <- engines.get("name" -> "Thomas" and "number" -> 1)
+        e <- engines.get("name" -> "Thomas" && "number" -> 1)
       } yield e
 
       scanamo.exec(result).futureValue should equal(Some(Right(Engine("Thomas", 1))))
@@ -75,7 +74,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[City](t)
+      val cities = Table[Simple, String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -91,7 +90,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       scanamo.exec {
         for {
@@ -108,7 +107,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -130,7 +129,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Forecast](t)
+      val forecasts = Table[Simple, String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -145,7 +144,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Forecast](t)
+      val forecasts = Table[Simple, String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -166,7 +165,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -181,7 +180,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Lemming](t)
+      val lemmings = Table[Simple, String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -195,7 +194,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -209,7 +208,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -226,15 +225,15 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Bear](t)
+      val bears = Table[Simple, String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
           _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" -> "Graham" and ("alias" -> "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" and ("alias" -> "Kanga")).scan
+          res2 <- bears.index(i).limit(1).from("name" -> "Graham" && "alias" -> "Guardianista").scan
+          res3 <- bears.index(i).limit(1).from("name" -> "Yogi" && "alias" -> "Kanga").scan
         } yield res2 ::: res3
       } yield bs
 
@@ -247,7 +246,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Animal](t)
+      val animals = Table[Composite, (String, Int), Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -271,7 +270,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Transport](t)
+      val transports = Table[Composite, (String, String), Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -293,7 +292,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Transport](t)
+      val transports = Table[Composite, (String, String), Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -314,7 +313,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Transport](t)
+        val transports = Table[Composite, (String, String), Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -342,9 +341,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
       stationTable.deleteAll(
-        UniqueKeys(MultipleKeyList(("mode", "name"), stations.map(station => (station.mode, station.name))))
+        stations.map(station => "mode" -> station.mode && "name" -> station.name)
       )
 
     val LiverpoolStreet = Station("Underground", "Liverpool Street", 1)
@@ -354,7 +353,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Station](t)
+        val stationTable = Table[Composite, (String, String), Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -383,7 +382,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -399,7 +398,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Rabbit](t)
+      val rabbits = Table[Simple, String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -413,7 +412,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Farmer](t)
+      val farmers = Table[Simple, String, Farmer](t)
 
       scanamo
         .exec(for {
@@ -424,7 +423,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
               Farmer("Bean", 55L, Farm(List("turkey")))
             )
           )
-          fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
+          fs1 <- farmers.getAll(List("name" -> "Boggis", "name" -> "Bean"))
           fs2 <- farmers.getAll("name" -> Set("Boggis", "Bean"))
         } yield (fs1, fs2))
         .futureValue should equal(
@@ -437,12 +436,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Doctor](t)
+      val doctors = Table[Composite, (String, Int), Doctor](t)
 
       scanamo
         .exec(for {
           _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-          ds <- doctors.getAll(("actor" and "regeneration") -> Set("McCoy" -> 9, "Ecclestone" -> 11))
+          ds <- doctors.getAll(List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone"  && "regeneration" -> 11))
         } yield ds)
         .futureValue should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
@@ -452,12 +451,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Farm](t)
+      val farmsTable = Table[Simple, Int, Farm](t)
 
       scanamo
         .exec(for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
+          fs <- farmsTable.getAll(farms.map(f => Key("id", f.id)))
         } yield fs)
         .futureValue should equal(farms.map(Right(_)))
     }
@@ -467,12 +466,12 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Farm](t)
+      val farmsTable = Table[Simple, Int, Farm](t)
 
       scanamo
         .exec(for {
           _ <- farmsTable.putAll(farms)
-          fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
+          fs <- farmsTable.consistently.getAll(farms.map(f => Key("id", f.id)))
         } yield fs)
         .futureValue should equal(farms.map(Right(_)))
     }
@@ -483,7 +482,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -500,7 +499,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -516,7 +515,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -536,7 +535,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Farmer](t)
+      val farmersTable = Table[Simple, String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -556,7 +555,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Gremlin](t)
+      val gremlinsTable = Table[Simple, Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -5,7 +5,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.{ BeforeAndAfterAll, FunSpec, Matchers }
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.auto._
 
@@ -27,7 +26,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -45,7 +44,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -60,7 +59,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Composite, (String, Int), Engine](t)
+      val engines = Table[String, Int, Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
@@ -74,7 +73,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[Simple, String, City](t)
+      val cities = Table[String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -90,7 +89,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo.exec {
         for {
@@ -107,7 +106,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -129,7 +128,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -144,7 +143,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -165,7 +164,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -180,7 +179,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Simple, String, Lemming](t)
+      val lemmings = Table[String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -194,7 +193,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -208,7 +207,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -225,7 +224,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
@@ -246,7 +245,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Composite, (String, Int), Animal](t)
+      val animals = Table[String, Int, Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -270,7 +269,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -292,7 +291,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -313,7 +312,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Composite, (String, String), Transport](t)
+        val transports = Table[String, String, Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -353,7 +352,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Composite, (String, String), Station](t)
+        val stationTable = Table[String, String, Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -382,7 +381,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -398,7 +397,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Simple, String, Rabbit](t)
+      val rabbits = Table[String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -412,7 +411,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo
         .exec(for {
@@ -436,12 +435,13 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Composite, (String, Int), Doctor](t)
+      val doctors = Table[String, Int, Doctor](t)
 
       scanamo
         .exec(for {
           _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-          ds <- doctors.getAll(List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone"  && "regeneration" -> 11))
+          ds <- doctors
+            .getAll(List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone" && "regeneration" -> 11))
         } yield ds)
         .futureValue should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
@@ -451,7 +451,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo
         .exec(for {
@@ -466,7 +466,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo
         .exec(for {
@@ -482,7 +482,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -499,7 +499,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -515,7 +515,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -535,7 +535,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -555,7 +555,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with BeforeAndAfterAll with
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Simple, Int, Gremlin](t)
+      val gremlinsTable = Table[Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -4,7 +4,6 @@ import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 import org.scalatest.{ FunSpec, Matchers }
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.auto._
 
@@ -18,7 +17,7 @@ class ScanamoTest extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -36,7 +35,7 @@ class ScanamoTest extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val result = for {
         _ <- farmers.put(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -51,7 +50,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S, "number" -> N) { t =>
       case class Engine(name: String, number: Int)
 
-      val engines = Table[Composite, (String, Int), Engine](t)
+      val engines = Table[String, Int, Engine](t)
 
       val result = for {
         _ <- engines.put(Engine("Thomas", 1))
@@ -65,7 +64,7 @@ class ScanamoTest extends FunSpec with Matchers {
   it("should get consistently asynchronously") {
     case class City(name: String, country: String)
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val cities = Table[Simple, String, City](t)
+      val cities = Table[String, City](t)
 
       val result = for {
         _ <- cities.put(City("Nashville", "US"))
@@ -81,7 +80,7 @@ class ScanamoTest extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo.exec {
         for {
@@ -98,7 +97,7 @@ class ScanamoTest extends FunSpec with Matchers {
       case class Farm(asyncAnimals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       val dataSet = Set(
         Farmer("Patty", 200L, Farm(List("unicorn"))),
@@ -120,7 +119,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String)
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain"))
         _ <- forecasts.update("location" -> "London", set("weather" -> "Sun"))
@@ -135,7 +134,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("location" -> S) { t =>
       case class Forecast(location: String, weather: String, equipment: Option[String])
 
-      val forecasts = Table[Simple, String, Forecast](t)
+      val forecasts = Table[String, Forecast](t)
 
       val ops = for {
         _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
@@ -156,7 +155,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Bear(name: String, favouriteFood: String)
 
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
 
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
@@ -171,7 +170,7 @@ class ScanamoTest extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Lemming(name: String, stuff: String)
-      val lemmings = Table[Simple, String, Lemming](t)
+      val lemmings = Table[String, Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
         ls <- lemmings.scan
@@ -185,7 +184,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey"))
         _ <- bears.put(Bear("Yogi", "picnic baskets"))
@@ -199,7 +198,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
@@ -214,7 +213,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Bear(name: String, favouriteFood: String, alias: Option[String])
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("name" -> S)("alias" -> S) { (t, i) =>
-      val bears = Table[Simple, String, Bear](t)
+      val bears = Table[String, Bear](t)
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
@@ -235,7 +234,7 @@ class ScanamoTest extends FunSpec with Matchers {
   it("should query asynchronously") {
     LocalDynamoDB.usingRandomTable(client)("species" -> S, "number" -> N) { t =>
       case class Animal(species: String, number: Int)
-      val animals = Table[Composite, (String, Int), Animal](t)
+      val animals = Table[String, Int, Animal](t)
       val ops = for {
         _ <- animals.put(Animal("Wolf", 1))
         _ <- (1 to 3).toList.traverse(i => animals.put(Animal("Pig", i)))
@@ -259,7 +258,7 @@ class ScanamoTest extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("mode" -> S, "line" -> S) { t =>
       case class Transport(mode: String, line: String)
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val ops = for {
         _ <- transports.putAll(
           Set(
@@ -281,7 +280,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
-      val transports = Table[Composite, (String, String), Transport](t)
+      val transports = Table[String, String, Transport](t)
       val result = for {
         _ <- transports.putAll(
           Set(
@@ -302,7 +301,7 @@ class ScanamoTest extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
       (t, i) =>
-        val transports = Table[Composite, (String, String), Transport](t)
+        val transports = Table[String, String, Transport](t)
         val result = for {
           _ <- transports.putAll(
             Set(
@@ -330,7 +329,7 @@ class ScanamoTest extends FunSpec with Matchers {
   it("queries an index asynchronously with `between` sort-key condition") {
     case class Station(mode: String, name: String, zone: Int)
 
-    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Set[Station]) =
+    def deletaAllStations(stationTable: Table[Composite, (String, String), Station], stations: Iterable[Station]) =
       stationTable.deleteAll(
         stations.map(station => "mode" -> station.mode && "name" -> station.name)
       )
@@ -342,7 +341,7 @@ class ScanamoTest extends FunSpec with Matchers {
 
     LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "name" -> S)("mode" -> S, "zone" -> N) {
       (t, i) =>
-        val stationTable = Table[Composite, (String, String), Station](t)
+        val stationTable = Table[String, String, Station](t)
         val stations = Set(LiverpoolStreet, CamdenTown, GoldersGreen, Hainault)
         val ops = for {
           _ <- stationTable.putAll(stations)
@@ -371,7 +370,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Farmer(firstName: String, surname: String, age: Option[Int])
 
     LocalDynamoDB.usingRandomTable(client)("firstName" -> S, "surname" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("Fred", "Perry", None))
         _ <- farmersTable.put(Farmer("Fred", "McDonald", Some(54)))
@@ -387,7 +386,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Rabbit(name: String)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val rabbits = Table[Simple, String, Rabbit](t)
+      val rabbits = Table[String, Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
         rs <- rabbits.scan
@@ -401,7 +400,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
-      val farmers = Table[Simple, String, Farmer](t)
+      val farmers = Table[String, Farmer](t)
 
       scanamo.exec(for {
         _ <- farmers.putAll(
@@ -423,11 +422,13 @@ class ScanamoTest extends FunSpec with Matchers {
 
     LocalDynamoDB.usingRandomTable(client)("actor" -> S, "regeneration" -> N) { t =>
       case class Doctor(actor: String, regeneration: Int)
-      val doctors = Table[Composite, (String, Int), Doctor](t)
+      val doctors = Table[String, Int, Doctor](t)
 
       scanamo.exec(for {
         _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-        ds <- doctors.getAll(List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone" && "regeneration" -> 11))
+        ds <- doctors.getAll(
+          List("actor" -> "McCoy" && "regeneration" -> 9, "actor" -> "Ecclestone" && "regeneration" -> 11)
+        )
       } yield ds) should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
@@ -436,7 +437,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo.exec(for {
         _ <- farmsTable.putAll(farms)
@@ -449,7 +450,7 @@ class ScanamoTest extends FunSpec with Matchers {
     LocalDynamoDB.usingRandomTable(client)("id" -> N) { t =>
       case class Farm(id: Int, name: String)
       val farms = (1 to 101).map(i => Farm(i, s"Farm #$i")).toSet
-      val farmsTable = Table[Simple, Int, Farm](t)
+      val farmsTable = Table[Int, Farm](t)
 
       scanamo.exec(for {
         _ <- farmsTable.putAll(farms)
@@ -463,7 +464,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
         result <- farmersTable.put(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
@@ -480,7 +481,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
       val farmerOps = for {
         result <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
@@ -496,7 +497,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
@@ -516,7 +517,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Farmer(name: String, age: Long, farm: Farm)
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val farmersTable = Table[Simple, String, Farmer](t)
+      val farmersTable = Table[String, Farmer](t)
 
       val farmerOps = for {
         _ <- farmersTable.put(Farmer("McDonald", 55, Farm(List("sheep", "cow"))))
@@ -536,7 +537,7 @@ class ScanamoTest extends FunSpec with Matchers {
     case class Gremlin(number: Int, wet: Boolean)
 
     LocalDynamoDB.usingRandomTable(client)("number" -> N) { t =>
-      val gremlinsTable = Table[Simple, Int, Gremlin](t)
+      val gremlinsTable = Table[Int, Gremlin](t)
 
       val ops = for {
         _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))


### PR DESCRIPTION
Partially addresses #398 

The new `Key` replaces `UniqueKey` and has two type parameters: `Key[KT, T]`

- `KT` identifies whether the table has a `Simple` or `Composite` key
- `T` is the type of key values. In the `Composite` case, it is actually `(T', T")`

`KT` is just a phantom type to make sure a key is "correct by construction". This changes ripples through the whole API, notably `Table` is now indexed by these two types to make sure all APIs relying on keys receive correct values.

This is still a WIP as I want to tackle `Query` in here too, because now we can enforce the `query*` APIs can only be called when the table has a composite key at compile time, which I think is great.