### PR TITLE
Upgrade to ZIO 1.0.0-RC20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ crossScalaVersions in ThisBuild := Seq("2.12.10", "2.13.1")
 
 val catsVersion = "2.1.1"
 val catsEffectVersion = "2.1.3"
-val zioVersion = "1.0.0-RC19"
+val zioVersion = "1.0.0-RC20"
 
 lazy val stdOptions = Seq(
   "-deprecation",
@@ -169,7 +169,7 @@ lazy val zio = (project in file("zio"))
       "org.typelevel"  %% "cats-effect"      % catsEffectVersion,
       "dev.zio"        %% "zio"              % zioVersion,
       "dev.zio"        %% "zio-streams"      % zioVersion % Provided,
-      "dev.zio"        %% "zio-interop-cats" % "2.0.0.0-RC14",
+      "dev.zio"        %% "zio-interop-cats" % "2.1.3.0-RC15",
       "org.scalatest"  %% "scalatest"        % "3.1.2"    % Test,
       "org.scalacheck" %% "scalacheck"       % "1.14.3"   % Test
     ),


### PR DESCRIPTION
### Summary

- Upgraded zio to 1.0.0-RC20.
- Upgraded zio-interop-cats to 2.1.3.0-RC15.
