### PR TITLE
Allow specifying port on scanamo-testkit LocalDynamoDB client

### DIFF
--- a/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
@@ -9,11 +9,11 @@ import com.amazonaws.services.dynamodbv2.model._
 import scala.collection.JavaConverters._
 
 object LocalDynamoDB {
-  def client(): AmazonDynamoDBAsync =
+  def client(port: Int = 8042): AmazonDynamoDBAsync =
     AmazonDynamoDBAsyncClient
       .asyncBuilder()
       .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "credentials")))
-      .withEndpointConfiguration(new EndpointConfiguration("http://localhost:8042", ""))
+      .withEndpointConfiguration(new EndpointConfiguration(s"http://localhost:$port", ""))
       .withClientConfiguration(new ClientConfiguration().withClientExecutionTimeout(50000).withRequestTimeout(5000))
       .build()
 


### PR DESCRIPTION
This is useful for multi-project builds that have some subprojects with tests that require LocalDynamoDB, and others that don't - the two subprojects will need different ports to not interfere with each other (not killing each other's LocalDynamoDB process before time). This problem seemed to rear it's head in the Ophan build as we tried to upgrade to sbt 1.3.

See also https://github.com/localytics/sbt-dynamodb/issues/53 and the alternative strategy used in Scanamo itself: https://github.com/scanamo/scanamo/pull/232