### PR TITLE
Add generic set to Dynamo Formats

### DIFF
--- a/formats/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/formats/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -471,6 +471,16 @@ object DynamoFormat extends EnumDynamoFormat {
       final override val default = Some(Set.empty[String])
     }
 
+  /**
+    * {{{
+    * prop> (s: Set[Boolean]) =>
+    *     | DynamoFormat[Set[Boolean]].read(DynamoFormat[Set[Boolean]].write(s)) ==
+    *     |   Right(s)
+    * }}}
+    */
+  implicit def genericSet[T: DynamoFormat]: DynamoFormat[Set[T]] =
+    iso[Set[T], List[T]](_.toSet, DynamoDefault.SomeDef(Set.empty))(_.toList)
+
   private val javaMapFormat: DynamoFormat[DynamoObject] =
     attribute(_.asObject, DynamoValue.fromDynamoObject, "M")
 


### PR DESCRIPTION
This allows for a Generic Scala `Set` to be interpreted by the program. 

Previously Sets of numbers and strings were accepted, but not Sets of custom objects. Provided the items are in a DynamoFormat, this can now be done. 