### PR TITLE
Drop 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,5 @@ jobs:
 
     # Cross-build
     - <<: *test
-      scala: 2.11.12
-      name: "Tests for 2.11"
-
-    # Cross-build
-    - <<: *test
       scala: 2.13.1
       name: "Tests for 2.13"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,5 +35,5 @@ Releasing
 ---------
 
 `release cross` from the SBT prompt should publish an artifact to Maven 
-Central for both Scala 2.11 and Scala 2.12. It will also attempt to update
+Central for both Scala 2.12 and Scala 2.13. It will also attempt to update
 the documentation website at http://www.scanamo.org/ with the latest scaladoc.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 libraryDependencies += "org.scanamo" %% "scanamo" % "1.0.0-M10"
 ```
 
-Scanamo is published for Scala 2.13, Scala 2.12, and Scala 2.11.
+Scanamo is published for Scala 2.13 and Scala 2.12.
 
 Basic Usage
 -----------
@@ -69,6 +69,6 @@ language governing permissions and limitations under the License.
 [Badge-Codecov]: https://coveralls.io/repos/github/scanamo/scanamo/badge.svg?branch=master "Codecov"
 [Badge-IsItMaintained]: http://isitmaintained.com/badge/resolution/scanamo/scanamo.svg "Average time to resolve an issue"
 [Badge-Scaladex]: https://index.scala-lang.org/count.svg?q=dependencies:scanamo/scanamo&subject=scaladex "Scaladex"
-[Badge-MavenReleases]: https://maven-badges.herokuapp.com/maven-central/org.scanamo/scanamo_2.11/badge.svg "Maven Releases"
+[Badge-MavenReleases]: https://maven-badges.herokuapp.com/maven-central/org.scanamo/scanamo_2.12/badge.svg "Maven Releases"
 [Badge-Travis]: https://travis-ci.org/scanamo/scanamo.svg?branch=master "Travis CI"
 [Badge-Gitter]: https://badges.gitter.im/scanamo/scanamo.svg "Gitter chat"

--- a/build.sbt
+++ b/build.sbt
@@ -112,8 +112,8 @@ lazy val scanamo = (project in file("scanamo"))
   .settings(
     libraryDependencies ++= Seq(
       awsDynamoDB,
-      "org.typelevel" %% "cats-free" % catsVersion,
-      "com.propensive" %% "magnolia" % "0.12.7",
+      "org.typelevel"  %% "cats-free" % catsVersion,
+      "com.propensive" %% "magnolia"  % "0.12.7",
       // Use Joda for custom conversion example
       "org.joda"          % "joda-convert"              % "2.2.1"       % Provided,
       "joda-time"         % "joda-time"                 % "2.10.5"      % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion in ThisBuild := "2.12.10"
-crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.10", "2.13.1")
+crossScalaVersions in ThisBuild := Seq("2.12.10", "2.13.1")
 
 val catsVersion = "2.0.0"
 val catsEffectVersion = "2.0.0"
@@ -43,11 +43,6 @@ def extraOptions(scalaVersion: String) =
         "-Ywarn-unused:imports",
         "-opt:l:inline",
         "-opt-inline-from:<source>"
-      ) ++ std2xOptions
-    case Some((2, 11)) =>
-      Seq(
-        "-Xexperimental",
-        "-Ywarn-unused-import"
       ) ++ std2xOptions
     case _ => Seq.empty
   }
@@ -94,14 +89,6 @@ addCommandAlias("publishMicrosite", "docs/publishMicrosite")
 
 val awsDynamoDB = "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.732"
 
-def customDeps(scalaVersion: String) =
-  CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, 11)) =>
-      Seq("com.propensive" %% "magnolia" % "0.10.0")
-    case _ =>
-      Seq("com.propensive" %% "magnolia" % "0.12.7")
-  }
-
 lazy val refined = (project in file("refined"))
   .settings(
     commonSettings,
@@ -126,13 +113,14 @@ lazy val scanamo = (project in file("scanamo"))
     libraryDependencies ++= Seq(
       awsDynamoDB,
       "org.typelevel" %% "cats-free" % catsVersion,
+      "com.propensive" %% "magnolia" % "0.12.7",
       // Use Joda for custom conversion example
       "org.joda"          % "joda-convert"              % "2.2.1"       % Provided,
       "joda-time"         % "joda-time"                 % "2.10.5"      % Test,
       "org.scalatest"     %% "scalatest"                % "3.1.1"       % Test,
       "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test,
       "org.scalacheck"    %% "scalacheck"               % "1.14.3"      % Test
-    ) ++ customDeps(scalaVersion.value)
+    )
   )
   .dependsOn(testkit % "test->test")
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,7 +19,7 @@ Quick start
 
 Note: the `LocalDynamoDB` object is provided by the `scanamo-testkit` package.
 
-Scanamo is published for Scala 2.13, 2.12 and 2.11 to Maven Central, so just add the following to your `build.sbt`:
+Scanamo is published for Scala 2.13 and 2.12 to Maven Central, so just add the following to your `build.sbt`:
 
 ```sbt
 libraryDependencies += "org.scanamo" %% "scanamo" % "@VERSION@"
@@ -68,7 +68,7 @@ Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/
 [Badge-Codecov]: https://coveralls.io/repos/github/guardian/scanamo/badge.svg?branch=master "Codecov"
 [Badge-IsItMaintained]: http://isitmaintained.com/badge/resolution/scanamo/scanamo.svg "Average time to resolve an issue"
 [Badge-Scaladex]: https://index.scala-lang.org/count.svg?q=dependencies:scanamo/scanamo&subject=scaladex "Scaladex"
-[Badge-MavenReleases]: https://maven-badges.herokuapp.com/maven-central/com.gu/scanamo_2.11/badge.svg "Maven Releases"
+[Badge-MavenReleases]: https://maven-badges.herokuapp.com/maven-central/com.gu/scanamo_2.12/badge.svg "Maven Releases"
 [Badge-Travis]: https://travis-ci.org/scanamo/scanamo.svg?branch=master "Travis CI"
 [Badge-Gitter]: https://badges.gitter.im/guardian/scanamo.svg "Gitter chat"
 


### PR DESCRIPTION
Both cats and magnolia are doing it, but this is an overall move in the library ecosystem. I'm not particularly for or against, in the sense that I'd like to remove at least the cats dependency in the future – we can do without magnolia/shapeless starting from Scala 3.