### PR TITLE
Allow customization of retryable exceptions

### DIFF
--- a/alpakka/src/main/scala/org/scanamo/ops/AlpakkaInterpreter.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/AlpakkaInterpreter.scala
@@ -26,9 +26,13 @@ import akka.stream.alpakka.dynamodb.scaladsl.DynamoDb
 import akka.stream.scaladsl.Source
 import akka.NotUsed
 
-private[scanamo] class AlpakkaInterpreter(client: DynamoClient, retryPolicy: RetryPolicy)
+private[scanamo] class AlpakkaInterpreter(client: DynamoClient,
+                                          retryPolicy: RetryPolicy,
+                                          isRetryable: Throwable => Boolean)
     extends (ScanamoOpsA ~> AlpakkaInterpreter.Alpakka)
     with WithRetry {
+  override def retryable(throwable: Throwable): Boolean = isRetryable(throwable)
+
   final private def run(op: AwsOp): AlpakkaInterpreter.Alpakka[op.B] =
     retry(DynamoDb.source(op).withAttributes(DynamoAttributes.client(client)), retryPolicy)
 

--- a/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/RetryPolicy.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/RetryPolicy.scala
@@ -17,7 +17,9 @@
 package org.scanamo.ops.retrypolicy
 
 import java.util.SplittableRandom
+
 import org.scanamo.ops.retrypolicy.RetryPolicy._
+
 import scala.concurrent.duration._
 
 sealed abstract class RetryPolicy extends Product with Serializable { self =>

--- a/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/WithRetry.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/retrypolicy/WithRetry.scala
@@ -18,18 +18,18 @@ package org.scanamo.ops.retrypolicy
 
 import java.util.concurrent.TimeUnit
 
-import com.amazonaws.services.dynamodbv2.model._
-
-import akka.stream.scaladsl.Source
 import akka.NotUsed
+import akka.stream.scaladsl.Source
+
 import scala.concurrent.duration.FiniteDuration
 
 trait WithRetry {
+  def retryable(throwable: Throwable): Boolean
+
   final def retry[T](op: => Source[T, NotUsed], retryPolicy: RetryPolicy): Source[T, NotUsed] =
     op.recoverWithRetries(
       1, {
-        case exception @ (_: InternalServerErrorException | _: ItemCollectionSizeLimitExceededException |
-            _: LimitExceededException | _: ProvisionedThroughputExceededException | _: RequestLimitExceededException) =>
+        case exception if retryable(exception) =>
           if (retryPolicy.continue) {
             Source
               .single(())

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -1,19 +1,23 @@
 package org.scanamo
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
 import com.amazonaws.services.dynamodbv2.model._
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.{ Assertion, AsyncFreeSpec, BeforeAndAfterAll }
 import org.scanamo.ops.retrypolicy.{ RetryPolicy, WithRetry }
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
+import scala.util.control.{ NoStackTrace, NonFatal }
 
-class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry {
+class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry with Matchers {
   implicit val actorSystem: ActorSystem = ActorSystem()
   implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  override def retryable(throwable: Throwable): Boolean = ScanamoAlpakka.defaultRetryableCheck(throwable)
 
   override protected def afterAll(): Unit = {
     materializer.shutdown()
@@ -49,5 +53,37 @@ class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetr
     "Exponential delay AND maximum" in testcase(max(tries) && exponential(delay, factor))
     "Constant delay OR linear delay" in testcaseWithDelay(max(tries) && (fixed(delay) || linear(delay)))
     "Constant delay OR exponential delay" in testcaseWithDelay(max(tries) && (fixed(delay) || exponential(delay)))
+  }
+
+  "Retry Policies should check if exception is retryable" - {
+    "Perform retry if true" in {
+      var executedOnce = false
+      def op: Source[String, NotUsed] =
+        if (!executedOnce) {
+          executedOnce = true
+          Source.failed(new ProvisionedThroughputExceededException("Throughput Exceeded"))
+        } else {
+          Source.single("Success")
+        }
+
+      retry[String](op, RetryPolicy.once)
+        .runWith(Sink.head)
+        .map(x => x should equal("Success"))
+    }
+
+    "Skip retry if false" in {
+      var executedOnce = false
+      def op: Source[String, NotUsed] =
+        if (!executedOnce) {
+          executedOnce = true
+          Source.failed(new RuntimeException("Don't retry me"))
+        } else {
+          Source.single("Fail, this should not be retried")
+        }
+
+      retry[String](op, RetryPolicy.once).recover { case _: RuntimeException => "Success" }
+        .runWith(Sink.head)
+        .map(x => x should equal("Success"))
+    }
   }
 }


### PR DESCRIPTION
Previously it was hardcoded what `Throwable` should be retried (see
`WithRetry` trait).  However we are currently experiencing serious
issues with 500 from DynamoDB that we (in our case) would like to
retry.

With this pr, we pass a predicate `Throwable => Boolean` from
`ScanamoAlpakka` down to the `AlpakkaInterpreter` to implement the new
abstract `retryable` method from `WithRetry`.

By default, we use the same retry behavior as before, see
`ScanamoAlpakka.defaultRetryableCheck`

What do you think? 