### PR TITLE
Upgrade to AWS SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ scala> import org.scanamo.syntax._
 scala> import org.scanamo.generic.auto._
  
 scala> val client = LocalDynamoDB.client()
-scala> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+scala> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 scala> val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("name" -> S)
 
 scala> case class Farm(animals: List[String])

--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -20,7 +20,7 @@ import cats.{ ~>, Monad }
 import akka.NotUsed
 import akka.stream.alpakka.dynamodb.DynamoClient
 import akka.stream.scaladsl.{ Sink, Source }
-import com.amazonaws.services.dynamodbv2.model.{
+import software.amazon.awssdk.services.dynamodb.model.{
   AmazonDynamoDBException,
   InternalServerErrorException,
   ItemCollectionSizeLimitExceededException,

--- a/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
+++ b/alpakka/src/main/scala/org/scanamo/ScanamoAlpakka.scala
@@ -18,10 +18,11 @@ package org.scanamo
 
 import cats.{ ~>, Monad }
 import akka.NotUsed
-import akka.stream.alpakka.dynamodb.DynamoClient
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{
-  AmazonDynamoDBException,
+  DynamoDbException,
   InternalServerErrorException,
   ItemCollectionSizeLimitExceededException,
   LimitExceededException,
@@ -43,10 +44,12 @@ import scala.concurrent.Future
   * Moreover, the interface returns either a [[scala.concurrent.Future]] or [[akka.stream.scaladsl.Source]]
   * based on the kind of execution used.
   */
-class ScanamoAlpakka private (client: DynamoClient, retryPolicy: RetryPolicy, isRetryable: Throwable => Boolean) {
+class ScanamoAlpakka private (client: DynamoDbAsyncClient, retryPolicy: RetryPolicy, isRetryable: Throwable => Boolean)(
+  implicit mat: Materializer
+) {
   import ScanamoAlpakka._
 
-  final private val interpreter = new AlpakkaInterpreter(client, retryPolicy, isRetryable)
+  final private val interpreter = new AlpakkaInterpreter(retryPolicy, isRetryable)(client, mat)
 
   def exec[A](op: ScanamoOps[A]): Alpakka[A] =
     run(op)
@@ -55,7 +58,7 @@ class ScanamoAlpakka private (client: DynamoClient, retryPolicy: RetryPolicy, is
     op.foldMap(interpreter andThen hoist)
 
   def execFuture[A](op: ScanamoOps[A]): Future[A] =
-    run(op).runWith(Sink.head[A])(client.materializer)
+    run(op).runWith(Sink.head[A])
 
   private def run[A](op: ScanamoOps[A]): Alpakka[A] =
     op.foldMap(interpreter)
@@ -63,18 +66,18 @@ class ScanamoAlpakka private (client: DynamoClient, retryPolicy: RetryPolicy, is
 
 object ScanamoAlpakka extends AlpakkaInstances {
   def apply(
-    client: DynamoClient,
+    client: DynamoDbAsyncClient,
     retrySettings: RetryPolicy = RetryPolicy.max(3),
     isRetryable: Throwable => Boolean = defaultRetryableCheck
-  ): ScanamoAlpakka = new ScanamoAlpakka(client, retrySettings, isRetryable)
+  )(implicit mat: Materializer): ScanamoAlpakka = new ScanamoAlpakka(client, retrySettings, isRetryable)
 
   def defaultRetryableCheck(throwable: Throwable): Boolean = throwable match {
     case _: InternalServerErrorException | _: ItemCollectionSizeLimitExceededException | _: LimitExceededException |
         _: ProvisionedThroughputExceededException | _: RequestLimitExceededException =>
       true
-    case e: AmazonDynamoDBException
-        if e.getErrorCode.contains("ThrottlingException") |
-          e.getErrorCode.contains("InternalFailure") =>
+    case e: DynamoDbException
+        if e.awsErrorDetails.errorCode.contains("ThrottlingException") |
+          e.awsErrorDetails.errorCode.contains("InternalFailure") =>
       true
     case _ => false
   }

--- a/alpakka/src/main/scala/org/scanamo/ops/AlpakkaInterpreter.scala
+++ b/alpakka/src/main/scala/org/scanamo/ops/AlpakkaInterpreter.scala
@@ -18,7 +18,7 @@ package org.scanamo.ops
 
 import cats.~>
 import cats.syntax.either._
-import com.amazonaws.services.dynamodbv2.model.{ Put => _, Get => _, Delete => _, Update => _, _ }
+import software.amazon.awssdk.services.dynamodb.model.{ Put => _, Get => _, Delete => _, Update => _, _ }
 import org.scanamo.ops.retrypolicy._
 
 import akka.stream.alpakka.dynamodb.{ AwsOp, AwsPagedOp, DynamoAttributes, DynamoClient }
@@ -48,13 +48,13 @@ private[scanamo] class AlpakkaInterpreter(client: DynamoClient,
       case BatchGet(req)   => run(req)
       case ConditionalDelete(req) =>
         run(JavaRequests.delete(req))
-          .map(Either.right[ConditionalCheckFailedException, DeleteItemResult])
+          .map(Either.right[ConditionalCheckFailedException, DeleteItemResponse])
           .recover {
             case e: ConditionalCheckFailedException => Either.left(e)
           }
       case ConditionalPut(req) =>
         run(JavaRequests.put(req))
-          .map(Either.right[ConditionalCheckFailedException, PutItemResult])
+          .map(Either.right[ConditionalCheckFailedException, PutItemResponse])
           .recover {
             case e: ConditionalCheckFailedException => Either.left(e)
           }

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -6,12 +6,13 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
 import software.amazon.awssdk.services.dynamodb.model._
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{ Assertion, AsyncFreeSpec, BeforeAndAfterAll }
+import org.scalatest.{ Assertion, BeforeAndAfterAll }
+import org.scalatest.freespec.AsyncFreeSpec
 import org.scanamo.ops.retrypolicy.{ RetryPolicy, WithRetry }
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import scala.util.control.{ NoStackTrace, NonFatal }
+import scala.util.control.NonFatal
 
 class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetry with Matchers {
   implicit val actorSystem: ActorSystem = ActorSystem()
@@ -29,7 +30,7 @@ class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetr
   private val factor = 1.2
 
   private def testcase(policy: RetryPolicy): Future[Assertion] =
-    retry(Source.failed(new LimitExceededException("Limit Exceeded")), policy).recover {
+    retry(Source.failed(LimitExceededException.builder.message("Limit Exceeded").build), policy).recover {
       case NonFatal(t) => t
     }.runWith(Sink.seq)
       .map(x => assert(x.size == 1))
@@ -61,7 +62,7 @@ class RetryPolicySpec extends AsyncFreeSpec with BeforeAndAfterAll with WithRetr
       def op: Source[String, NotUsed] =
         if (!executedOnce) {
           executedOnce = true
-          Source.failed(new ProvisionedThroughputExceededException("Throughput Exceeded"))
+          Source.failed(ProvisionedThroughputExceededException.builder.message("Throughput Exceeded").build)
         } else {
           Source.single("Success")
         }

--- a/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/RetryPolicySpec.scala
@@ -4,7 +4,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{ Assertion, AsyncFreeSpec, BeforeAndAfterAll }
 import org.scanamo.ops.retrypolicy.{ RetryPolicy, WithRetry }

--- a/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
@@ -2,8 +2,6 @@ package org.scanamo
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.alpakka.dynamodb.{ DynamoClient, DynamoSettings }
-import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scanamo.query._
 import org.scanamo.syntax._
@@ -11,27 +9,22 @@ import org.scanamo.fixtures._
 import org.scanamo.generic.auto._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ BeforeAndAfterAll, FunSpecLike, Matchers }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import cats.implicits._
 import org.scanamo.ops.ScanamoOps
 
-class ScanamoAlpakkaSpec extends FunSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
+class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
   implicit val system = ActorSystem("scanamo-alpakka")
-  val client = LocalDynamoDB.client()
 
   implicit val materializer = ActorMaterializer.create(system)
   implicit val executor = system.dispatcher
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(10, Seconds), interval = Span(15, Millis))
-  val dummyCreds = new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "credentials"))
-  val alpakkaClient = DynamoClient(
-    DynamoSettings(region = "", host = "localhost")
-      .withPort(8042)
-      .withParallelism(2)
-      .withCredentialsProvider(dummyCreds)
-  )
 
-  val scanamo = ScanamoAlpakka(alpakkaClient)
+  val client = LocalDynamoDB.client()
+  val scanamo = ScanamoAlpakka(client)
 
   override protected def afterAll(): Unit = {
     system.terminate()

--- a/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.dynamodb.{ DynamoClient, DynamoSettings }
 import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.fixtures._

--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,8 @@ lazy val testkit = (project in file("testkit"))
     publishingSettings,
     name := "scanamo-testkit",
     libraryDependencies ++= Seq(
-      awsDynamoDB
+      awsDynamoDB,
+      "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
     )
   )
 
@@ -187,7 +188,7 @@ lazy val alpakka = (project in file("alpakka"))
     libraryDependencies ++= Seq(
       awsDynamoDB,
       "org.typelevel"      %% "cats-free"                    % catsVersion,
-      "com.lightbend.akka" %% "akka-stream-alpakka-dynamodb" % "1.1.2",
+      "com.lightbend.akka" %% "akka-stream-alpakka-dynamodb" % "2.0.0",
       "org.scalatest"      %% "scalatest"                    % "3.1.2" % Test,
       "org.scalacheck"     %% "scalacheck"                   % "1.14.3" % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val root = (project in file("."))
 addCommandAlias("makeMicrosite", "docs/makeMicrosite")
 addCommandAlias("publishMicrosite", "docs/publishMicrosite")
 
-val awsDynamoDB = "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.784"
+val awsDynamoDB = "software.amazon.awssdk" % "dynamodb" % "2.13.18"
 
 lazy val refined = (project in file("refined"))
   .settings(
@@ -112,8 +112,9 @@ lazy val scanamo = (project in file("scanamo"))
   .settings(
     libraryDependencies ++= Seq(
       awsDynamoDB,
-      "org.typelevel"  %% "cats-free" % catsVersion,
-      "com.propensive" %% "magnolia"  % "0.12.7",
+      "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
+      "org.typelevel"          %% "cats-free"          % catsVersion,
+      "com.propensive"         %% "magnolia"           % "0.12.7",
       // Use Joda for custom conversion example
       "org.joda"          % "joda-convert"              % "2.2.1"       % Provided,
       "joda-time"         % "joda-time"                 % "2.10.6"      % Test,

--- a/cats/src/main/scala/org/scanamo/ScanamoCats.scala
+++ b/cats/src/main/scala/org/scanamo/ScanamoCats.scala
@@ -18,12 +18,12 @@ package org.scanamo
 
 import cats.{ ~>, Monad }
 import cats.effect.Async
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import fs2.Stream
 import monix.tail.Iterant
 import org.scanamo.ops.{ CatsInterpreter, ScanamoOps, ScanamoOpsT }
 
-class ScanamoCats[F[_]: Async](client: AmazonDynamoDBAsync) {
+class ScanamoCats[F[_]: Async](client: DynamoDbAsyncClient) {
   final private val interpreter = new CatsInterpreter(client)
 
   final def exec[A](op: ScanamoOps[A]): F[A] = op.foldMap(interpreter)
@@ -33,7 +33,7 @@ class ScanamoCats[F[_]: Async](client: AmazonDynamoDBAsync) {
 }
 
 object ScanamoCats {
-  def apply[F[_]: Async](client: AmazonDynamoDBAsync): ScanamoCats[F] = new ScanamoCats(client)
+  def apply[F[_]: Async](client: DynamoDbAsyncClient): ScanamoCats[F] = new ScanamoCats(client)
 
   def ToIterant[F[_]: Async]: F ~> Iterant[F, ?] =
     new (F ~> Iterant[F, ?]) {

--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -19,32 +19,27 @@ package org.scanamo.ops
 import cats.effect.Async
 import cats.implicits._
 import cats.~>
-import software.amazon.awssdk.services.dynamodb.model.DynamoDbRequest
-import com.amazonaws.handlers.AsyncHandler
+import java.util.concurrent.CompletableFuture
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{ Put => _, Delete => _, Update => _, Get => _, _ }
 
 class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
-  final private def eff[A <: DynamoDbRequest, B](
-    f: (A, AsyncHandler[A, B]) => java.util.concurrent.Future[B],
-    req: A
-  ): F[B] =
+  final private def eff[A <: AnyRef](fut: => CompletableFuture[A]): F[A] =
     F.async { cb =>
-      val handler = new AsyncHandler[A, B] {
-        def onError(exception: Exception): Unit =
-          cb(Left(exception))
-
-        def onSuccess(request: A, result: B): Unit =
-          cb(Right(result))
+      fut.handle[Unit] { (a, x) =>
+        if (a eq null)
+          cb(Left(x))
+        else
+          cb(Right(a))
       }
-      val _ = f(req, handler)
+      ()
     }
 
   override def apply[A](fa: ScanamoOpsA[A]): F[A] = fa match {
     case Put(req) =>
-      eff(client.putItemAsync, JavaRequests.put(req))
+      eff(client.putItem(JavaRequests.put(req)))
     case ConditionalPut(req) =>
-      eff(client.putItemAsync, JavaRequests.put(req)).attempt
+      eff(client.putItem(JavaRequests.put(req))).attempt
         .flatMap(
           _.fold(
             _ match {
@@ -55,11 +50,11 @@ class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) e
           )
         )
     case Get(req) =>
-      eff(client.getItemAsync, req)
+      eff(client.getItem(req))
     case Delete(req) =>
-      eff(client.deleteItemAsync, JavaRequests.delete(req))
+      eff(client.deleteItem(JavaRequests.delete(req)))
     case ConditionalDelete(req) =>
-      eff(client.deleteItemAsync, JavaRequests.delete(req)).attempt
+      eff(client.deleteItem(JavaRequests.delete(req))).attempt
         .flatMap(
           _.fold(
             _ match {
@@ -70,27 +65,18 @@ class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) e
           )
         )
     case Scan(req) =>
-      eff(client.scanAsync, JavaRequests.scan(req))
+      eff(client.scan(JavaRequests.scan(req)))
     case Query(req) =>
-      eff(client.queryAsync, JavaRequests.query(req))
+      eff(client.query(JavaRequests.query(req)))
     // Overloading means we need explicit parameter types here
     case BatchWrite(req) =>
-      eff(
-        client.batchWriteItemAsync(
-          _: BatchWriteItemRequest,
-          _: AsyncHandler[BatchWriteItemRequest, BatchWriteItemResult]
-        ),
-        req
-      )
+      eff(client.batchWriteItem(req))
     case BatchGet(req) =>
-      eff(
-        client.batchGetItemAsync(_: BatchGetItemRequest, _: AsyncHandler[BatchGetItemRequest, BatchGetItemResult]),
-        req
-      )
+      eff(client.batchGetItem(req))
     case Update(req) =>
-      eff(client.updateItemAsync, JavaRequests.update(req))
+      eff(client.updateItem(JavaRequests.update(req)))
     case ConditionalUpdate(req) =>
-      eff(client.updateItemAsync, JavaRequests.update(req)).attempt
+      eff(client.updateItem(JavaRequests.update(req))).attempt
         .flatMap(
           _.fold(
             _ match {
@@ -100,6 +86,6 @@ class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) e
             a => F.delay(Right(a))
           )
         )
-    case TransactWriteAll(req) => eff(client.transactWriteItemsAsync, JavaRequests.transactItems(req))
+    case TransactWriteAll(req) => eff(client.transactWriteItems(JavaRequests.transactItems(req)))
   }
 }

--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -19,13 +19,13 @@ package org.scanamo.ops
 import cats.effect.Async
 import cats.implicits._
 import cats.~>
-import com.amazonaws.AmazonWebServiceRequest
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbRequest
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.amazonaws.services.dynamodbv2.model.{ Put => _, Delete => _, Update => _, Get => _, _ }
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.{ Put => _, Delete => _, Update => _, Get => _, _ }
 
-class CatsInterpreter[F[_]](client: AmazonDynamoDBAsync)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
-  final private def eff[A <: AmazonWebServiceRequest, B](
+class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
+  final private def eff[A <: DynamoDbRequest, B](
     f: (A, AsyncHandler[A, B]) => java.util.concurrent.Future[B],
     req: A
   ): F[B] =

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.implicits._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scanamo.ops.ScanamoOps
 import org.scanamo.query._
 import org.scanamo.syntax._

--- a/docs/docs/batch-operations.md
+++ b/docs/docs/batch-operations.md
@@ -15,7 +15,7 @@ import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
  
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 
 LocalDynamoDB.createTable(client)("lemmings")("role" -> S)

--- a/docs/docs/batch-operations.md
+++ b/docs/docs/batch-operations.md
@@ -13,7 +13,7 @@ has support for putting, getting and deleting in batches
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
  
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)

--- a/docs/docs/conditional-operations.md
+++ b/docs/docs/conditional-operations.md
@@ -13,7 +13,7 @@ import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 case class Gremlin(number: Int, name: String, wet: Boolean, friendly: Boolean)
 ```

--- a/docs/docs/conditional-operations.md
+++ b/docs/docs/conditional-operations.md
@@ -12,7 +12,7 @@ Modifying operations ([Put](operations.md#put-and-get), [Delete](operations.md#d
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 case class Gremlin(number: Int, name: String, wet: Boolean, friendly: Boolean)

--- a/docs/docs/dynamo-format.md
+++ b/docs/docs/dynamo-format.md
@@ -62,7 +62,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 case class Foo(dateTime: DateTime)
 
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 
 LocalDynamoDB.createTable(client)("foo")("dateTime" -> S)

--- a/docs/docs/dynamo-format.md
+++ b/docs/docs/dynamo-format.md
@@ -58,7 +58,7 @@ For example, to store Joda `DateTime` objects as ISO `String`s in Dynamo:
 import org.joda.time._
 import org.scanamo._
 import org.scanamo.generic.auto._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 case class Foo(dateTime: DateTime)
 
@@ -103,7 +103,7 @@ import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)

--- a/docs/docs/dynamo-format.md
+++ b/docs/docs/dynamo-format.md
@@ -105,7 +105,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 
 type PosInt = Int Refined Positive

--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -16,7 +16,7 @@ import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 
 case class Station(line: String, name: String, zone: Int)

--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -15,7 +15,7 @@ returned, it could still exhaust the provisioned capacity or force the provision
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -33,7 +33,7 @@ import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
  
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("name" -> S)
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,7 +31,7 @@ then, given a table and some case classes
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
  
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)

--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -31,7 +31,7 @@ import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 LocalDynamoDB.createTable(client)("muppets")("name" -> S)
 

--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -29,7 +29,7 @@ Dynamo and subsequently retrieving them:
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
@@ -58,7 +58,7 @@ To remove an item in its entirety, we can use delete:
 ```scala mdoc:silent
 import org.scanamo._
 import org.scanamo.syntax._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 LocalDynamoDB.createTable(client)("villains")("name" -> S)
 
@@ -84,7 +84,7 @@ If you want to change some of the fields of an item, that don't form part of its
 ```scala mdoc:silent
 import org.scanamo._
 import org.scanamo.syntax._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 LocalDynamoDB.createTable(client)("teams")("name" -> S)
 
@@ -159,7 +159,7 @@ supports scanning it:
 
 ```scala mdoc:silent
 import org.scanamo._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 LocalDynamoDB.createTable(client)("lines")("mode" -> S, "line" -> S)
 

--- a/docs/docs/using-indexes.md
+++ b/docs/docs/using-indexes.md
@@ -20,7 +20,7 @@ case class Transport(mode: String, line: String, colour: String)
 val transport = Table[Transport]("transport")
 val colourIndex = transport.index("colour-index")
 
-val client = LocalDynamoDB.client()
+val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 ```

--- a/docs/docs/using-indexes.md
+++ b/docs/docs/using-indexes.md
@@ -22,7 +22,7 @@ val colourIndex = transport.index("colour-index")
 
 val client = LocalDynamoDB.client()
 val scanamo = Scanamo(client)
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 ```
 ```scala mdoc
 LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")("mode" -> S, "line" -> S)("colour" -> S) {

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1-69-693de22a")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1-229-b7c15aa9")

--- a/refined/src/test/scala/org/scanamo/refined/RefinedDynamoFormatSpec.scala
+++ b/refined/src/test/scala/org/scanamo/refined/RefinedDynamoFormatSpec.scala
@@ -6,7 +6,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
 
 import org.scanamo.TypeCoercionError
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 import org.scalatest.{ FlatSpec, Matchers }
 

--- a/refined/src/test/scala/org/scanamo/refined/RefinedDynamoFormatSpec.scala
+++ b/refined/src/test/scala/org/scanamo/refined/RefinedDynamoFormatSpec.scala
@@ -8,20 +8,21 @@ import eu.timepit.refined.numeric.Positive
 import org.scanamo.TypeCoercionError
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RefinedDynamoFormatSpec extends FlatSpec with Matchers {
+class RefinedDynamoFormatSpec extends AnyFlatSpec with Matchers {
   type PosInt = Int Refined Positive
 
   "DynamoFormat[PosInt]" should "read a positive integer value" in {
-    val valueToRead = new AttributeValue().withN("10")
+    val valueToRead = AttributeValue.builder.n("10").build
 
     val valueRead = DynamoFormat[PosInt].read(valueToRead)
     valueRead shouldBe Right(10: PosInt)
   }
 
   it should "fail to read non positive integers" in {
-    val valueToRead = new AttributeValue().withN("-234")
+    val valueToRead = AttributeValue.builder.n("-234").build
 
     val expectedErrorMsg = "Predicate failed: (-234 > 0)."
 

--- a/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -26,7 +26,7 @@ import cats.instances.list._
 import cats.instances.vector._
 import cats.syntax.either._
 import cats.syntax.traverse._
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import magnolia.Magnolia
 import org.scanamo.generic.{ AutoDerivationUnlocker, Derivation }
 

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -18,7 +18,7 @@ package org.scanamo
 
 import cats.Parallel
 import cats.kernel.Monoid
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import java.util.{ Map => JMap, HashMap }
 import cats.syntax.apply._
 import cats.syntax.semigroup._
@@ -142,7 +142,7 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
   /**
     * Make an AWS SDK value out of this map
     */
-  final def toAttributeValue: AttributeValue = new AttributeValue().withM(toJavaMap)
+  final def toAttributeValue: AttributeValue = AttributeValue.builder.m(toJavaMap).build
 
   /**
     * Builds a [[scala.collection.Map]] if this map is made entirely of values of type `V`

--- a/scanamo/src/main/scala/org/scanamo/DynamoReadError.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoReadError.scala
@@ -18,7 +18,7 @@ package org.scanamo
 
 import cats.data.NonEmptyList
 import cats.Show
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 
 sealed abstract class ScanamoError
 final case class ConditionNotMet(e: ConditionalCheckFailedException) extends ScanamoError

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -20,7 +20,7 @@ import cats.{ Monad, MonoidK }
 import cats.MonoidK.ops._
 import cats.free.{ Free, FreeT }
 import cats.syntax.semigroupk._
-import com.amazonaws.services.dynamodbv2.model.{ QueryResult, ScanResult }
+import software.amazon.awssdk.services.dynamodb.model.{ QueryResponse, ScanResponse }
 import org.scanamo.ops.{ ScanamoOps, ScanamoOpsA, ScanamoOpsT }
 import org.scanamo.request.{ ScanamoQueryRequest, ScanamoScanRequest }
 
@@ -82,10 +82,10 @@ private[scanamo] trait DynamoResultStream[Req, Res] {
 }
 
 private[scanamo] object DynamoResultStream {
-  object ScanResultStream extends DynamoResultStream[ScanamoScanRequest, ScanResult] {
-    final def items(res: ScanResult) =
-      res.getItems.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
-    final def lastEvaluatedKey(res: ScanResult) = Option(res.getLastEvaluatedKey).map(DynamoObject(_))
+  object ScanResponseStream extends DynamoResultStream[ScanamoScanRequest, ScanResponse] {
+    final def items(res: ScanResponse) =
+      res.items.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
+    final def lastEvaluatedKey(res: ScanResponse) = Option(res.lastEvaluatedKey).map(DynamoObject(_))
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))
     final def withLimit(limit: Int) =
@@ -97,10 +97,10 @@ private[scanamo] object DynamoResultStream {
     final def startKey(req: ScanamoScanRequest) = req.options.exclusiveStartKey
   }
 
-  object QueryResultStream extends DynamoResultStream[ScanamoQueryRequest, QueryResult] {
-    final def items(res: QueryResult) =
-      res.getItems.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
-    final def lastEvaluatedKey(res: QueryResult) = Option(res.getLastEvaluatedKey).map(DynamoObject(_))
+  object QueryResponseStream extends DynamoResultStream[ScanamoQueryRequest, QueryResponse] {
+    final def items(res: QueryResponse) =
+      res.items.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
+    final def lastEvaluatedKey(res: QueryResponse) = Option(res.lastEvaluatedKey).map(DynamoObject(_))
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))
     final def withLimit(limit: Int) =

--- a/scanamo/src/main/scala/org/scanamo/DynamoValue.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoValue.scala
@@ -300,7 +300,7 @@ object DynamoValue {
     */
   final def fromAttributeValue(av: AttributeValue): DynamoValue =
     if (av.nul)
-      DynNull
+      nil
     else if (av.bool ne null)
       DynBool(av.bool)
     else if (av.n ne null)
@@ -309,18 +309,20 @@ object DynamoValue {
       DynString(av.s)
     else if (av.b ne null)
       DynByte(av.b.asByteBuffer)
-    else if (av.ns ne null)
+    else if (av.hasNs)
       DynArray(DynamoArray.unsafeNumbers(av.ns))
-    else if (av.bs ne null)
+    else if (av.hasBs)
       DynArray(
         DynamoArray.byteBuffers(av.bs.stream.map[ByteBuffer](_.asByteBuffer).collect(Collectors.toList[ByteBuffer]))
       )
-    else if (av.ss ne null)
+    else if (av.hasSs)
       DynArray(DynamoArray.strings(av.ss))
-    else if (av.l ne null)
+    else if (av.hasL)
       DynArray(DynamoArray(av.l))
-    else
+    else if (av.hasM)
       DynObject(DynamoObject(av.m))
+    else
+      DynNull
 
   /**
     * Creates a map from a [[DynamoObject]]

--- a/scanamo/src/main/scala/org/scanamo/DynamoValue.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoValue.scala
@@ -16,8 +16,11 @@
 
 package org.scanamo
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import java.nio.ByteBuffer
+import java.{ util => ju }
+import java.util.stream.Collectors
 
 /**
   * A `DynamoValue` is a pure representation of an `AttributeValue` from the AWS SDK.
@@ -32,9 +35,9 @@ sealed abstract class DynamoValue extends Product with Serializable { self =>
     case DynNull        => Null
     case DynBool(true)  => True
     case DynBool(false) => False
-    case DynNum(n)      => new AttributeValue().withN(n.toString)
-    case DynString(s)   => new AttributeValue().withS(s)
-    case DynByte(b)     => new AttributeValue().withB(b)
+    case DynNum(n)      => AttributeValue.builder.n(n.toString).build
+    case DynString(s)   => AttributeValue.builder.s(s).build
+    case DynByte(b)     => AttributeValue.builder.b(SdkBytes.fromByteBuffer(b)).build
     case DynObject(as)  => as.toAttributeValue
     case DynArray(as)   => as.toAttributeValue
   }
@@ -223,10 +226,11 @@ sealed abstract class DynamoValue extends Product with Serializable { self =>
 }
 
 object DynamoValue {
-  private[scanamo] val Null: AttributeValue = new AttributeValue().withNULL(true)
-  private[scanamo] val True: AttributeValue = new AttributeValue().withBOOL(true)
-  private[scanamo] val False: AttributeValue = new AttributeValue().withBOOL(false)
-  private[scanamo] val EmptyList: AttributeValue = new AttributeValue().withL()
+  private[scanamo] val Null: AttributeValue = AttributeValue.builder.nul(true).build
+  private[scanamo] val True: AttributeValue = AttributeValue.builder.bool(true).build
+  private[scanamo] val False: AttributeValue = AttributeValue.builder.bool(false).build
+  private[scanamo] val EmptyList: AttributeValue =
+    AttributeValue.builder.l(ju.Collections.EMPTY_LIST.asInstanceOf[ju.List[AttributeValue]]).build
 
   private[DynamoValue] case object DynNull extends DynamoValue
   final private[DynamoValue] case class DynBool(b: Boolean) extends DynamoValue
@@ -295,26 +299,28 @@ object DynamoValue {
     * Creats a pure value from an `AttributeValue`
     */
   final def fromAttributeValue(av: AttributeValue): DynamoValue =
-    if (!(av.isNULL eq null) && av.isNULL)
+    if (av.nul)
       DynNull
-    else if (av.getBOOL ne null)
-      DynBool(av.getBOOL)
-    else if (av.getN ne null)
-      DynNum(av.getN)
-    else if (av.getS ne null)
-      DynString(av.getS)
-    else if (av.getB ne null)
-      DynByte(av.getB)
-    else if (av.getNS ne null)
-      DynArray(DynamoArray.unsafeNumbers(av.getNS))
-    else if (av.getBS ne null)
-      DynArray(DynamoArray.byteBuffers(av.getBS))
-    else if (av.getSS ne null)
-      DynArray(DynamoArray.strings(av.getSS))
-    else if (av.getL ne null)
-      DynArray(DynamoArray(av.getL))
+    else if (av.bool ne null)
+      DynBool(av.bool)
+    else if (av.n ne null)
+      DynNum(av.n)
+    else if (av.s ne null)
+      DynString(av.s)
+    else if (av.b ne null)
+      DynByte(av.b.asByteBuffer)
+    else if (av.ns ne null)
+      DynArray(DynamoArray.unsafeNumbers(av.ns))
+    else if (av.bs ne null)
+      DynArray(
+        DynamoArray.byteBuffers(av.bs.stream.map[ByteBuffer](_.asByteBuffer).collect(Collectors.toList[ByteBuffer]))
+      )
+    else if (av.ss ne null)
+      DynArray(DynamoArray.strings(av.ss))
+    else if (av.l ne null)
+      DynArray(DynamoArray(av.l))
     else
-      DynObject(DynamoObject(av.getM))
+      DynObject(DynamoObject(av.m))
 
   /**
     * Creates a map from a [[DynamoObject]]

--- a/scanamo/src/main/scala/org/scanamo/Return.scala
+++ b/scanamo/src/main/scala/org/scanamo/Return.scala
@@ -1,6 +1,6 @@
 package org.scanamo
 
-import com.amazonaws.services.dynamodbv2.model.ReturnValue
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue
 
 sealed abstract class PutReturn extends Product with Serializable { self =>
   import PutReturn._

--- a/scanamo/src/main/scala/org/scanamo/ScanamoAsync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoAsync.scala
@@ -18,7 +18,7 @@ package org.scanamo
 
 import cats.Monad
 import cats.~>
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import org.scanamo.ops._
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -26,10 +26,10 @@ import scala.concurrent.{ ExecutionContext, Future }
   * Provides the same interface as [[org.scanamo.Scanamo]], except that it requires an implicit
   * concurrent.ExecutionContext and returns a concurrent.Future
   *
-  * Note that that com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient just uses an
+  * Note that that software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientClient just uses an
   * java.util.concurrent.ExecutorService to make calls asynchronously
   */
-class ScanamoAsync private (client: AmazonDynamoDBAsync)(implicit ec: ExecutionContext) {
+class ScanamoAsync private (client: DynamoDbAsyncClient)(implicit ec: ExecutionContext) {
   import cats.instances.future._
 
   final private val interpreter = new ScanamoAsyncInterpreter(client)
@@ -45,5 +45,5 @@ class ScanamoAsync private (client: AmazonDynamoDBAsync)(implicit ec: ExecutionC
 }
 
 object ScanamoAsync {
-  def apply(client: AmazonDynamoDBAsync)(implicit ec: ExecutionContext): ScanamoAsync = new ScanamoAsync(client)
+  def apply(client: DynamoDbAsyncClient)(implicit ec: ExecutionContext): ScanamoAsync = new ScanamoAsync(client)
 }

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -17,9 +17,9 @@
 package org.scanamo
 
 import cats.{ Monad, MonoidK }
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import java.util.{ List => JList, Map => JMap }
-import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
+import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
 import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query._
 import org.scanamo.request._
@@ -41,19 +41,19 @@ object ScanamoFree {
   def putAndReturn[T: DynamoFormat](tableName: String)(ret: PutReturn,
                                                        item: T): ScanamoOps[Option[Either[DynamoReadError, T]]] =
     nativePut(tableName, ret, item)
-      .map(r => Option(r.getAttributes).filterNot(_.isEmpty).map(DynamoObject(_)).map(read[T]))
+      .map(r => Option(r.attributes).filterNot(_.isEmpty).map(DynamoObject(_)).map(read[T]))
 
   private def nativePut[T](tableName: String, ret: PutReturn, item: T)(
     implicit f: DynamoFormat[T]
-  ): ScanamoOps[PutItemResult] =
+  ): ScanamoOps[PutItemResponse] =
     ScanamoOps.put(ScanamoPutRequest(tableName, f.write(item), None, ret))
 
   def putAll[T](tableName: String)(items: Set[T])(implicit f: DynamoFormat[T]): ScanamoOps[Unit] = {
     def loop(items: List[JMap[String, JList[WriteRequest]]]): ScanamoOps[Unit] = items match {
       case Nil => ().pure[ScanamoOps]
       case map :: rest =>
-        ScanamoOps.batchWrite(new BatchWriteItemRequest().withRequestItems(map)).flatMap { resp =>
-          val unprocessed = resp.getUnprocessedItems
+        ScanamoOps.batchWrite(BatchWriteItemRequest.builder.requestItems(map).build).flatMap { resp =>
+          val unprocessed = resp.unprocessedItems
           loop(if (unprocessed.isEmpty) rest else unprocessed :: rest)
         }
     }
@@ -65,8 +65,9 @@ object ScanamoFree {
           tableName,
           batch,
           item =>
-            new WriteRequest()
-              .withPutRequest(new PutRequest().withItem(f.write(item).asObject.getOrElse(DynamoObject.empty).toJavaMap))
+            WriteRequest.builder
+              .putRequest(PutRequest.builder.item(f.write(item).asObject.getOrElse(DynamoObject.empty).toJavaMap).build)
+              .build
         )
       }
       .toList
@@ -76,12 +77,12 @@ object ScanamoFree {
 
   def transactPutAllTable[T](
     tableName: String
-  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResult] =
+  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResponse] =
     transactPutAll(items.map(tableName -> _))
 
   def transactPutAll[T](
     tableAndItems: List[(String, T)]
-  )(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResult] = {
+  )(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResponse] = {
     val dItems = tableAndItems.map {
       case (tableName, itm) =>
         TransactPutItem(tableName, f.write(itm), None)
@@ -91,12 +92,12 @@ object ScanamoFree {
 
   def transactUpdateAllTable(
     tableName: String
-  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResult] =
+  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResponse] =
     transactUpdateAll(items.map(tableName → _))
 
   def transactUpdateAll(
     tableAndItems: List[(String, (UniqueKey[_], UpdateExpression))]
-  ): ScanamoOps[TransactWriteItemsResult] = {
+  ): ScanamoOps[TransactWriteItemsResponse] = {
     val items = tableAndItems.map {
       case (tableName, (key, updateExpression)) ⇒
         TransactUpdateItem(tableName, key.toDynamoObject, updateExpression, None)
@@ -106,12 +107,12 @@ object ScanamoFree {
 
   def transactDeleteAllTable(
     tableName: String
-  )(items: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResult] =
+  )(items: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =
     transactDeleteAll(items.map(tableName → _))
 
   def transactDeleteAll(
     tableAndItems: List[(String, UniqueKey[_])]
-  ): ScanamoOps[TransactWriteItemsResult] = {
+  ): ScanamoOps[TransactWriteItemsResponse] = {
     val items = tableAndItems.map {
       case (tableName, key) ⇒
         TransactDeleteItem(tableName, key.toDynamoObject, None)
@@ -127,9 +128,9 @@ object ScanamoFree {
         val map = buildMap[DynamoObject, WriteRequest](
           tableName,
           batch,
-          item => new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(item.toJavaMap))
+          item => WriteRequest.builder.deleteRequest(DeleteRequest.builder.key(item.toJavaMap).build).build
         )
-        ScanamoOps.batchWrite(new BatchWriteItemRequest().withRequestItems(map))
+        ScanamoOps.batchWrite(BatchWriteItemRequest.builder.requestItems(map).build)
       }
       // can't believe cats doesn't provide a version of traverse that doesn't accumulate the result
       .void
@@ -139,12 +140,13 @@ object ScanamoFree {
   )(key: UniqueKey[_], consistent: Boolean): ScanamoOps[Option[Either[DynamoReadError, T]]] =
     ScanamoOps
       .get(
-        new GetItemRequest()
-          .withTableName(tableName)
-          .withKey(key.toDynamoObject.toJavaMap)
-          .withConsistentRead(consistent)
+        GetItemRequest.builder
+          .tableName(tableName)
+          .key(key.toDynamoObject.toJavaMap)
+          .consistentRead(consistent)
+          .build
       )
-      .map(res => Option(res.getItem).map(m => read[T](DynamoObject(m))))
+      .map(res => Option(res.item).map(m => read[T](DynamoObject(m))))
 
   def getAll[T: DynamoFormat](
     tableName: String
@@ -156,19 +158,20 @@ object ScanamoFree {
         val map = emptyMap[String, KeysAndAttributes](1)
         map.put(
           tableName,
-          new KeysAndAttributes()
-            .withKeys(
+          KeysAndAttributes.builder
+            .keys(
               batch.foldLeft(emptyList[JMap[String, AttributeValue]](batch.size)) {
                 case (keys, key) =>
                   keys.add(key.toJavaMap)
                   keys
               }
             )
-            .withConsistentRead(consistent)
+            .consistentRead(consistent)
+            .build
         )
-        ScanamoOps.batchGet(new BatchGetItemRequest().withRequestItems(map))
+        ScanamoOps.batchGet(BatchGetItemRequest.builder.requestItems(map).build)
       }
-      .map(_.flatMap(_.getResponses.get(tableName).asScala.map(m => read[T](DynamoObject(m)))))
+      .map(_.flatMap(_.responses.get(tableName).asScala.map(m => read[T](DynamoObject(m)))))
       .map(_.toSet)
 
   def delete(tableName: String)(key: UniqueKey[_]): ScanamoOps[Unit] =
@@ -178,30 +181,31 @@ object ScanamoFree {
     tableName: String
   )(ret: DeleteReturn, key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, T]]] =
     nativeDelete(tableName, key, ret)
-      .map(r => Option(r.getAttributes).filterNot(_.isEmpty).map(DynamoObject(_)).map(read[T]))
+      .map(r => Option(r.attributes).filterNot(_.isEmpty).map(DynamoObject(_)).map(read[T]))
 
-  def nativeDelete(tableName: String, key: UniqueKey[_], ret: DeleteReturn): ScanamoOps[DeleteItemResult] =
+  def nativeDelete(tableName: String, key: UniqueKey[_], ret: DeleteReturn): ScanamoOps[DeleteItemResponse] =
     ScanamoOps.delete(ScanamoDeleteRequest(tableName, key.toDynamoObject, None, ret))
 
   def scan[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default)).map(_._1)
+    ScanResponseStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default)).map(_._1)
 
   def scanM[M[_]: Monad: MonoidK, T: DynamoFormat](tableName: String,
                                                    pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
-    ScanResultStream.streamTo[M, T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default), pageSize)
+    ScanResponseStream.streamTo[M, T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default), pageSize)
 
-  def scan0[T: DynamoFormat](tableName: String): ScanamoOps[ScanResult] =
+  def scan0[T: DynamoFormat](tableName: String): ScanamoOps[ScanResponse] =
     ScanamoOps.scan(ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default))
 
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default)).map(_._1)
+    QueryResponseStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default)).map(_._1)
 
   def queryM[M[_]: Monad: MonoidK, T: DynamoFormat](
     tableName: String
   )(query: Query[_], pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
-    QueryResultStream.streamTo[M, T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default), pageSize)
+    QueryResponseStream
+      .streamTo[M, T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default), pageSize)
 
-  def query0[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[QueryResult] =
+  def query0[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[QueryResponse] =
     ScanamoOps.query(ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default))
 
   def update[T: DynamoFormat](
@@ -219,7 +223,7 @@ object ScanamoFree {
           None
         )
       )
-      .map(r => read[T](DynamoObject(r.getAttributes)))
+      .map(r => read[T](DynamoObject(r.attributes)))
 
   /**
     * {{{

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -38,7 +38,7 @@ class Scanamo private (client: DynamoDbClient) {
     * >>> case class Transport(mode: String, line: String)
     * >>> val transport = Table[Transport]("transport")
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -17,7 +17,7 @@
 package org.scanamo
 
 import cats.{ ~>, Id, Monad }
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import org.scanamo.ops._
 
 /**
@@ -25,7 +25,7 @@ import org.scanamo.ops._
   *
   * To avoid blocking, use [[org.scanamo.ScanamoAsync]]
   */
-class Scanamo private (client: AmazonDynamoDB) {
+class Scanamo private (client: DynamoDbClient) {
   final private val interpreter = new ScanamoSyncInterpreter(client)
 
   /**
@@ -40,7 +40,7 @@ class Scanamo private (client: AmazonDynamoDB) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withTable(client)("transport")("mode" -> S, "line" -> S) {
     * ...   import org.scanamo.syntax._
@@ -63,7 +63,7 @@ class Scanamo private (client: AmazonDynamoDB) {
 }
 
 object Scanamo {
-  def apply(client: AmazonDynamoDB): Scanamo = new Scanamo(client)
+  def apply(client: DynamoDbClient): Scanamo = new Scanamo(client)
 
   val ToList: Id ~> List = new (Id ~> List) {
     def apply[A](fa: Id[A]): List[A] = fa :: Nil

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -38,7 +38,7 @@ sealed abstract class SecondaryIndex[V] {
     * {{{
     * >>> case class Bear(name: String, favouriteFood: String, antagonist: Option[String])
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
@@ -84,7 +84,7 @@ sealed abstract class SecondaryIndex[V] {
     * {{{
     * >>> case class GithubProject(organisation: String, repository: String, language: String, license: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
@@ -136,7 +136,7 @@ sealed abstract class SecondaryIndex[V] {
     * {{{
     * >>> case class Transport(mode: String, line: String, colour: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._
@@ -171,7 +171,7 @@ sealed abstract class SecondaryIndex[V] {
     * {{{
     * >>> case class Transport(mode: String, line: String, colour: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -17,7 +17,7 @@
 package org.scanamo
 
 import cats.{ Monad, MonoidK }
-import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
+import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
 import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query.{ Condition, ConditionExpression, Query, UniqueKey, UniqueKeyCondition }
 import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
@@ -40,7 +40,7 @@ sealed abstract class SecondaryIndex[V] {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> import org.scanamo.generic.auto._
     *
@@ -86,7 +86,7 @@ sealed abstract class SecondaryIndex[V] {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
@@ -138,7 +138,7 @@ sealed abstract class SecondaryIndex[V] {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     *
@@ -173,7 +173,7 @@ sealed abstract class SecondaryIndex[V] {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     *
@@ -218,11 +218,11 @@ private[scanamo] case class SecondaryIndexWithOptions[V: DynamoFormat](
     copy(queryOptions = queryOptions.copy(filter = Some(c)))
   def descending: SecondaryIndexWithOptions[V] =
     copy(queryOptions = queryOptions.copy(ascending = false))
-  def scan() = ScanResultStream.stream[V](ScanamoScanRequest(tableName, Some(indexName), queryOptions)).map(_._1)
+  def scan() = ScanResponseStream.stream[V](ScanamoScanRequest(tableName, Some(indexName), queryOptions)).map(_._1)
   def scanPaginatedM[M[_]: Monad: MonoidK](pageSize: Int) =
-    ScanResultStream.streamTo[M, V](ScanamoScanRequest(tableName, Some(indexName), queryOptions), pageSize)
+    ScanResponseStream.streamTo[M, V](ScanamoScanRequest(tableName, Some(indexName), queryOptions), pageSize)
   def query(query: Query[_]) =
-    QueryResultStream.stream[V](ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions)).map(_._1)
+    QueryResponseStream.stream[V](ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions)).map(_._1)
   def queryPaginatedM[M[_]: Monad: MonoidK](query: Query[_], pageSize: Int) =
-    QueryResultStream.streamTo[M, V](ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions), pageSize)
+    QueryResponseStream.streamTo[M, V](ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions), pageSize)
 }

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -30,7 +30,7 @@ import org.scanamo.update.UpdateExpression
   * {{{
   * >>> case class Transport(mode: String, line: String)
   *
-  * >>> val client = LocalDynamoDB.client()
+  * >>> val client = LocalDynamoDB.syncClient()
   * >>> val scanamo = Scanamo(client)
   * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
   *
@@ -80,7 +80,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     *
     * >>> val dataSet = Set(
@@ -107,7 +107,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Transport(mode: String, line: String, colour: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._
@@ -159,7 +159,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Forecast(location: String, weather: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
@@ -316,7 +316,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Transport(mode: String, line: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
@@ -348,7 +348,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class City(country: String, name: String)
     *
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)("country" -> S, "name" -> S) { t =>
     * ...   import org.scanamo.syntax._
@@ -386,7 +386,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.generic.auto._
     * >>> import org.scanamo.query._
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     *
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
@@ -543,7 +543,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     *
     * >>> case class Bear(name: String, favouriteFood: String)
@@ -594,7 +594,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Bear(name: String, favouriteFood: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
@@ -644,7 +644,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Transport(mode: String, line: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     *
     * >>> import cats.implicits._
@@ -665,7 +665,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...     ))
     * ...     res <- table.limit(1).scan0
     * ...     uniqueKeyCondition = UniqueKeyCondition[AndEqualsCondition[KeyEquals[String], KeyEquals[String]], (AttributeName, AttributeName)]
-    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.getLastEvaluatedKey))
+    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.lastEvaluatedKey))
     * ...     ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(table.from(_).scan())
     * ...   } yield ts
     * ...   scanamo.exec(ops)
@@ -681,7 +681,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Transport(mode: String, line: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     *
     * >>> import org.scanamo.syntax._
@@ -737,7 +737,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Transport(mode: String, line: String)
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     *
     * >>> import cats.implicits._
@@ -761,7 +761,7 @@ case class Table[V: DynamoFormat](name: String) {
     * ...     ))
     * ...     res <- table.limit(1).query0("mode" -> "Bus" and "line" -> "234")
     * ...     uniqueKeyCondition = UniqueKeyCondition[AndEqualsCondition[KeyEquals[String], KeyEquals[String]], (AttributeName, AttributeName)]
-    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.getLastEvaluatedKey))
+    * ...     lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.lastEvaluatedKey))
     * ...     ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(table.from(_).scan())
     * ...   } yield ts
     * ...   scanamo.exec(ops)
@@ -777,7 +777,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class Bear(name: String, favouriteFood: String, antagonist: Option[String])
     *
-    * >>> val client = LocalDynamoDB.client()
+    * >>> val client = LocalDynamoDB.syncClient()
     * >>> val scanamo = Scanamo(client)
     * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -17,8 +17,8 @@
 package org.scanamo
 
 import cats.{ Monad, MonoidK }
-import com.amazonaws.services.dynamodbv2.model.{ QueryResult, ScanResult, TransactWriteItemsResult }
-import org.scanamo.DynamoResultStream.{ QueryResultStream, ScanResultStream }
+import software.amazon.awssdk.services.dynamodb.model.{ QueryResponse, ScanResponse, TransactWriteItemsResponse }
+import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
 import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query._
 import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
@@ -32,7 +32,7 @@ import org.scanamo.update.UpdateExpression
   *
   * >>> val client = LocalDynamoDB.client()
   * >>> val scanamo = Scanamo(client)
-  * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+  * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
   *
   * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
   * ...   import org.scanamo.syntax._
@@ -76,7 +76,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class Farm(animals: List[String])
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     *
@@ -109,7 +109,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     *
@@ -161,7 +161,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("location" -> S) { t =>
     * ...   import org.scanamo.syntax._
@@ -318,7 +318,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   import org.scanamo.syntax._
@@ -347,7 +347,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> case class City(country: String, name: String)
     *
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
     * >>> val (get, scan, query) = LocalDynamoDB.withRandomTable(client)("country" -> S, "name" -> S) { t =>
@@ -385,7 +385,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     * >>> import org.scanamo.query._
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
     *
@@ -542,7 +542,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
     *
@@ -596,7 +596,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
     * ...   import org.scanamo._
@@ -636,7 +636,7 @@ case class Table[V: DynamoFormat](name: String) {
 
   /**
     * Scans the table and returns the raw DynamoDB result. Sometimes, one might want to
-    * access metadata returned in the `ScanResult` object, such as the last evaluated
+    * access metadata returned in the `ScanResponse` object, such as the last evaluated
     * key for example. `Table#scan` only returns a list of results, so there is no
     * place for putting that information: this is where `scan0` comes in handy!
     *
@@ -653,7 +653,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     * >>> import org.scanamo.query._
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   val table = Table[Transport](t)
@@ -673,7 +673,7 @@ case class Table[V: DynamoFormat](name: String) {
     * List(Right(Transport(Underground,Circle)), Right(Transport(Underground,Metropolitan)))
     * }}}
     */
-  def scan0: ScanamoOps[ScanResult] = ScanamoFree.scan0[V](name)
+  def scan0: ScanamoOps[ScanResponse] = ScanamoFree.scan0[V](name)
 
   /**
     * Query a table based on the hash key and optionally the range key
@@ -686,7 +686,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   val table = Table[Transport](t)
@@ -729,7 +729,7 @@ case class Table[V: DynamoFormat](name: String) {
 
   /**
     * Queries the table and returns the raw DynamoDB result. Sometimes, one might want to
-    * access metadata returned in the `QueryResult` object, such as the last evaluated
+    * access metadata returned in the `QueryResponse` object, such as the last evaluated
     * key for example. `Table#query` only returns a list of results, so there is no
     * place for putting that information: this is where `query0` comes in handy!
     *
@@ -746,7 +746,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
     * >>> import org.scanamo.query._
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("mode" -> S, "line" -> S) { t =>
     * ...   val table = Table[Transport](t)
@@ -769,7 +769,7 @@ case class Table[V: DynamoFormat](name: String) {
     * List(Right(Transport(Bus,390)), Right(Transport(Underground,Central)), Right(Transport(Underground,Circle)), Right(Transport(Underground,Metropolitan)))
     * }}}
     */
-  def query0(query: Query[_]): ScanamoOps[QueryResult] = ScanamoFree.query0[V](name)(query)
+  def query0(query: Query[_]): ScanamoOps[QueryResponse] = ScanamoFree.query0[V](name)(query)
 
   /**
     * Filter the results of a Scan or Query
@@ -779,7 +779,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> val client = LocalDynamoDB.client()
     * >>> val scanamo = Scanamo(client)
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> import org.scanamo.syntax._
     * >>> import org.scanamo.generic.auto._
@@ -799,7 +799,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> case class Station(line: String, name: String, zone: Int)
     *
     *
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
     *
     * >>> LocalDynamoDB.withRandomTable(client)("line" -> S, "name" -> S) { t =>
     * ...   val stationTable = Table[Station](t)
@@ -824,13 +824,13 @@ case class Table[V: DynamoFormat](name: String) {
   def descending =
     TableWithOptions(name, ScanamoQueryOptions.default).descending
 
-  def transactPutAll(vs: List[V]): ScanamoOps[TransactWriteItemsResult] =
+  def transactPutAll(vs: List[V]): ScanamoOps[TransactWriteItemsResponse] =
     ScanamoFree.transactPutAllTable(name)(vs)
 
-  def transactUpdateAll(vs: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResult] =
+  def transactUpdateAll(vs: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResponse] =
     ScanamoFree.transactUpdateAllTable(name)(vs)
 
-  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResult] =
+  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =
     ScanamoFree.transactDeleteAllTable(name)(vs)
 }
 
@@ -873,20 +873,20 @@ private[scanamo] case class TableWithOptions[V: DynamoFormat](tableName: String,
     copy(queryOptions = queryOptions.copy(filter = Some(c)))
 
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]] =
-    ScanResultStream.stream[V](ScanamoScanRequest(tableName, None, queryOptions)).map(_._1)
+    ScanResponseStream.stream[V](ScanamoScanRequest(tableName, None, queryOptions)).map(_._1)
   def scanM[M[_]: Monad: MonoidK]: ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     scanPaginatedM(Int.MaxValue)
   def scanPaginatedM[M[_]: Monad: MonoidK](pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    ScanResultStream.streamTo[M, V](ScanamoScanRequest(tableName, None, queryOptions), pageSize)
-  def scan0: ScanamoOps[ScanResult] =
+    ScanResponseStream.streamTo[M, V](ScanamoScanRequest(tableName, None, queryOptions), pageSize)
+  def scan0: ScanamoOps[ScanResponse] =
     ScanamoOps.scan(ScanamoScanRequest(tableName, None, queryOptions))
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =
-    QueryResultStream.stream[V](ScanamoQueryRequest(tableName, None, query, queryOptions)).map(_._1)
+    QueryResponseStream.stream[V](ScanamoQueryRequest(tableName, None, query, queryOptions)).map(_._1)
   def queryM[M[_]: Monad: MonoidK](query: Query[_]): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
     queryPaginatedM(query, Int.MaxValue)
   def queryPaginatedM[M[_]: Monad: MonoidK](query: Query[_],
                                             pageSize: Int): ScanamoOpsT[M, List[Either[DynamoReadError, V]]] =
-    QueryResultStream.streamTo[M, V](ScanamoQueryRequest(tableName, None, query, queryOptions), pageSize)
-  def query0(query: Query[_]): ScanamoOps[QueryResult] =
+    QueryResponseStream.streamTo[M, V](ScanamoQueryRequest(tableName, None, query, queryOptions), pageSize)
+  def query0(query: Query[_]): ScanamoOps[QueryResponse] =
     ScanamoOps.query(ScanamoQueryRequest(tableName, None, query, queryOptions))
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoAsyncInterpreter.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoAsyncInterpreter.scala
@@ -46,7 +46,7 @@ class ScanamoAsyncInterpreter(client: DynamoDbAsyncClient)(implicit ec: Executio
       client
         .deleteItem(JavaRequests.delete(req))
         .toScala
-        .map(Either.right[ConditionalCheckFailedException, DeleteItemResponse](_))
+        .map(Either.right[ConditionalCheckFailedException, DeleteItemResponse])
         .recover { case e: ConditionalCheckFailedException => Either.left(e) }
     case Scan(req)  => client.scan(JavaRequests.scan(req)).toScala
     case Query(req) => client.query(JavaRequests.query(req)).toScala
@@ -58,7 +58,7 @@ class ScanamoAsyncInterpreter(client: DynamoDbAsyncClient)(implicit ec: Executio
       client
         .updateItem(JavaRequests.update(req))
         .toScala
-        .map(Either.right[ConditionalCheckFailedException, UpdateItemResponse](_))
+        .map(Either.right[ConditionalCheckFailedException, UpdateItemResponse])
         .recover {
           case e: ConditionalCheckFailedException => Either.left(e)
         }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoAsyncInterpreter.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoAsyncInterpreter.scala
@@ -18,76 +18,50 @@ package org.scanamo.ops
 
 import cats._
 import cats.syntax.either._
-import com.amazonaws.AmazonWebServiceRequest
-import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.amazonaws.services.dynamodbv2.model.{ Put => _, Get => _, Delete => _, Update => _, _ }
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.{ Put => _, Get => _, Delete => _, Update => _, _ }
 
-import scala.concurrent.{ ExecutionContext, Future, Promise }
-import scala.util.{ Failure, Success }
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.compat.java8.FutureConverters._
 
 /*
- * Interpret Scanamo operations into a `Future` using the AmazonDynamoDBAsync client
+ * Interpret Scanamo operations into a `Future` using the DynamoDbClient client
  * which doesn't block, using it's own thread pool for I/O requests internally
  */
-class ScanamoAsyncInterpreter(client: AmazonDynamoDBAsync)(implicit ec: ExecutionContext)
+class ScanamoAsyncInterpreter(client: DynamoDbAsyncClient)(implicit ec: ExecutionContext)
     extends (ScanamoOpsA ~> Future) {
-  final private def futureOf[X <: AmazonWebServiceRequest, T](
-    call: (X, AsyncHandler[X, T]) => java.util.concurrent.Future[T],
-    req: X
-  ): Future[T] = {
-    val p = Promise[T]()
-    val h = new AsyncHandler[X, T] {
-      def onError(exception: Exception): Unit = { p.complete(Failure(exception)); () }
-      def onSuccess(request: X, result: T): Unit = { p.complete(Success(result)); () }
-    }
-    call(req, h)
-    p.future
-  }
-
   override def apply[A](op: ScanamoOpsA[A]): Future[A] = op match {
-    case Put(req) =>
-      futureOf(client.putItemAsync, JavaRequests.put(req))
+    case Put(req) => client.putItem(JavaRequests.put(req)).toScala
     case ConditionalPut(req) =>
-      futureOf(client.putItemAsync, JavaRequests.put(req))
-        .map(Either.right[ConditionalCheckFailedException, PutItemResult])
+      client
+        .putItem(JavaRequests.put(req))
+        .toScala
+        .map(Either.right[ConditionalCheckFailedException, PutItemResponse])
         .recover {
           case e: ConditionalCheckFailedException => Either.left(e)
         }
-    case Get(req) =>
-      futureOf(client.getItemAsync, req)
-    case Delete(req) =>
-      futureOf(client.deleteItemAsync, JavaRequests.delete(req))
+    case Get(req)    => client.getItem(req).toScala
+    case Delete(req) => client.deleteItem(JavaRequests.delete(req)).toScala
     case ConditionalDelete(req) =>
-      futureOf(client.deleteItemAsync, JavaRequests.delete(req))
-        .map(Either.right[ConditionalCheckFailedException, DeleteItemResult])
+      client
+        .deleteItem(JavaRequests.delete(req))
+        .toScala
+        .map(Either.right[ConditionalCheckFailedException, DeleteItemResponse](_))
         .recover { case e: ConditionalCheckFailedException => Either.left(e) }
-    case Scan(req) =>
-      futureOf(client.scanAsync, JavaRequests.scan(req))
-    case Query(req) =>
-      futureOf(client.queryAsync, JavaRequests.query(req))
+    case Scan(req)  => client.scan(JavaRequests.scan(req)).toScala
+    case Query(req) => client.query(JavaRequests.query(req)).toScala
     // Overloading means we need explicit parameter types here
-    case BatchWrite(req) =>
-      futureOf(
-        client.batchWriteItemAsync(
-          _: BatchWriteItemRequest,
-          _: AsyncHandler[BatchWriteItemRequest, BatchWriteItemResult]
-        ),
-        req
-      )
-    case BatchGet(req) =>
-      futureOf(
-        client.batchGetItemAsync(_: BatchGetItemRequest, _: AsyncHandler[BatchGetItemRequest, BatchGetItemResult]),
-        req
-      )
-    case Update(req) =>
-      futureOf(client.updateItemAsync, JavaRequests.update(req))
+    case BatchWrite(req) => client.batchWriteItem(req).toScala
+    case BatchGet(req)   => client.batchGetItem(req).toScala
+    case Update(req)     => client.updateItem(JavaRequests.update(req)).toScala
     case ConditionalUpdate(req) =>
-      futureOf(client.updateItemAsync, JavaRequests.update(req))
-        .map(Either.right[ConditionalCheckFailedException, UpdateItemResult])
+      client
+        .updateItem(JavaRequests.update(req))
+        .toScala
+        .map(Either.right[ConditionalCheckFailedException, UpdateItemResponse](_))
         .recover {
           case e: ConditionalCheckFailedException => Either.left(e)
         }
-    case TransactWriteAll(req) => futureOf(client.transactWriteItemsAsync, JavaRequests.transactItems(req))
+    case TransactWriteAll(req) => client.transactWriteItems(JavaRequests.transactItems(req)).toScala
   }
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
@@ -16,51 +16,51 @@
 
 package org.scanamo.ops
 
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.scanamo.request._
 
 sealed trait ScanamoOpsA[A] extends Product with Serializable
-final case class Put(req: ScanamoPutRequest) extends ScanamoOpsA[PutItemResult]
+final case class Put(req: ScanamoPutRequest) extends ScanamoOpsA[PutItemResponse]
 final case class ConditionalPut(req: ScanamoPutRequest)
-    extends ScanamoOpsA[Either[ConditionalCheckFailedException, PutItemResult]]
-final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
-final case class Delete(req: ScanamoDeleteRequest) extends ScanamoOpsA[DeleteItemResult]
+    extends ScanamoOpsA[Either[ConditionalCheckFailedException, PutItemResponse]]
+final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResponse]
+final case class Delete(req: ScanamoDeleteRequest) extends ScanamoOpsA[DeleteItemResponse]
 final case class ConditionalDelete(req: ScanamoDeleteRequest)
-    extends ScanamoOpsA[Either[ConditionalCheckFailedException, DeleteItemResult]]
-final case class Scan(req: ScanamoScanRequest) extends ScanamoOpsA[ScanResult]
-final case class Query(req: ScanamoQueryRequest) extends ScanamoOpsA[QueryResult]
-final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
-final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResult]
-final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResult]
+    extends ScanamoOpsA[Either[ConditionalCheckFailedException, DeleteItemResponse]]
+final case class Scan(req: ScanamoScanRequest) extends ScanamoOpsA[ScanResponse]
+final case class Query(req: ScanamoQueryRequest) extends ScanamoOpsA[QueryResponse]
+final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResponse]
+final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResponse]
+final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResponse]
 final case class ConditionalUpdate(req: ScanamoUpdateRequest)
-    extends ScanamoOpsA[Either[ConditionalCheckFailedException, UpdateItemResult]]
-final case class TransactWriteAll(req: ScanamoTransactWriteRequest) extends ScanamoOpsA[TransactWriteItemsResult]
+    extends ScanamoOpsA[Either[ConditionalCheckFailedException, UpdateItemResponse]]
+final case class TransactWriteAll(req: ScanamoTransactWriteRequest) extends ScanamoOpsA[TransactWriteItemsResponse]
 
 object ScanamoOps {
   import cats.free.Free.liftF
 
-  def put(req: ScanamoPutRequest): ScanamoOps[PutItemResult] = liftF[ScanamoOpsA, PutItemResult](Put(req))
-  def conditionalPut(req: ScanamoPutRequest): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] =
-    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, PutItemResult]](ConditionalPut(req))
-  def get(req: GetItemRequest): ScanamoOps[GetItemResult] = liftF[ScanamoOpsA, GetItemResult](Get(req))
-  def delete(req: ScanamoDeleteRequest): ScanamoOps[DeleteItemResult] =
-    liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
+  def put(req: ScanamoPutRequest): ScanamoOps[PutItemResponse] = liftF[ScanamoOpsA, PutItemResponse](Put(req))
+  def conditionalPut(req: ScanamoPutRequest): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResponse]] =
+    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, PutItemResponse]](ConditionalPut(req))
+  def get(req: GetItemRequest): ScanamoOps[GetItemResponse] = liftF[ScanamoOpsA, GetItemResponse](Get(req))
+  def delete(req: ScanamoDeleteRequest): ScanamoOps[DeleteItemResponse] =
+    liftF[ScanamoOpsA, DeleteItemResponse](Delete(req))
   def conditionalDelete(
     req: ScanamoDeleteRequest
-  ): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] =
-    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, DeleteItemResult]](ConditionalDelete(req))
-  def scan(req: ScanamoScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
-  def query(req: ScanamoQueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](Query(req))
-  def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
-    liftF[ScanamoOpsA, BatchWriteItemResult](BatchWrite(req))
-  def batchGet(req: BatchGetItemRequest): ScanamoOps[BatchGetItemResult] =
-    liftF[ScanamoOpsA, BatchGetItemResult](BatchGet(req))
-  def update(req: ScanamoUpdateRequest): ScanamoOps[UpdateItemResult] =
-    liftF[ScanamoOpsA, UpdateItemResult](Update(req))
+  ): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResponse]] =
+    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, DeleteItemResponse]](ConditionalDelete(req))
+  def scan(req: ScanamoScanRequest): ScanamoOps[ScanResponse] = liftF[ScanamoOpsA, ScanResponse](Scan(req))
+  def query(req: ScanamoQueryRequest): ScanamoOps[QueryResponse] = liftF[ScanamoOpsA, QueryResponse](Query(req))
+  def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResponse] =
+    liftF[ScanamoOpsA, BatchWriteItemResponse](BatchWrite(req))
+  def batchGet(req: BatchGetItemRequest): ScanamoOps[BatchGetItemResponse] =
+    liftF[ScanamoOpsA, BatchGetItemResponse](BatchGet(req))
+  def update(req: ScanamoUpdateRequest): ScanamoOps[UpdateItemResponse] =
+    liftF[ScanamoOpsA, UpdateItemResponse](Update(req))
   def conditionalUpdate(
     req: ScanamoUpdateRequest
-  ): ScanamoOps[Either[ConditionalCheckFailedException, UpdateItemResult]] =
-    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, UpdateItemResult]](ConditionalUpdate(req))
-  def transactWriteAll(req: ScanamoTransactWriteRequest): ScanamoOps[TransactWriteItemsResult] =
-    liftF[ScanamoOpsA, TransactWriteItemsResult](TransactWriteAll(req))
+  ): ScanamoOps[Either[ConditionalCheckFailedException, UpdateItemResponse]] =
+    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, UpdateItemResponse]](ConditionalUpdate(req))
+  def transactWriteAll(req: ScanamoTransactWriteRequest): ScanamoOps[TransactWriteItemsResponse] =
+    liftF[ScanamoOpsA, TransactWriteItemsResponse](TransactWriteAll(req))
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoSyncInterpreter.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoSyncInterpreter.scala
@@ -18,8 +18,8 @@ package org.scanamo.ops
 
 import cats._
 import cats.syntax.either._
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 
 /**
   * Interpret Scanamo operations using blocking requests to DynamoDB with any
@@ -29,7 +29,7 @@ import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
   * the [Id Monad](http://typelevel.org/cats/datatypes/id.html) which is just
   * a type alias for the type itself (`type Id[A] = A`).
   */
-class ScanamoSyncInterpreter(client: AmazonDynamoDB) extends (ScanamoOpsA ~> Id) {
+class ScanamoSyncInterpreter(client: DynamoDbClient) extends (ScanamoOpsA ~> Id) {
   def apply[A](op: ScanamoOpsA[A]): Id[A] = op match {
     case Put(req) =>
       client.putItem(JavaRequests.put(req))

--- a/scanamo/src/main/scala/org/scanamo/update/UpdateExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/update/UpdateExpression.scala
@@ -16,7 +16,7 @@
 
 package org.scanamo.update
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import cats.data.NonEmptyVector
 import org.scanamo.{ DynamoFormat, DynamoValue }
 import org.scanamo.query._

--- a/scanamo/src/test/scala/org/scanamo/DynamoFormatTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/DynamoFormatTest.scala
@@ -2,6 +2,7 @@ package org.scanamo
 
 import scala.reflect.runtime.universe._
 
+import software.amazon.awssdk.services.dynamodb.model._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scalacheck._
 import org.scalatest.funspec.AnyFunSpec
@@ -20,9 +21,10 @@ class DynamoFormatTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPro
         val format = DynamoFormat[Person]
         forAll(gen) { a: A =>
           val person = Person("bob", a)
-          client.putItem(t, format.write(person).toAttributeValue.getM)
-          val resp = client.getItem(t, DynamoObject("name" -> "bob").toJavaMap)
-          format.read(DynamoObject(resp.getItem).toDynamoValue) shouldBe Right(person)
+          client.putItem(PutItemRequest.builder.tableName(t).item(format.write(person).toAttributeValue.m).build).get
+          val resp =
+            client.getItem(GetItemRequest.builder.tableName(t).key(DynamoObject("name" -> "bob").toJavaMap).build).get
+          format.read(DynamoObject(resp.item).toDynamoValue) shouldBe Right(person)
         }
       }
     }

--- a/scanamo/src/test/scala/org/scanamo/DynamoFormatTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/DynamoFormatTest.scala
@@ -2,7 +2,7 @@ package org.scanamo
 
 import scala.reflect.runtime.universe._
 
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scalacheck._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.fixtures._

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -22,7 +22,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
   val scanamo = ScanamoAsync(client)
 
   override protected def afterAll(): Unit = {
-    client.shutdown()
+    client.close()
     super.afterAll()
   }
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoFreeTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoFreeTest.scala
@@ -34,20 +34,22 @@ class RequestCountingInterpreter extends (ScanamoOpsA ~> RequestCountingInterpre
     case Scan(req) =>
       State(counter =>
         if (counter < 42)
-          counter + 1 -> new ScanResponse()
-            .withLastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1).toAttributeValue).asJava)
-            .withItems(List.fill(req.options.limit.getOrElse(50))(new util.HashMap[String, AttributeValue]()): _*)
+          counter + 1 -> ScanResponse.builder
+            .lastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1).toAttributeValue).asJava)
+            .items(List.fill(req.options.limit.getOrElse(50))(new util.HashMap[String, AttributeValue]()): _*)
+            .build
         else
-          counter -> new ScanResponse().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
+          counter -> ScanResponse.builder.items(List.empty[java.util.Map[String, AttributeValue]].asJava).build
       )
     case Query(req) =>
       State(counter =>
         if (counter < 42)
-          counter + 1 -> new QueryResponse()
-            .withLastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1).toAttributeValue).asJava)
-            .withItems(List.fill(req.options.limit.getOrElse(0))(new util.HashMap[String, AttributeValue]()): _*)
+          counter + 1 -> QueryResponse.builder
+            .lastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1).toAttributeValue).asJava)
+            .items(List.fill(req.options.limit.getOrElse(0))(new util.HashMap[String, AttributeValue]()): _*)
+            .build
         else
-          counter -> new QueryResponse().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
+          counter -> QueryResponse.builder.items(List.empty[java.util.Map[String, AttributeValue]].asJava).build
       )
     case BatchWrite(_)        => ???
     case BatchGet(_)          => ???

--- a/scanamo/src/test/scala/org/scanamo/ScanamoFreeTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoFreeTest.scala
@@ -5,7 +5,7 @@ import java.util
 import cats._
 import cats.data.State
 import cats.implicits._
-import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, QueryResult, ScanResult }
+import software.amazon.awssdk.services.dynamodb.model.{ AttributeValue, QueryResponse, ScanResponse }
 import org.scanamo.ops.{ BatchGet, BatchWrite, Query, _ }
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -34,20 +34,20 @@ class RequestCountingInterpreter extends (ScanamoOpsA ~> RequestCountingInterpre
     case Scan(req) =>
       State(counter =>
         if (counter < 42)
-          counter + 1 -> new ScanResult()
+          counter + 1 -> new ScanResponse()
             .withLastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1).toAttributeValue).asJava)
             .withItems(List.fill(req.options.limit.getOrElse(50))(new util.HashMap[String, AttributeValue]()): _*)
         else
-          counter -> new ScanResult().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
+          counter -> new ScanResponse().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
       )
     case Query(req) =>
       State(counter =>
         if (counter < 42)
-          counter + 1 -> new QueryResult()
+          counter + 1 -> new QueryResponse()
             .withLastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1).toAttributeValue).asJava)
             .withItems(List.fill(req.options.limit.getOrElse(0))(new util.HashMap[String, AttributeValue]()): _*)
         else
-          counter -> new QueryResult().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
+          counter -> new QueryResponse().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
       )
     case BatchWrite(_)        => ???
     case BatchGet(_)          => ???

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -1,10 +1,10 @@
 package org.scanamo
 
 import cats.implicits._
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.fixtures._

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -12,7 +12,7 @@ import org.scanamo.generic.auto._
 import org.scanamo.ops.ScanamoOps
 
 class ScanamoTest extends AnyFunSpec with Matchers {
-  val client = LocalDynamoDB.client()
+  val client = LocalDynamoDB.syncClient()
   val scanamo = Scanamo(client)
 
   it("should put asynchronously") {

--- a/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
@@ -27,6 +27,7 @@ import scala.concurrent.duration._
 import scala.compat.java8.DurationConverters._
 
 import java.net.URI
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 
 object LocalDynamoDB {
   def client(port: Int = 8042): DynamoDbAsyncClient =
@@ -39,6 +40,7 @@ object LocalDynamoDB {
           .apiCallTimeout(5.seconds.toJava)
           .build
       )
+      .httpClient(NettyNioAsyncHttpClient.builder.build)
       .region(Region.EU_WEST_1)
       .build
 

--- a/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
@@ -19,14 +19,14 @@ package org.scanamo
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.dynamodbv2._
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb._
+import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.collection.JavaConverters._
 
 object LocalDynamoDB {
-  def client(port: Int = 8042): AmazonDynamoDBAsync =
-    AmazonDynamoDBAsyncClient
+  def client(port: Int = 8042): DynamoDbAsyncClient =
+    DynamoDbAsyncClientClient
       .asyncBuilder()
       .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "credentials")))
       .withEndpointConfiguration(new EndpointConfiguration(s"http://localhost:$port", ""))

--- a/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
+++ b/testkit/src/main/scala/org/scanamo/LocalDynamoDB.scala
@@ -16,59 +16,132 @@
 
 package org.scanamo
 
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb._
 import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.compat.java8.DurationConverters._
+
+import java.net.URI
 
 object LocalDynamoDB {
   def client(port: Int = 8042): DynamoDbAsyncClient =
-    DynamoDbAsyncClientClient
-      .asyncBuilder()
-      .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "credentials")))
-      .withEndpointConfiguration(new EndpointConfiguration(s"http://localhost:$port", ""))
-      .withClientConfiguration(new ClientConfiguration().withClientExecutionTimeout(50000).withRequestTimeout(5000))
-      .build()
+    DynamoDbAsyncClient.builder
+      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "credentials")))
+      .endpointOverride(URI.create(s"http://localhost:$port"))
+      .overrideConfiguration(
+        ClientOverrideConfiguration.builder
+          .apiCallAttemptTimeout(5.seconds.toJava)
+          .apiCallTimeout(5.seconds.toJava)
+          .build
+      )
+      .region(Region.EU_WEST_1)
+      .build
 
-  def createTable(client: AmazonDynamoDB)(tableName: String)(attributes: (String, ScalarAttributeType)*) =
-    client.createTable(
-      attributeDefinitions(attributes),
-      tableName,
-      keySchema(attributes),
-      arbitraryThroughputThatIsIgnoredByDynamoDBLocal
-    )
+  def syncClient(port: Int = 8042): DynamoDbClient =
+    DynamoDbClient.builder
+      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "credentials")))
+      .endpointOverride(URI.create(s"http://localhost:$port"))
+      .overrideConfiguration(
+        ClientOverrideConfiguration.builder
+          .apiCallAttemptTimeout(5.seconds.toJava)
+          .apiCallTimeout(5.seconds.toJava)
+          .build
+      )
+      .region(Region.EU_WEST_1)
+      .build
+
+  def createTable(client: DynamoDbAsyncClient)(tableName: String)(attributes: (String, ScalarAttributeType)*) =
+    client
+      .createTable(
+        CreateTableRequest.builder
+          .attributeDefinitions(attributeDefinitions(attributes))
+          .tableName(tableName)
+          .keySchema(keySchema(attributes))
+          .provisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+          .build
+      )
+      .get
+
+  def createTable(client: DynamoDbClient)(tableName: String)(attributes: (String, ScalarAttributeType)*) =
+    client
+      .createTable(
+        CreateTableRequest.builder
+          .attributeDefinitions(attributeDefinitions(attributes))
+          .tableName(tableName)
+          .keySchema(keySchema(attributes))
+          .provisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+          .build
+      )
 
   def createTableWithIndex(
-    client: AmazonDynamoDB,
+    client: DynamoDbAsyncClient,
     tableName: String,
     secondaryIndexName: String,
     primaryIndexAttributes: List[(String, ScalarAttributeType)],
     secondaryIndexAttributes: List[(String, ScalarAttributeType)]
   ) =
-    client.createTable(
-      new CreateTableRequest()
-        .withTableName(tableName)
-        .withAttributeDefinitions(
-          attributeDefinitions(primaryIndexAttributes ++ (secondaryIndexAttributes diff primaryIndexAttributes))
-        )
-        .withKeySchema(keySchema(primaryIndexAttributes))
-        .withProvisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
-        .withGlobalSecondaryIndexes(
-          new GlobalSecondaryIndex()
-            .withIndexName(secondaryIndexName)
-            .withKeySchema(keySchema(secondaryIndexAttributes))
-            .withProvisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
-            .withProjection(new Projection().withProjectionType(ProjectionType.ALL))
-        )
-    )
+    client
+      .createTable(
+        CreateTableRequest.builder
+          .tableName(tableName)
+          .attributeDefinitions(
+            attributeDefinitions(primaryIndexAttributes ++ (secondaryIndexAttributes diff primaryIndexAttributes))
+          )
+          .keySchema(keySchema(primaryIndexAttributes))
+          .provisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+          .globalSecondaryIndexes(
+            GlobalSecondaryIndex.builder
+              .indexName(secondaryIndexName)
+              .keySchema(keySchema(secondaryIndexAttributes))
+              .provisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+              .projection(Projection.builder.projectionType(ProjectionType.ALL).build)
+              .build
+          )
+          .build
+      )
+      .get
 
-  def deleteTable(client: AmazonDynamoDB)(tableName: String) =
-    client.deleteTable(tableName)
+  def createTableWithIndex(
+    client: DynamoDbClient,
+    tableName: String,
+    secondaryIndexName: String,
+    primaryIndexAttributes: List[(String, ScalarAttributeType)],
+    secondaryIndexAttributes: List[(String, ScalarAttributeType)]
+  ) =
+    client
+      .createTable(
+        CreateTableRequest.builder
+          .tableName(tableName)
+          .attributeDefinitions(
+            attributeDefinitions(primaryIndexAttributes ++ (secondaryIndexAttributes diff primaryIndexAttributes))
+          )
+          .keySchema(keySchema(primaryIndexAttributes))
+          .provisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+          .globalSecondaryIndexes(
+            GlobalSecondaryIndex.builder
+              .indexName(secondaryIndexName)
+              .keySchema(keySchema(secondaryIndexAttributes))
+              .provisionedThroughput(arbitraryThroughputThatIsIgnoredByDynamoDBLocal)
+              .projection(Projection.builder.projectionType(ProjectionType.ALL).build)
+              .build
+          )
+          .build
+      )
 
-  def withTable[T](client: AmazonDynamoDB)(tableName: String)(attributeDefinitions: (String, ScalarAttributeType)*)(
+  def deleteTable(client: DynamoDbAsyncClient)(tableName: String) =
+    client.deleteTable { b => b.tableName(tableName); () }.get
+
+  def deleteTable(client: DynamoDbClient)(tableName: String) =
+    client.deleteTable { b => b.tableName(tableName); () }
+
+  def withTable[T](client: DynamoDbAsyncClient)(tableName: String)(
+    attributeDefinitions: (String, ScalarAttributeType)*
+  )(
     thunk: => T
   ): T = {
     createTable(client)(tableName)(attributeDefinitions: _*)
@@ -76,13 +149,29 @@ object LocalDynamoDB {
       try {
         thunk
       } finally {
-        client.deleteTable(tableName)
+        deleteTable(client)(tableName)
         ()
       }
     res
   }
 
-  def withRandomTable[T](client: AmazonDynamoDB)(attributeDefinitions: (String, ScalarAttributeType)*)(
+  def withTable[T](client: DynamoDbClient)(tableName: String)(
+    attributeDefinitions: (String, ScalarAttributeType)*
+  )(
+    thunk: => T
+  ): T = {
+    createTable(client)(tableName)(attributeDefinitions: _*)
+    val res =
+      try {
+        thunk
+      } finally {
+        deleteTable(client)(tableName)
+        ()
+      }
+    res
+  }
+
+  def withRandomTable[T](client: DynamoDbAsyncClient)(attributeDefinitions: (String, ScalarAttributeType)*)(
     thunk: String => T
   ): T = {
     var created: Boolean = false
@@ -101,27 +190,70 @@ object LocalDynamoDB {
       try {
         thunk(tableName)
       } finally {
-        client.deleteTable(tableName)
+        deleteTable(client)(tableName)
         ()
       }
     res
   }
 
-  def usingTable[T](client: AmazonDynamoDB)(tableName: String)(attributeDefinitions: (String, ScalarAttributeType)*)(
+  def withRandomTable[T](client: DynamoDbClient)(attributeDefinitions: (String, ScalarAttributeType)*)(
+    thunk: String => T
+  ): T = {
+    var created: Boolean = false
+    var tableName: String = null
+    while (!created) {
+      try {
+        tableName = java.util.UUID.randomUUID.toString
+        createTable(client)(tableName)(attributeDefinitions: _*)
+        created = true
+      } catch {
+        case _: ResourceInUseException =>
+      }
+    }
+
+    val res =
+      try {
+        thunk(tableName)
+      } finally {
+        deleteTable(client)(tableName)
+        ()
+      }
+    res
+  }
+
+  def usingTable[T](client: DynamoDbAsyncClient)(tableName: String)(
+    attributeDefinitions: (String, ScalarAttributeType)*
+  )(
     thunk: => T
   ): Unit = {
     withTable(client)(tableName)(attributeDefinitions: _*)(thunk)
     ()
   }
 
-  def usingRandomTable[T](client: AmazonDynamoDB)(attributeDefinitions: (String, ScalarAttributeType)*)(
+  def usingTable[T](client: DynamoDbClient)(tableName: String)(
+    attributeDefinitions: (String, ScalarAttributeType)*
+  )(
+    thunk: => T
+  ): Unit = {
+    withTable(client)(tableName)(attributeDefinitions: _*)(thunk)
+    ()
+  }
+
+  def usingRandomTable[T](client: DynamoDbAsyncClient)(attributeDefinitions: (String, ScalarAttributeType)*)(
     thunk: String => T
   ): Unit = {
     withRandomTable(client)(attributeDefinitions: _*)(thunk)
     ()
   }
 
-  def withTableWithSecondaryIndex[T](client: AmazonDynamoDB)(tableName: String, secondaryIndexName: String)(
+  def usingRandomTable[T](client: DynamoDbClient)(attributeDefinitions: (String, ScalarAttributeType)*)(
+    thunk: String => T
+  ): Unit = {
+    withRandomTable(client)(attributeDefinitions: _*)(thunk)
+    ()
+  }
+
+  def withTableWithSecondaryIndex[T](client: DynamoDbAsyncClient)(tableName: String, secondaryIndexName: String)(
     primaryIndexAttributes: (String, ScalarAttributeType)*
   )(secondaryIndexAttributes: (String, ScalarAttributeType)*)(
     thunk: => T
@@ -137,14 +269,36 @@ object LocalDynamoDB {
       try {
         thunk
       } finally {
-        client.deleteTable(tableName)
+        deleteTable(client)(tableName)
+        ()
+      }
+    res
+  }
+
+  def withTableWithSecondaryIndex[T](client: DynamoDbClient)(tableName: String, secondaryIndexName: String)(
+    primaryIndexAttributes: (String, ScalarAttributeType)*
+  )(secondaryIndexAttributes: (String, ScalarAttributeType)*)(
+    thunk: => T
+  ): T = {
+    createTableWithIndex(
+      client,
+      tableName,
+      secondaryIndexName,
+      primaryIndexAttributes.toList,
+      secondaryIndexAttributes.toList
+    )
+    val res =
+      try {
+        thunk
+      } finally {
+        deleteTable(client)(tableName)
         ()
       }
     res
   }
 
   def withRandomTableWithSecondaryIndex[T](
-    client: AmazonDynamoDB
+    client: DynamoDbAsyncClient
   )(primaryIndexAttributes: (String, ScalarAttributeType)*)(secondaryIndexAttributes: (String, ScalarAttributeType)*)(
     thunk: (String, String) => T
   ): T = {
@@ -172,7 +326,42 @@ object LocalDynamoDB {
       try {
         thunk(tableName, indexName)
       } finally {
-        client.deleteTable(tableName)
+        deleteTable(client)(tableName)
+        ()
+      }
+    res
+  }
+
+  def withRandomTableWithSecondaryIndex[T](
+    client: DynamoDbClient
+  )(primaryIndexAttributes: (String, ScalarAttributeType)*)(secondaryIndexAttributes: (String, ScalarAttributeType)*)(
+    thunk: (String, String) => T
+  ): T = {
+    var tableName: String = null
+    var indexName: String = null
+    var created: Boolean = false
+    while (!created) {
+      try {
+        tableName = java.util.UUID.randomUUID.toString
+        indexName = java.util.UUID.randomUUID.toString
+        createTableWithIndex(
+          client,
+          tableName,
+          indexName,
+          primaryIndexAttributes.toList,
+          secondaryIndexAttributes.toList
+        )
+        created = true
+      } catch {
+        case _: ResourceInUseException =>
+      }
+    }
+
+    val res =
+      try {
+        thunk(tableName, indexName)
+      } finally {
+        deleteTable(client)(tableName)
         ()
       }
     res
@@ -181,11 +370,15 @@ object LocalDynamoDB {
   private def keySchema(attributes: Seq[(String, ScalarAttributeType)]) = {
     val hashKeyWithType :: rangeKeyWithType = attributes.toList
     val keySchemas = hashKeyWithType._1 -> KeyType.HASH :: rangeKeyWithType.map(_._1 -> KeyType.RANGE)
-    keySchemas.map { case (symbol, keyType) => new KeySchemaElement(symbol, keyType) }.asJava
+    keySchemas.map { case (symbol, keyType) => KeySchemaElement.builder.attributeName(symbol).keyType(keyType).build }.asJava
   }
 
   private def attributeDefinitions(attributes: Seq[(String, ScalarAttributeType)]) =
-    attributes.map { case (symbol, attributeType) => new AttributeDefinition(symbol, attributeType) }.asJava
+    attributes.map {
+      case (symbol, attributeType) =>
+        AttributeDefinition.builder.attributeName(symbol).attributeType(attributeType).build
+    }.asJava
 
-  private val arbitraryThroughputThatIsIgnoredByDynamoDBLocal = new ProvisionedThroughput(1L, 1L)
+  private val arbitraryThroughputThatIsIgnoredByDynamoDBLocal =
+    ProvisionedThroughput.builder.readCapacityUnits(1L).writeCapacityUnits(1L).build
 }

--- a/zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -17,14 +17,14 @@
 package org.scanamo
 
 import cats.{ ~>, Monad }
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.AmazonDynamoDBException
 import org.scanamo.ops._
 import zio.IO
 import zio.interop.catz._
 import zio.stream.{ Stream, ZStream }
 
-class ScanamoZio private (client: AmazonDynamoDBAsync) {
+class ScanamoZio private (client: DynamoDbAsyncClient) {
   final private val interpreter: ScanamoOpsA ~> IO[AmazonDynamoDBException, ?] =
     new ZioInterpreter(client)
 
@@ -35,7 +35,7 @@ class ScanamoZio private (client: AmazonDynamoDBAsync) {
 }
 
 object ScanamoZio {
-  def apply(client: AmazonDynamoDBAsync): ScanamoZio = new ScanamoZio(client)
+  def apply(client: DynamoDbAsyncClient): ScanamoZio = new ScanamoZio(client)
 
   val ToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =
     new (IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?]) {

--- a/zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -18,27 +18,27 @@ package org.scanamo
 
 import cats.{ ~>, Monad }
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-import software.amazon.awssdk.services.dynamodb.model.AmazonDynamoDBException
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
 import org.scanamo.ops._
 import zio.IO
 import zio.interop.catz._
 import zio.stream.{ Stream, ZStream }
 
 class ScanamoZio private (client: DynamoDbAsyncClient) {
-  final private val interpreter: ScanamoOpsA ~> IO[AmazonDynamoDBException, ?] =
+  final private val interpreter: ScanamoOpsA ~> IO[DynamoDbException, ?] =
     new ZioInterpreter(client)
 
-  final def exec[A](op: ScanamoOps[A]): IO[AmazonDynamoDBException, A] = op.foldMap(interpreter)
+  final def exec[A](op: ScanamoOps[A]): IO[DynamoDbException, A] = op.foldMap(interpreter)
 
-  final def execT[M[_]: Monad, A](hoist: IO[AmazonDynamoDBException, ?] ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+  final def execT[M[_]: Monad, A](hoist: IO[DynamoDbException, ?] ~> M)(op: ScanamoOpsT[M, A]): M[A] =
     op.foldMap(interpreter andThen hoist)
 }
 
 object ScanamoZio {
   def apply(client: DynamoDbAsyncClient): ScanamoZio = new ScanamoZio(client)
 
-  val ToStream: IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?] =
-    new (IO[AmazonDynamoDBException, ?] ~> Stream[AmazonDynamoDBException, ?]) {
-      def apply[A](fa: IO[AmazonDynamoDBException, A]): Stream[AmazonDynamoDBException, A] = ZStream.fromEffect(fa)
+  val ToStream: IO[DynamoDbException, ?] ~> Stream[DynamoDbException, ?] =
+    new (IO[DynamoDbException, ?] ~> Stream[DynamoDbException, ?]) {
+      def apply[A](fa: IO[DynamoDbException, A]): Stream[DynamoDbException, A] = ZStream.fromEffect(fa)
     }
 }

--- a/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -3,6 +3,7 @@ package org.scanamo
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
 import org.scanamo.query._
 import org.scanamo.fixtures._
 import org.scanamo.generic.auto._
@@ -12,7 +13,6 @@ import cats.implicits._
 import zio.Runtime.default._
 import zio.stream.interop.catz._
 import zio.stream.{ Sink, Stream }
-import software.amazon.awssdk.services.dynamodb.model.AmazonDynamoDBException
 import org.scanamo.ops.ScanamoOps
 
 class ScanamoZioSpec extends AnyFunSpec with Matchers {
@@ -179,7 +179,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
   }
 
   it("should stream full table scan") {
-    type SIO[A] = Stream[AmazonDynamoDBException, A]
+    type SIO[A] = Stream[DynamoDbException, A]
 
     LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
       val list = List(

--- a/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -2,7 +2,7 @@ package org.scanamo
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 import org.scanamo.query._
 import org.scanamo.fixtures._
 import org.scanamo.generic.auto._
@@ -12,7 +12,7 @@ import cats.implicits._
 import zio.Runtime.default._
 import zio.stream.interop.catz._
 import zio.stream.{ Sink, Stream }
-import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
+import software.amazon.awssdk.services.dynamodb.model.AmazonDynamoDBException
 import org.scanamo.ops.ScanamoOps
 
 class ScanamoZioSpec extends AnyFunSpec with Matchers {


### PR DESCRIPTION
It's been too long coming and many people have asked for it. I don't think #395 is worth the pain.

Closes #395 

A few notable things:
- now that `AttributeValue` has better accessors, we can avoid allocating many `Option` when decoding attributes and items
- there's a lot of redundancy in `LocalDynamoDB`, I didn't want to tackle this here. It will be for a follow-up PR... the tests infra needs an overhaul anyway
