### PR TITLE
AWS SDK changes are too important

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,1 @@
-updates.ignore = [{ groupId = "com.amazonaws", artifactId = "aws-java-sdk-dynamodb" }]
+


### PR DESCRIPTION
Unignore SDK updates, it seems they do break the underlying format from time to time, which is probably why #593 happened.