### PR TITLE
Add DynamoFormat#{xmap,coercedXmap,iso}

### DIFF
--- a/joda/src/main/scala/org/scanamo/joda/JodaFormats.scala
+++ b/joda/src/main/scala/org/scanamo/joda/JodaFormats.scala
@@ -32,7 +32,7 @@ object JodaFormats {
     *  }}}
     */
   implicit val jodaInstantAsLongFormat =
-    DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](new Instant(_))(x => x.getMillis)
+    DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](new Instant(_), x => x.getMillis)
 
   /**
     *  Convenient, readable format for Joda DateTime, but requires that all dates serialised
@@ -50,8 +50,7 @@ object JodaFormats {
     *  }}}
     */
   implicit val jodaStringFormat = DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](
-    DateTime.parse(_)
-  )(
+    DateTime.parse,
     _.toString
   )
 }

--- a/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -89,6 +89,11 @@ trait DynamoFormat[T] {
   def read(av: DynamoValue): Either[DynamoReadError, T]
   def read(av: AttributeValue): Either[DynamoReadError, T] = read(DynamoValue.fromAttributeValue(av))
   def write(t: T): DynamoValue
+
+  def iso[U](r: T => U, w: U => T): DynamoFormat[U] = DynamoFormat.iso(r, w)(this)
+  def xmap[U](r: T => Either[DynamoReadError, U])(w: U => T): DynamoFormat[U] = DynamoFormat.xmap(r)(w)(this)
+  def coercedXmap[U](read: T => U)(write: U => T): DynamoFormat[U] =
+    DynamoFormat.coercedXmap(read)(write)(this, implicitly)
 }
 
 object DynamoFormat extends LowPriorityFormats {

--- a/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -91,9 +91,9 @@ trait DynamoFormat[T] {
   def write(t: T): DynamoValue
 
   def iso[U](r: T => U, w: U => T): DynamoFormat[U] = DynamoFormat.iso(r, w)(this)
-  def xmap[U](r: T => Either[DynamoReadError, U])(w: U => T): DynamoFormat[U] = DynamoFormat.xmap(r)(w)(this)
-  def coercedXmap[U](read: T => U)(write: U => T): DynamoFormat[U] =
-    DynamoFormat.coercedXmap(read)(write)(this, implicitly)
+  def xmap[U](r: T => Either[DynamoReadError, U], w: U => T): DynamoFormat[U] = DynamoFormat.xmap(r, w)(this)
+  def coercedXmap[U](read: T => U, write: U => T): DynamoFormat[U] =
+    DynamoFormat.coercedXmap(read, write)(this, implicitly)
 }
 
 object DynamoFormat extends LowPriorityFormats {
@@ -180,18 +180,17 @@ object DynamoFormat extends LowPriorityFormats {
     *
     * >>> implicit val jodaLongFormat = DynamoFormat.xmap[DateTime, Long](
     * ...   l => Right(new DateTime(l).withZone(DateTimeZone.UTC))
-    * ... )(
+    * ... ,
     * ...   _.withZone(DateTimeZone.UTC).getMillis
     * ... )
     * >>> DynamoFormat[DateTime].read(DynamoValue.fromNumber(0L))
     * Right(1970-01-01T00:00:00.000Z)
     * }}}
     */
-  def xmap[A, B](r: B => Either[DynamoReadError, A])(w: A => B)(implicit f: DynamoFormat[B]): DynamoFormat[A] =
-    new DynamoFormat[A] {
-      final def read(item: DynamoValue): Either[DynamoReadError, A] = f.read(item).flatMap(r)
-      final def write(t: A): DynamoValue = f.write(w(t))
-    }
+  def xmap[A, B](r: B => Either[DynamoReadError, A], w: A => B)(implicit f: DynamoFormat[B]) = new DynamoFormat[A] {
+    final def read(item: DynamoValue) = f.read(item).flatMap(r)
+    final def write(t: A) = f.write(w(t))
+  }
 
   /**
     * Returns a [[DynamoFormat]] for the case where `A` can always be converted `B`,
@@ -202,7 +201,7 @@ object DynamoFormat extends LowPriorityFormats {
     *
     * >>> val jodaStringFormat = DynamoFormat.coercedXmap[LocalDate, String, IllegalArgumentException](
     * ...   LocalDate.parse
-    * ... )(
+    * ... ,
     * ...   _.toString
     * ... )
     * >>> jodaStringFormat.read(jodaStringFormat.write(new LocalDate(2007, 8, 18)))
@@ -212,8 +211,8 @@ object DynamoFormat extends LowPriorityFormats {
     * Left(TypeCoercionError(java.lang.IllegalArgumentException: Invalid format: "Togtogdenoggleplop"))
     * }}}
     */
-  def coercedXmap[A, B: DynamoFormat, T >: Null <: Throwable: ClassTag](read: B => A)(write: A => B): DynamoFormat[A] =
-    xmap(coerce[B, A, T](read))(write)
+  def coercedXmap[A, B: DynamoFormat, T >: Null <: Throwable: ClassTag](read: B => A, write: A => B) =
+    xmap(coerce[B, A, T](read), write)
 
   /**
     * {{{
@@ -320,7 +319,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit val byteArrayFormat: DynamoFormat[Array[Byte]] =
-    xmap(coerceByteBuffer(_.array))(ByteBuffer.wrap)(byteBufferFormat)
+    xmap(coerceByteBuffer(_.array), ByteBuffer.wrap)(byteBufferFormat)
 
   /**
     * {{{
@@ -330,7 +329,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit val uuidFormat: DynamoFormat[UUID] =
-    coercedXmap[UUID, String, IllegalArgumentException](UUID.fromString)(_.toString)
+    coercedXmap[UUID, String, IllegalArgumentException](UUID.fromString, _.toString)
 
   implicit val javaListFormat: DynamoFormat[List[DynamoValue]] =
     attribute({ dv =>
@@ -346,7 +345,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit def listFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[List[T]] =
-    xmap[List[T], List[DynamoValue]](_.traverse(f.read))(_.map(f.write))(javaListFormat)
+    xmap[List[T], List[DynamoValue]](_.traverse(f.read), _.map(f.write))(javaListFormat)
 
   /**
     * {{{
@@ -356,7 +355,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit def seqFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Seq[T]] =
-    xmap[Seq[T], List[T]](l => Right(l))(_.toList)
+    xmap[Seq[T], List[T]](l => Right(l.toSeq), _.toList)
 
   /**
     * {{{
@@ -366,7 +365,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit def vectorFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Vector[T]] =
-    xmap[Vector[T], List[DynamoValue]](_.toVector.traverse(f.read))(_.map(f.write).toList)(javaListFormat)
+    xmap[Vector[T], List[DynamoValue]](_.toVector.traverse(f.read), _.map(f.write).toList)(javaListFormat)
 
   /**
     * {{{
@@ -376,9 +375,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit def arrayFormat[T: ClassTag](implicit f: DynamoFormat[T]): DynamoFormat[Array[T]] =
-    xmap[Array[T], List[DynamoValue]](_.traverse(f.read).map(_.toArray))(
-      _.map(f.write).toList
-    )(javaListFormat)
+    xmap[Array[T], List[DynamoValue]](_.traverse(f.read).map(_.toArray), _.map(f.write).toList)(javaListFormat)
 
   private def numSetFormat[T: Numeric](r: String => Either[DynamoReadError, T]): DynamoFormat[Set[T]] =
     new DynamoFormat[Set[T]] {
@@ -529,7 +526,7 @@ object DynamoFormat extends LowPriorityFormats {
     * }}}
     */
   implicit def mapFormat[V](implicit f: DynamoFormat[V]): DynamoFormat[Map[String, V]] =
-    xmap[Map[String, V], DynamoObject](_.toMap[V])(m => DynamoObject(m.toSeq: _*))(javaMapFormat)
+    xmap[Map[String, V], DynamoObject](_.toMap[V], m => DynamoObject(m.toSeq: _*))(javaMapFormat)
 
   /**
     * {{{
@@ -574,8 +571,8 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[Instant].read(DynamoFormat[Instant].write(x)) == Right(x)
     *  }}}
     */
-  implicit val instantAsLongFormat: DynamoFormat[Instant] =
-    DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](x => Instant.ofEpochMilli(x))(x => x.toEpochMilli)
+  implicit val instantAsLongFormat =
+    DynamoFormat.coercedXmap[Instant, Long, ArithmeticException](x => Instant.ofEpochMilli(x), x => x.toEpochMilli)
 
   /**  Format for dealing with date-times with an offset from UTC.
     *  {{{
@@ -586,12 +583,10 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[OffsetDateTime].read(DynamoFormat[OffsetDateTime].write(x)) == Right(x)
     *  }}}
     */
-  implicit val offsetDateTimeFormat: DynamoFormat[OffsetDateTime] =
-    DynamoFormat.coercedXmap[OffsetDateTime, String, DateTimeParseException](
-      OffsetDateTime.parse
-    )(
-      _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-    )
+  implicit val offsetDateTimeFormat = DynamoFormat.coercedXmap[OffsetDateTime, String, DateTimeParseException](
+    OffsetDateTime.parse,
+    _.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  )
 
   /**  Format for dealing with date-times with a time zone in the ISO-8601 calendar system.
     *  {{{
@@ -602,12 +597,10 @@ object DynamoFormat extends LowPriorityFormats {
     *      | DynamoFormat[ZonedDateTime].read(DynamoFormat[ZonedDateTime].write(x)) == Right(x)
     *  }}}
     */
-  implicit val zonedDateTimeFormat: DynamoFormat[ZonedDateTime] =
-    DynamoFormat.coercedXmap[ZonedDateTime, String, DateTimeParseException](
-      ZonedDateTime.parse
-    )(
-      _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
-    )
+  implicit val zonedDateTimeFormat = DynamoFormat.coercedXmap[ZonedDateTime, String, DateTimeParseException](
+    ZonedDateTime.parse,
+    _.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+  )
 }
 
 private[scanamo] trait LowPriorityFormats {


### PR DESCRIPTION
Adds the `xmap`/`coercedXmap`/`iso` method to all `DynamoFormat`, being essentially a
shortcut to the static `DynamoFormat.{xmap,coercedXmap,iso}`

Besides convenience, the type-inference is also much better.