### PR TITLE
RetryPolicy fixes

### DIFF
--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -35,7 +35,7 @@ class ScanamoAlpakka private (client: DynamoClient, retryPolicy: RetryPolicy) {
 object ScanamoAlpakka extends AlpakkaInstances {
   def apply(
     client: DynamoClient,
-    retrySettings: RetryPolicy = RetryPolicy.Max(numberOfRetries = 3)
+    retrySettings: RetryPolicy = RetryPolicy.max(3)
   ): ScanamoAlpakka = new ScanamoAlpakka(client, retrySettings)
 }
 

--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 /**
   * Provides the same interface as [[org.scanamo.Scanamo]], except that it requires an
   * [[https://github.com/akka/alpakka Alpakka]] client and a [[org.scanamo.ops.retrypolicy.RetryPolicy]].
-  * `retryPolicy` defaults to [[org.scanamo.ops.retrypolicy.RetryPolicy.Max]] with maximum 3 retries if not explicitly
+  * `retryPolicy` defaults to [[org.scanamo.ops.retrypolicy.RetryPolicy.max]] with maximum 3 retries if not explicitly
   * provided. Moreover, the interface returns either a [[scala.concurrent.Future]] or [[akka.stream.scaladsl.Source]]
   * based on the kind of execution used.
   */

--- a/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/RetryPolicy.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/RetryPolicy.scala
@@ -5,30 +5,29 @@ import org.scanamo.ops.retrypolicy.RetryPolicy._
 import scala.concurrent.duration.FiniteDuration
 
 sealed abstract class RetryPolicy extends Product with Serializable { self =>
-  final def done: Boolean = self match {
-    case Max(1)                      => true
-    case And(thisPolicy, thatPolicy) => thisPolicy.done && thatPolicy.done
-    case Or(thisPolicy, thatPolicy)  => thisPolicy.done || thatPolicy.done
-    case Never                       => true
-    case _                           => false
+  final def continue: Boolean = self match {
+    case Max(0) | Never              => false
+    case And(thisPolicy, thatPolicy) => thisPolicy.continue && thatPolicy.continue
+    case Or(thisPolicy, thatPolicy)  => thisPolicy.continue || thatPolicy.continue
+    case _                           => true
   }
 
   final def delay: Long = self match {
-    case Constant(retryDelay)       => retryDelay.toMillis
-    case Linear(retryDelay, factor) => retryDelay.toMillis * factor.toLong
-    case Exponential(retryDelay, factor) =>
-      val delayMillis = retryDelay.toMillis
-      delayMillis * Math.pow(delayMillis.toDouble, factor).toLong
-    case And(thisPolicy, thatPolicy) => Math.max(thisPolicy.delay, thatPolicy.delay)
-    case Or(thisPolicy, thatPolicy)  => Math.min(thisPolicy.delay, thatPolicy.delay)
-    case _                           => 0
+    case Constant(retryDelay)            => retryDelay.toMillis
+    case Linear(retryDelay, factor)      => retryDelay.toMillis * factor.toLong
+    case Exponential(retryDelay, factor) => retryDelay.toMillis * factor.toLong
+    case And(thisPolicy, thatPolicy)     => Math.max(thisPolicy.delay, thatPolicy.delay)
+    case Or(thisPolicy, thatPolicy)      => Math.min(thisPolicy.delay, thatPolicy.delay)
+    case _                               => 0
   }
 
   final def update: RetryPolicy = self match {
-    case Max(retries)                => Max(retries - 1)
-    case And(thisPolicy, thatPolicy) => And(thisPolicy.update, thatPolicy.update)
-    case Or(thisPolicy, thatPolicy)  => Or(thisPolicy.update, thatPolicy.update)
-    case retryPolicy                 => retryPolicy
+    case Max(retries) if retries > 0     => Max(retries - 1)
+    case And(thisPolicy, thatPolicy)     => And(thisPolicy.update, thatPolicy.update)
+    case Or(thisPolicy, thatPolicy)      => Or(thisPolicy.update, thatPolicy.update)
+    case Linear(retryDelay, factor)      => Linear(retryDelay, factor + 1)
+    case Exponential(retryDelay, factor) => Exponential(retryDelay, factor * 2)
+    case retryPolicy                     => retryPolicy
   }
 
   final val retries: Int = self match {

--- a/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/RetryPolicy.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/RetryPolicy.scala
@@ -16,16 +16,10 @@ sealed abstract class RetryPolicy extends Product with Serializable { self =>
     case Constant(retryDelay)               => retryDelay
     case Linear(retryDelay, n)              => retryDelay * n.toDouble
     case Exponential(retryDelay, factor, n) => retryDelay * Math.pow(factor, n.toDouble)
-    case And(thisPolicy, thatPolicy) =>
-      val d1 = thisPolicy.delay
-      val d2 = thatPolicy.delay
-      if (d1 >= d2) d1 else d2
-    case Or(thisPolicy, thatPolicy) =>
-      val d1 = thisPolicy.delay
-      val d2 = thatPolicy.delay
-      if (d1 <= d2) d1 else d2
-    case Never => Duration.Inf
-    case _     => Duration.Zero
+    case And(thisPolicy, thatPolicy)        => thisPolicy.delay.max(thatPolicy.delay)
+    case Or(thisPolicy, thatPolicy)         => thisPolicy.delay.min(thatPolicy.delay)
+    case Never                              => Duration.Inf
+    case _                                  => Duration.Zero
   }
 
   final def update: RetryPolicy = self match {

--- a/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/WithRetry.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/WithRetry.scala
@@ -18,7 +18,7 @@ trait WithRetry {
           if (retryPolicy.continue) {
             Source
               .single(())
-              .delay(FiniteDuration(retryPolicy.delay, TimeUnit.MILLISECONDS))
+              .delay(FiniteDuration(retryPolicy.delay.toMillis, TimeUnit.MILLISECONDS))
               .flatMapConcat(_ => retry(op, retryPolicy.update))
           } else {
             Source.failed(exception)

--- a/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/WithRetry.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/WithRetry.scala
@@ -15,8 +15,11 @@ trait WithRetry {
       1, {
         case exception @ (_: InternalServerErrorException | _: ItemCollectionSizeLimitExceededException |
             _: LimitExceededException | _: ProvisionedThroughputExceededException | _: RequestLimitExceededException) =>
-          if (!retryPolicy.done) {
-            retry(op, retryPolicy.update).delay(FiniteDuration(retryPolicy.delay, TimeUnit.MILLISECONDS))
+          if (retryPolicy.continue) {
+            Source
+              .single(())
+              .delay(FiniteDuration(retryPolicy.delay, TimeUnit.MILLISECONDS))
+              .flatMapConcat(_ => retry(op, retryPolicy.update))
           } else {
             Source.failed(exception)
           }

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -36,9 +36,9 @@ class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetr
     val minDelay = tries * delay.toMillis
     val start = System.currentTimeMillis()
     val future = testcase(policy)
-    future transform { _ =>
+    future map { _ =>
       val stop = System.currentTimeMillis()
-      Success(assert(stop - start > minDelay))
+      assert(stop - start > minDelay)
     }
   }
 

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.Success
 
-class ScanamoIssue extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry {
+class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry {
 
   implicit val actorSystem: ActorSystem = ActorSystem()
   implicit val materializer: ActorMaterializer = ActorMaterializer()

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -43,12 +43,13 @@ class ScanamoIssue extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry {
   }
 
   "Retry Policies should terminate" - {
-    "Plain maximum" in testcase(RetryPolicy.Max(tries))
-    "Constant delay AND maximum" in testcaseWithDelay(RetryPolicy.Max(tries) && RetryPolicy.Constant(delay))
-    "Linear delay AND maximum" in testcaseWithDelay(RetryPolicy.Max(tries) && RetryPolicy.Linear(delay, factor))
-    "Exponential delay AND maximum" in testcase(RetryPolicy.Max(tries) && RetryPolicy.Exponential(delay, factor))
-    // "Constant delay OR maximum" in testcaseWithDelay(RetryPolicy.Max(tries) || RetryPolicy.Max(tries * 2) && RetryPolicy.Constant(delay))
-    // "Linear delay OR maximum" in testcaseWithDelay(RetryPolicy.Max(tries) || RetryPolicy.Max(tries * 2) && RetryPolicy.Linear(delay, factor))
-    // "Exponential delay OR maximum" in testcase(RetryPolicy.Max(tries) || RetryPolicy.Max(tries * 2) && RetryPolicy.Exponential(delay, factor))
+    import RetryPolicy._
+
+    "Plain maximum" in testcase(max(tries))
+    "Constant delay AND maximum" in testcaseWithDelay(max(tries) && fixed(delay))
+    "Linear delay AND maximum" in testcaseWithDelay(max(tries) && linear(delay))
+    "Exponential delay AND maximum" in testcase(max(tries) && exponential(delay, factor))
+    "Constant delay OR linear delay" in testcaseWithDelay(max(tries) && (fixed(delay) || linear(delay)))
+    "Constant delay OR exponential delay" in testcaseWithDelay(max(tries) && (fixed(delay) || exponential(delay)))
   }
 }

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -1,0 +1,54 @@
+package org.scanamo
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import com.amazonaws.services.dynamodbv2.model._
+import org.scalatest.{ Assertion, AsyncFreeSpec, BeforeAndAfterAll }
+import org.scanamo.ops.retrypolicy.{ RetryPolicy, WithRetry }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+import scala.util.Success
+
+class ScanamoIssue extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry {
+
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  override protected def afterAll(): Unit = {
+    materializer.shutdown()
+    Await.ready(actorSystem.terminate(), 10.seconds)
+  }
+
+  private val tries = 5
+  private val delay = 10.millis
+  private val factor = 1.2
+
+  private def testcase(policy: RetryPolicy): Future[Assertion] =
+    retry(Source.failed(new LimitExceededException("Limit Exceeded")), policy).recover {
+      case NonFatal(t) => t
+    }.runWith(Sink.seq)
+      .map(x => assert(x.size == 1))
+
+  private def testcaseWithDelay(policy: RetryPolicy): Future[Assertion] = {
+    val minDelay = tries * delay.toMillis
+    val start = System.currentTimeMillis()
+    val future = testcase(policy)
+    future transform { _ =>
+      val stop = System.currentTimeMillis()
+      Success(assert(stop - start > minDelay))
+    }
+  }
+
+  "Retry Policies should terminate" - {
+    "Plain maximum" in testcase(RetryPolicy.Max(tries))
+    "Constant delay AND maximum" in testcaseWithDelay(RetryPolicy.Max(tries) && RetryPolicy.Constant(delay))
+    "Linear delay AND maximum" in testcaseWithDelay(RetryPolicy.Max(tries) && RetryPolicy.Linear(delay, factor))
+    "Exponential delay AND maximum" in testcase(RetryPolicy.Max(tries) && RetryPolicy.Exponential(delay, factor))
+    // "Constant delay OR maximum" in testcaseWithDelay(RetryPolicy.Max(tries) || RetryPolicy.Max(tries * 2) && RetryPolicy.Constant(delay))
+    // "Linear delay OR maximum" in testcaseWithDelay(RetryPolicy.Max(tries) || RetryPolicy.Max(tries * 2) && RetryPolicy.Linear(delay, factor))
+    // "Exponential delay OR maximum" in testcase(RetryPolicy.Max(tries) || RetryPolicy.Max(tries * 2) && RetryPolicy.Exponential(delay, factor))
+  }
+}


### PR DESCRIPTION
Closes #448 

Also steals tests from the ticket.

Fixes:
- Max bottoms out at 0 and never goes below
- switch `Duration` for `FiniteDuration` (`Never ~ Duration.Inf`)
- Fixes exponential delay calculation
- adds constructors to guarantee correctness
- proper introduction of a delay in the stream algebra
