### PR TITLE
Use zio stream provided instances

### DIFF
--- a/zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -1,6 +1,6 @@
 package org.scanamo
 
-import cats.{ ~>, Monad, MonoidK }
+import cats.{ ~>, Monad }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import org.scanamo.ops._
@@ -19,22 +19,6 @@ class ScanamoZio private (client: AmazonDynamoDBAsync) {
 }
 
 object ScanamoZio {
-  implicit def streamInstances[E] = new Monad[Stream[E, ?]] with MonoidK[Stream[E, ?]] {
-    def combineK[A](x: Stream[E, A], y: Stream[E, A]): Stream[E, A] =
-      x ++ y
-
-    def empty[A]: Stream[E, A] = Stream.empty
-
-    def flatMap[A, B](fa: Stream[E, A])(f: A => Stream[E, B]): Stream[E, B] = fa flatMap f
-
-    def pure[A](x: A): Stream[E, A] = Stream.succeed(x)
-
-    def tailRecM[A, B](a: A)(f: A => Stream[E, Either[A, B]]): Stream[E, B] = f(a) flatMap {
-      case Left(a)  => tailRecM(a)(f)
-      case Right(b) => Stream.succeed(b)
-    }
-  }
-
   def apply(client: AmazonDynamoDBAsync): ScanamoZio = new ScanamoZio(client)
 
   val ToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =

--- a/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -7,6 +7,7 @@ import org.scanamo.syntax._
 import org.scanamo.auto._
 import cats.implicits._
 import zio.DefaultRuntime
+import zio.stream.interop.catz._
 import zio.stream.{ Sink, Stream }
 import org.scanamo.error.DynamoReadError
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
@@ -202,8 +203,6 @@ class ScanamoZioSpec extends FunSpec with Matchers {
   }
 
   it("should stream full table scan") {
-    import ScanamoZio._
-
     type SIO[A] = Stream[AmazonDynamoDBException, A]
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>


### PR DESCRIPTION
They are [now provided](https://github.com/zio/interop-cats/pull/67) by the interop layer and properly battle-tested for correctness (which wasn;'t the case here 😅 ).