### PR TITLE
Temp Fix #589 - "Throughput exceeds the current capacity of your table or …

### DIFF
--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -21,6 +21,7 @@ import akka.NotUsed
 import akka.stream.alpakka.dynamodb.DynamoClient
 import akka.stream.scaladsl.{ Sink, Source }
 import com.amazonaws.services.dynamodbv2.model.{
+  AmazonDynamoDBException,
   InternalServerErrorException,
   ItemCollectionSizeLimitExceededException,
   LimitExceededException,
@@ -71,7 +72,8 @@ object ScanamoAlpakka extends AlpakkaInstances {
     case _: InternalServerErrorException | _: ItemCollectionSizeLimitExceededException | _: LimitExceededException |
         _: ProvisionedThroughputExceededException | _: RequestLimitExceededException =>
       true
-    case _ => false
+    case e: AmazonDynamoDBException if e.getErrorCode.contains("ThrottlingException") => true
+    case _                                                                            => false
   }
 }
 


### PR DESCRIPTION
…index" when using on-demand mode with Alpakka client.

I think I found out the cause for #589: The exception thrown is of the base type `AmazonDynamoDBException` instead of one of the subtypes handled in `ScanamoAlpakka.defaultRetryableCheck`.

The fix is not pretty, but easy enough.

Would you consider merging this - and including it in another release?

Resolves #589 