### PR TITLE
Annotate return types

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -182,10 +182,11 @@ object DynamoFormat extends LowPriorityFormats {
     * Right(1970-01-01T00:00:00.000Z)
     * }}}
     */
-  def xmap[A, B](r: B => Either[DynamoReadError, A])(w: A => B)(implicit f: DynamoFormat[B]): DynamoFormat[A] = new DynamoFormat[A] {
-    final def read(item: DynamoValue): Either[DynamoReadError, A] = f.read(item).flatMap(r)
-    final def write(t: A): DynamoValue = f.write(w(t))
-  }
+  def xmap[A, B](r: B => Either[DynamoReadError, A])(w: A => B)(implicit f: DynamoFormat[B]): DynamoFormat[A] =
+    new DynamoFormat[A] {
+      final def read(item: DynamoValue): Either[DynamoReadError, A] = f.read(item).flatMap(r)
+      final def write(t: A): DynamoValue = f.write(w(t))
+    }
 
   /**
     * Returns a [[DynamoFormat]] for the case where `A` can always be converted `B`,
@@ -580,11 +581,12 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[OffsetDateTime].read(DynamoFormat[OffsetDateTime].write(x)) == Right(x)
     *  }}}
     */
-  implicit val offsetDateTimeFormat: DynamoFormat[OffsetDateTime] = DynamoFormat.coercedXmap[OffsetDateTime, String, DateTimeParseException](
-    OffsetDateTime.parse
-  )(
-    _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-  )
+  implicit val offsetDateTimeFormat: DynamoFormat[OffsetDateTime] =
+    DynamoFormat.coercedXmap[OffsetDateTime, String, DateTimeParseException](
+      OffsetDateTime.parse
+    )(
+      _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    )
 
   /**  Format for dealing with date-times with a time zone in the ISO-8601 calendar system.
     *  {{{
@@ -595,11 +597,12 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[ZonedDateTime].read(DynamoFormat[ZonedDateTime].write(x)) == Right(x)
     *  }}}
     */
-  implicit val zonedDateTimeFormat: DynamoFormat[ZonedDateTime] = DynamoFormat.coercedXmap[ZonedDateTime, String, DateTimeParseException](
-    ZonedDateTime.parse
-  )(
-    _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
-  )
+  implicit val zonedDateTimeFormat: DynamoFormat[ZonedDateTime] =
+    DynamoFormat.coercedXmap[ZonedDateTime, String, DateTimeParseException](
+      ZonedDateTime.parse
+    )(
+      _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+    )
 }
 
 private[scanamo] trait LowPriorityFormats {

--- a/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -163,10 +163,10 @@ object DynamoFormat extends LowPriorityFormats {
     * Right(UserId(Eric))
     * }}}
     */
-  def iso[A, B](r: B => A, w: A => B)(implicit f: DynamoFormat[B]) =
+  def iso[A, B](r: B => A, w: A => B)(implicit f: DynamoFormat[B]): DynamoFormat[A] =
     new DynamoFormat[A] {
-      final def read(item: DynamoValue) = f.read(item).map(r)
-      final def write(t: A) = f.write(w(t))
+      final def read(item: DynamoValue): Either[DynamoReadError, A] = f.read(item).map(r)
+      final def write(t: A): DynamoValue = f.write(w(t))
     }
 
   /**
@@ -182,9 +182,9 @@ object DynamoFormat extends LowPriorityFormats {
     * Right(1970-01-01T00:00:00.000Z)
     * }}}
     */
-  def xmap[A, B](r: B => Either[DynamoReadError, A])(w: A => B)(implicit f: DynamoFormat[B]) = new DynamoFormat[A] {
-    final def read(item: DynamoValue) = f.read(item).flatMap(r)
-    final def write(t: A) = f.write(w(t))
+  def xmap[A, B](r: B => Either[DynamoReadError, A])(w: A => B)(implicit f: DynamoFormat[B]): DynamoFormat[A] = new DynamoFormat[A] {
+    final def read(item: DynamoValue): Either[DynamoReadError, A] = f.read(item).flatMap(r)
+    final def write(t: A): DynamoValue = f.write(w(t))
   }
 
   /**
@@ -206,7 +206,7 @@ object DynamoFormat extends LowPriorityFormats {
     * Left(TypeCoercionError(java.lang.IllegalArgumentException: Invalid format: "Togtogdenoggleplop"))
     * }}}
     */
-  def coercedXmap[A, B: DynamoFormat, T >: Null <: Throwable: ClassTag](read: B => A)(write: A => B) =
+  def coercedXmap[A, B: DynamoFormat, T >: Null <: Throwable: ClassTag](read: B => A)(write: A => B): DynamoFormat[A] =
     xmap(coerce[B, A, T](read))(write)
 
   /**
@@ -216,7 +216,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit val stringFormat: DynamoFormat[String] = new DynamoFormat[String] {
-    final def read(av: DynamoValue) =
+    final def read(av: DynamoValue): Either[DynamoReadError, String] =
       if (av.isNull)
         Right("")
       else
@@ -237,14 +237,14 @@ object DynamoFormat extends LowPriorityFormats {
   implicit val booleanFormat: DynamoFormat[Boolean] = attribute(_.asBoolean, DynamoValue.fromBoolean, "BOOL")
 
   private def numFormat[N: Numeric](f: String => N): DynamoFormat[N] = new DynamoFormat[N] {
-    final def read(av: DynamoValue) =
+    final def read(av: DynamoValue): Either[DynamoReadError, N] =
       for {
         ns <- Either.fromOption(av.asNumber, NoPropertyOfType("N", av))
         transform = coerceNumber(f)
         n <- transform(ns)
       } yield n
 
-    final def write(n: N) = DynamoValue.fromNumber(n)
+    final def write(n: N): DynamoValue = DynamoValue.fromNumber(n)
   }
 
   /**
@@ -314,7 +314,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit val byteArrayFormat: DynamoFormat[Array[Byte]] =
-    xmap(coerceByteBuffer(_.array))(ByteBuffer.wrap(_))(byteBufferFormat)
+    xmap(coerceByteBuffer(_.array))(ByteBuffer.wrap)(byteBufferFormat)
 
   /**
     * {{{
@@ -350,7 +350,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit def seqFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Seq[T]] =
-    xmap[Seq[T], List[T]](l => Right(l.toSeq))(_.toList)
+    xmap[Seq[T], List[T]](l => Right(l))(_.toList)
 
   /**
     * {{{
@@ -376,7 +376,7 @@ object DynamoFormat extends LowPriorityFormats {
 
   private def numSetFormat[T: Numeric](r: String => Either[DynamoReadError, T]): DynamoFormat[Set[T]] =
     new DynamoFormat[Set[T]] {
-      final def read(av: DynamoValue) =
+      final def read(av: DynamoValue): Either[DynamoReadError, Set[T]] =
         if (av.isNull)
           Right(Set.empty[T])
         else
@@ -386,7 +386,7 @@ object DynamoFormat extends LowPriorityFormats {
           } yield set.toSet
 
       // Set types cannot be empty
-      final def write(t: Set[T]) =
+      final def write(t: Set[T]): DynamoValue =
         if (t.isEmpty)
           DynamoValue.nil
         else
@@ -489,14 +489,14 @@ object DynamoFormat extends LowPriorityFormats {
     */
   implicit val stringSetFormat: DynamoFormat[Set[String]] =
     new DynamoFormat[Set[String]] {
-      final def read(av: DynamoValue) =
+      final def read(av: DynamoValue): Either[DynamoReadError, Set[String]] =
         if (av.isNull)
           Right(Set.empty)
         else
           Either.fromOption(av.asArray.flatMap(_.asStringArray).map(_.toSet), NoPropertyOfType("SS", av))
 
       // Set types cannot be empty
-      final def write(t: Set[String]) =
+      final def write(t: Set[String]): DynamoValue =
         if (t.isEmpty)
           DynamoValue.nil
         else
@@ -538,8 +538,8 @@ object DynamoFormat extends LowPriorityFormats {
     * true
     * }}}
     */
-  implicit def optionFormat[T](implicit f: DynamoFormat[T]) = new DynamoFormat[Option[T]] {
-    final def read(av: DynamoValue) =
+  implicit def optionFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Option[T]] = new DynamoFormat[Option[T]] {
+    final def read(av: DynamoValue): Either[DynamoReadError, Option[T]] =
       if (av.isNull)
         Right(None)
       else
@@ -552,7 +552,7 @@ object DynamoFormat extends LowPriorityFormats {
     * This ensures that if, for instance, you specify an update with Some(5) rather
     * than making the type of `Option` explicit, it doesn't fall back to auto-derivation
     */
-  implicit def someFormat[T](implicit f: DynamoFormat[T]) = new DynamoFormat[Some[T]] {
+  implicit def someFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Some[T]] = new DynamoFormat[Some[T]] {
     def read(av: DynamoValue): Either[DynamoReadError, Some[T]] =
       Option(av).map(f.read(_).map(Some(_))).getOrElse(Left[DynamoReadError, Some[T]](MissingProperty))
 
@@ -568,7 +568,7 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[Instant].read(DynamoFormat[Instant].write(x)) == Right(x)
     *  }}}
     */
-  implicit val instantAsLongFormat =
+  implicit val instantAsLongFormat: DynamoFormat[Instant] =
     DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](x => Instant.ofEpochMilli(x))(x => x.toEpochMilli)
 
   /**  Format for dealing with date-times with an offset from UTC.
@@ -580,7 +580,7 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[OffsetDateTime].read(DynamoFormat[OffsetDateTime].write(x)) == Right(x)
     *  }}}
     */
-  implicit val offsetDateTimeFormat = DynamoFormat.coercedXmap[OffsetDateTime, String, DateTimeParseException](
+  implicit val offsetDateTimeFormat: DynamoFormat[OffsetDateTime] = DynamoFormat.coercedXmap[OffsetDateTime, String, DateTimeParseException](
     OffsetDateTime.parse
   )(
     _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
@@ -595,7 +595,7 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[ZonedDateTime].read(DynamoFormat[ZonedDateTime].write(x)) == Right(x)
     *  }}}
     */
-  implicit val zonedDateTimeFormat = DynamoFormat.coercedXmap[ZonedDateTime, String, DateTimeParseException](
+  implicit val zonedDateTimeFormat: DynamoFormat[ZonedDateTime] = DynamoFormat.coercedXmap[ZonedDateTime, String, DateTimeParseException](
     ZonedDateTime.parse
   )(
     _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)

--- a/scanamo/src/test/scala/org/scanamo/generic/SemiAutoDerivationTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/generic/SemiAutoDerivationTest.scala
@@ -1,6 +1,6 @@
 package org.scanamo.generic
 
-import org.scanamo.{DynamoFormat, DynamoValue}
+import org.scanamo.{ DynamoFormat, DynamoValue }
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/scanamo/src/test/scala/org/scanamo/generic/SemiAutoDerivationTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/generic/SemiAutoDerivationTest.scala
@@ -1,6 +1,6 @@
 package org.scanamo.generic
 
-import org.scanamo.DynamoFormat
+import org.scanamo.{DynamoFormat, DynamoValue}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -20,7 +20,7 @@ class SemiAutoDerivationTest extends AnyFunSuite with Matchers {
       |""".stripMargin should compile
   }
 
-  def write[T](t: T)(implicit f: DynamoFormat[T]) = f.write(t)
+  def write[T](t: T)(implicit f: DynamoFormat[T]): DynamoValue = f.write(t)
 }
 
 case class Person(name: String, age: Int)


### PR DESCRIPTION
Some methods did not have return type
annotations (e.g. DynamoFormat.xmap) which meant that something
inference / tooltips would show a ugly type instead.  Fixed by adding
the annotations.