### PR TITLE
Fix a bug in `ScanResponseStream`

### DIFF
--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -227,15 +227,20 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         Item("item #5"),
         Item("item #6")
       )
-      val expected = list.map(i => List(Right(i)))
+      val expected = list.map(i => Right(i))
 
       val items = Table[Item](t)
       val ops = for {
         _ <- items.putAll(list.toSet).toFreeT[SIO]
-        list <- items.scanPaginatedM[SIO](1)
+        list <- items.scanPaginatedM[SIO](4)
       } yield list
 
-      scanamo.execT(ScanamoCats.ToStream)(ops).compile.toList.unsafeRunSync should contain theSameElementsAs expected
+      scanamo
+        .execT(ScanamoCats.ToStream)(ops)
+        .compile
+        .toList
+        .unsafeRunSync
+        .flatten should contain theSameElementsAs expected
     }
   }
 

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -107,7 +107,7 @@ private[scanamo] object DynamoResultStream {
       res.items.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
     final def lastEvaluatedKey(res: QueryResponse) = 
       Option(res.lastEvaluatedKey).filterNot(_.isEmpty).map(DynamoObject(_))
-    
+
     final def scannedCount(res: QueryResponse) = Option(res.scannedCount().intValue())
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -87,7 +87,9 @@ private[scanamo] object DynamoResultStream {
   object ScanResponseStream extends DynamoResultStream[ScanamoScanRequest, ScanResponse] {
     final def items(res: ScanResponse) =
       res.items.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
-    final def lastEvaluatedKey(res: ScanResponse) = Option(res.lastEvaluatedKey).map(DynamoObject(_))
+    final def lastEvaluatedKey(res: ScanResponse) =
+      Option(res.lastEvaluatedKey).filterNot(_.isEmpty).map(DynamoObject(_))
+
     final def scannedCount(res: ScanResponse) = Option(res.scannedCount().intValue())
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -105,7 +105,7 @@ private[scanamo] object DynamoResultStream {
   object QueryResponseStream extends DynamoResultStream[ScanamoQueryRequest, QueryResponse] {
     final def items(res: QueryResponse) =
       res.items.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
-    final def lastEvaluatedKey(res: QueryResponse) = 
+    final def lastEvaluatedKey(res: QueryResponse) =
       Option(res.lastEvaluatedKey).filterNot(_.isEmpty).map(DynamoObject(_))
 
     final def scannedCount(res: QueryResponse) = Option(res.scannedCount().intValue())

--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -105,7 +105,9 @@ private[scanamo] object DynamoResultStream {
   object QueryResponseStream extends DynamoResultStream[ScanamoQueryRequest, QueryResponse] {
     final def items(res: QueryResponse) =
       res.items.stream.reduce[List[DynamoObject]](Nil, (m, xs) => DynamoObject(xs) :: m, _ ++ _).reverse
-    final def lastEvaluatedKey(res: QueryResponse) = Option(res.lastEvaluatedKey).map(DynamoObject(_))
+    final def lastEvaluatedKey(res: QueryResponse) = 
+      Option(res.lastEvaluatedKey).filterNot(_.isEmpty).map(DynamoObject(_))
+    
     final def scannedCount(res: QueryResponse) = Option(res.scannedCount().intValue())
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))


### PR DESCRIPTION
I noticed a bug with `scanPaginatedM` namely dynamo returns an empty object as last key when the result size is less than the limit, i.e. there are no more pages.  However `ScanResponseStream` doesn't recognize this and still try to use the empty object as the next start key causing a 
```
software.amazon.awssdk.services.dynamodb.model.DynamoDbException: Exclusive Start Key must have same size as table's key schema
```
This PR changed one of the tests to expose this error and fixed the bug by filtering out empty last key.