### PR TITLE
#1083 Add field naming modes

### DIFF
--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/AutoDerivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/AutoDerivation.scala
@@ -17,11 +17,12 @@
 package org.scanamo.generic
 
 import magnolia._
-
 import org.scanamo.DynamoFormat
+
 import scala.reflect.macros.whitebox
 
 trait AutoDerivation extends Derivation {
+  this: FieldNamingMode =>
 
   /** Materialize an exported format by wrapping the magnolia derivation
     * during macro expansion
@@ -30,6 +31,6 @@ trait AutoDerivation extends Derivation {
     */
   def materializeImpl[A: c.WeakTypeTag](c: whitebox.Context): c.Expr[Exported[DynamoFormat[A]]] = {
     val magnoliaTree = c.Expr[DynamoFormat[A]](Magnolia.gen[A](c))
-    c.universe.reify(new Exported(magnoliaTree.splice))
+    c.universe.reify(Exported(magnoliaTree.splice))
   }
 }

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/Derivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/Derivation.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyChain
 import cats.syntax.bifunctor._
 import cats.syntax.parallel._
 import magnolia._
-import org.scanamo.{DynamoFormat, DynamoObject, DynamoValue, _}
+import org.scanamo.{ DynamoFormat, DynamoObject, DynamoValue, _ }
 
 private[scanamo] trait Derivation {
   this: FieldNamingMode =>

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/Derivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/Derivation.scala
@@ -19,11 +19,11 @@ package org.scanamo.generic
 import cats.data.NonEmptyChain
 import cats.syntax.bifunctor._
 import cats.syntax.parallel._
-import org.scanamo.{ DynamoFormat, DynamoObject, DynamoValue }
-import org.scanamo._
 import magnolia._
+import org.scanamo.{DynamoFormat, DynamoObject, DynamoValue, _}
 
 private[scanamo] trait Derivation {
+  this: FieldNamingMode =>
   type Typeclass[A] = DynamoFormat[A]
 
   type FieldName = String
@@ -40,7 +40,7 @@ private[scanamo] trait Derivation {
   //    be accumulated
   def combine[T](cc: CaseClass[Typeclass, T]): Typeclass[T] = {
     def decodeField(o: DynamoObject, param: Param[Typeclass, T]): Valid[param.PType] =
-      o(param.label)
+      o(transformName(param.label))
         .fold[Either[DynamoReadError, param.PType]] {
           param.default.fold(param.typeclass.read(DynamoValue.nil).leftMap(_ => MissingProperty))(Right(_))
         }(param.typeclass.read(_))
@@ -72,7 +72,7 @@ private[scanamo] trait Derivation {
         def writeObject(t: T): DynamoObject =
           DynamoObject(cc.parameters.foldLeft(List.empty[(String, DynamoValue)]) { case (xs, p) =>
             val v = p.typeclass.write(p.dereference(t))
-            if (v.isNull) xs else (p.label -> v) :: xs
+            if (v.isNull) xs else (transformName(p.label) -> v) :: xs
           }: _*)
       }
   }

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
@@ -31,5 +31,3 @@ trait KebabCaseFieldNamingMode extends FieldNamingMode {
       .replaceAll(pattern.pattern(), "$1-$2")
       .toLowerCase()
 }
-
-

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
@@ -8,12 +8,12 @@ trait FieldNamingMode {
 
 trait NoOpFieldNamingMode extends FieldNamingMode {
 
-  @inline final override def transformName(fieldName: String): String = fieldName
+  final override def transformName(fieldName: String): String = fieldName
 }
 
 trait PascalCaseFieldNamingMode extends FieldNamingMode {
 
-  @inline final override def transformName(fieldName: String): String = fieldName.capitalize
+  final override def transformName(fieldName: String): String = fieldName.capitalize
 }
 
 trait SnakeCaseFieldNamingMode extends FieldNamingMode {

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
@@ -18,7 +18,7 @@ trait PascalCaseFieldNamingMode extends FieldNamingMode {
 
 trait SnakeCaseFieldNamingMode extends FieldNamingMode {
   private val pattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
-  override def transformName(fieldName: String): String =
+  final override def transformName(fieldName: String): String =
     fieldName
       .replaceAll(pattern.pattern(), "$1_$2")
       .toLowerCase()
@@ -26,7 +26,7 @@ trait SnakeCaseFieldNamingMode extends FieldNamingMode {
 
 trait KebabCaseFieldNamingMode extends FieldNamingMode {
   private val pattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
-  override def transformName(fieldName: String): String =
+  final override def transformName(fieldName: String): String =
     fieldName
       .replaceAll(pattern.pattern(), "$1-$2")
       .toLowerCase()

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/FieldNamingMode.scala
@@ -1,0 +1,35 @@
+package org.scanamo.generic
+
+import java.util.regex.Pattern
+
+trait FieldNamingMode {
+  def transformName(fieldName: String): String
+}
+
+trait NoOpFieldNamingMode extends FieldNamingMode {
+
+  @inline final override def transformName(fieldName: String): String = fieldName
+}
+
+trait PascalCaseFieldNamingMode extends FieldNamingMode {
+
+  @inline final override def transformName(fieldName: String): String = fieldName.capitalize
+}
+
+trait SnakeCaseFieldNamingMode extends FieldNamingMode {
+  private val pattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
+  override def transformName(fieldName: String): String =
+    fieldName
+      .replaceAll(pattern.pattern(), "$1_$2")
+      .toLowerCase()
+}
+
+trait KebabCaseFieldNamingMode extends FieldNamingMode {
+  private val pattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
+  override def transformName(fieldName: String): String =
+    fieldName
+      .replaceAll(pattern.pattern(), "$1-$2")
+      .toLowerCase()
+}
+
+

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/SemiautoDerivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/SemiautoDerivation.scala
@@ -22,5 +22,6 @@ import org.scanamo.DynamoFormat
 import scala.language.experimental.macros
 
 trait SemiautoDerivation extends Derivation {
+  this: FieldNamingMode =>
   final def deriveDynamoFormat[A]: DynamoFormat[A] = macro Magnolia.gen[A]
 }

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/kebabCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/kebabCase.scala
@@ -1,7 +1,7 @@
 package org.scanamo.generic.auto
 
 import org.scanamo.DynamoFormat
-import org.scanamo.generic.{AutoDerivation, Exported, KebabCaseFieldNamingMode}
+import org.scanamo.generic.{ AutoDerivation, Exported, KebabCaseFieldNamingMode }
 
 object kebabCase extends AutoDerivation with KebabCaseFieldNamingMode {
   implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/kebabCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/kebabCase.scala
@@ -1,0 +1,8 @@
+package org.scanamo.generic.auto
+
+import org.scanamo.DynamoFormat
+import org.scanamo.generic.{AutoDerivation, Exported, KebabCaseFieldNamingMode}
+
+object kebabCase extends AutoDerivation with KebabCaseFieldNamingMode {
+  implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]
+}

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/package.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/package.scala
@@ -16,15 +16,15 @@
 
 package org.scanamo.generic
 
-import scala.language.experimental.macros
-
 import org.scanamo.DynamoFormat
+
+import scala.language.experimental.macros
 
 /** Fully automatic format derivation.
   *
   * Importing the contents of this package object provides [[org.scanamo.DynamoFormat]]
   * instances for algebraic data types.
   */
-package object auto extends AutoDerivation {
+package object auto extends AutoDerivation with NoOpFieldNamingMode {
   implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]
 }

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/pascalCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/pascalCase.scala
@@ -1,7 +1,7 @@
 package org.scanamo.generic.auto
 
 import org.scanamo.DynamoFormat
-import org.scanamo.generic.{AutoDerivation, Exported, PascalCaseFieldNamingMode}
+import org.scanamo.generic.{ AutoDerivation, Exported, PascalCaseFieldNamingMode }
 
 object pascalCase extends AutoDerivation with PascalCaseFieldNamingMode {
   implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/pascalCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/pascalCase.scala
@@ -1,0 +1,8 @@
+package org.scanamo.generic.auto
+
+import org.scanamo.DynamoFormat
+import org.scanamo.generic.{AutoDerivation, Exported, PascalCaseFieldNamingMode}
+
+object pascalCase extends AutoDerivation with PascalCaseFieldNamingMode {
+  implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]
+}

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/snakeCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/snakeCase.scala
@@ -1,0 +1,8 @@
+package org.scanamo.generic.auto
+
+import org.scanamo.DynamoFormat
+import org.scanamo.generic.{AutoDerivation, Exported, SnakeCaseFieldNamingMode}
+
+object snakeCase extends AutoDerivation with SnakeCaseFieldNamingMode {
+  implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]
+}

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/snakeCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/auto/snakeCase.scala
@@ -1,7 +1,7 @@
 package org.scanamo.generic.auto
 
 import org.scanamo.DynamoFormat
-import org.scanamo.generic.{AutoDerivation, Exported, SnakeCaseFieldNamingMode}
+import org.scanamo.generic.{ AutoDerivation, Exported, SnakeCaseFieldNamingMode }
 
 object snakeCase extends AutoDerivation with SnakeCaseFieldNamingMode {
   implicit final def genericDerivedFormat[A]: Exported[DynamoFormat[A]] = macro materializeImpl[A]

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/kebabCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/kebabCase.scala
@@ -1,0 +1,5 @@
+package org.scanamo.generic.semiauto
+
+import org.scanamo.generic.{KebabCaseFieldNamingMode, SemiautoDerivation}
+
+object kebabCase extends SemiautoDerivation with KebabCaseFieldNamingMode

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/kebabCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/kebabCase.scala
@@ -1,5 +1,5 @@
 package org.scanamo.generic.semiauto
 
-import org.scanamo.generic.{KebabCaseFieldNamingMode, SemiautoDerivation}
+import org.scanamo.generic.{ KebabCaseFieldNamingMode, SemiautoDerivation }
 
 object kebabCase extends SemiautoDerivation with KebabCaseFieldNamingMode

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/package.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/package.scala
@@ -21,4 +21,4 @@ package org.scanamo.generic
   * This object provides helpers for creating [[org.scanamo.DynamoFormat]]
   * instances for case classes.
   */
-package object semiauto extends SemiautoDerivation
+package object semiauto extends SemiautoDerivation with NoOpFieldNamingMode

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/pascalCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/pascalCase.scala
@@ -1,5 +1,5 @@
 package org.scanamo.generic.semiauto
 
-import org.scanamo.generic.{PascalCaseFieldNamingMode, SemiautoDerivation}
+import org.scanamo.generic.{ PascalCaseFieldNamingMode, SemiautoDerivation }
 
 object pascalCase extends SemiautoDerivation with PascalCaseFieldNamingMode

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/pascalCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/pascalCase.scala
@@ -1,0 +1,5 @@
+package org.scanamo.generic.semiauto
+
+import org.scanamo.generic.{PascalCaseFieldNamingMode, SemiautoDerivation}
+
+object pascalCase extends SemiautoDerivation with PascalCaseFieldNamingMode

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/snakeCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/snakeCase.scala
@@ -1,0 +1,5 @@
+package org.scanamo.generic.semiauto
+
+import org.scanamo.generic.{SemiautoDerivation, SnakeCaseFieldNamingMode}
+
+object snakeCase extends SemiautoDerivation with SnakeCaseFieldNamingMode

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/snakeCase.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/semiauto/snakeCase.scala
@@ -1,5 +1,5 @@
 package org.scanamo.generic.semiauto
 
-import org.scanamo.generic.{SemiautoDerivation, SnakeCaseFieldNamingMode}
+import org.scanamo.generic.{ SemiautoDerivation, SnakeCaseFieldNamingMode }
 
 object snakeCase extends SemiautoDerivation with SnakeCaseFieldNamingMode

--- a/scanamo/src/test/scala-2.x/org/scanamo/DynamoFormatTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/DynamoFormatTest.scala
@@ -42,7 +42,7 @@ class DynamoFormatTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPro
     Gen.containerOf[Set, BigDecimal](Arbitrary.arbLong.arbitrary.map(BigDecimal(_)))
   )
   val nonEmptyStringGen: Gen[String] =
-    Gen.nonEmptyContainerOf[Array, Char](Arbitrary.arbChar.arbitrary).map(arr => new String(arr))
+    Gen.nonEmptyContainerOf[Array, Char](Arbitrary.arbChar.arbitrary).map(String.valueOf)
   testReadWrite[Set[String]](Gen.containerOf[Set, String](nonEmptyStringGen))
   testReadWrite[Option[String]](Gen.option(nonEmptyStringGen))
   testReadWrite[Option[Int]]()

--- a/scanamo/src/test/scala-2.x/org/scanamo/generic/AutoDerivationTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/generic/AutoDerivationTest.scala
@@ -63,4 +63,103 @@ class AutoDerivationTest extends AnyFunSuite with Matchers {
 
     result should ===(DynamoValue.fromString("foo"))
   }
+
+  test("Derivation with pascalCase naming mode should correctly write field names") {
+    final case class Person(name: String, age: Int)
+
+    import org.scanamo.generic.auto.pascalCase._
+
+    val result = DynamoFormat[Person].write(Person("john", 12))
+
+    result should ===(
+      DynamoValue.fromDynamoObject(
+        DynamoObject(
+          "Name" -> DynamoValue.fromString("john"),
+          "Age" -> DynamoValue.fromNumber(12)
+        )
+      )
+    )
+  }
+
+  test("Derivation with pascalCase naming mode should correctly read field names") {
+    final case class Person(name: String, age: Int)
+
+    import org.scanamo.generic.auto.pascalCase._
+
+    val dynamoObject = DynamoValue.fromDynamoObject(
+      DynamoObject(
+        "Name" -> DynamoValue.fromString("john"),
+        "Age" -> DynamoValue.fromNumber(12)
+      )
+    )
+    val result = DynamoFormat[Person].read(dynamoObject)
+
+    result should ===(Right(Person("john", 12)))
+  }
+
+  test("Derivation with snakeCase naming mode should correctly write field names") {
+    final case class Person(fullName: String, age: Int)
+
+    import org.scanamo.generic.auto.snakeCase._
+
+    val result = DynamoFormat[Person].write(Person("john", 12))
+
+    result should ===(
+      DynamoValue.fromDynamoObject(
+        DynamoObject(
+          "full_name" -> DynamoValue.fromString("john"),
+          "age" -> DynamoValue.fromNumber(12)
+        )
+      )
+    )
+  }
+
+  test("Derivation with snakeCase naming mode should correctly read field names") {
+    final case class Person(fullName: String, age: Int)
+
+    import org.scanamo.generic.auto.snakeCase._
+
+    val dynamoObject = DynamoValue.fromDynamoObject(
+      DynamoObject(
+        "full_name" -> DynamoValue.fromString("john"),
+        "age" -> DynamoValue.fromNumber(12)
+      )
+    )
+    val result = DynamoFormat[Person].read(dynamoObject)
+
+    result should ===(Right(Person("john", 12)))
+  }
+
+  test("Derivation with kebabCase naming mode should correctly write field names") {
+    final case class Person(fullName: String, age: Int)
+
+    import org.scanamo.generic.auto.kebabCase._
+
+    val result = DynamoFormat[Person].write(Person("john", 12))
+
+    result should ===(
+      DynamoValue.fromDynamoObject(
+        DynamoObject(
+          "full-name" -> DynamoValue.fromString("john"),
+          "age" -> DynamoValue.fromNumber(12)
+        )
+      )
+    )
+  }
+
+  test("Derivation with kebabCase naming mode should correctly read field names") {
+    final case class Person(fullName: String, age: Int)
+
+    import org.scanamo.generic.auto.kebabCase._
+
+    val dynamoObject = DynamoValue.fromDynamoObject(
+      DynamoObject(
+        "full-name" -> DynamoValue.fromString("john"),
+        "age" -> DynamoValue.fromNumber(12)
+      )
+    )
+    val result = DynamoFormat[Person].read(dynamoObject)
+
+    result should ===(Right(Person("john", 12)))
+  }
 }


### PR DESCRIPTION
This change adds a new `FieldNamingMode` trait that should be mixed into Derivation trait implementation (self-type requirement).  
This trait has `transformName `method that is responsible for transforming the case class parameters names.
The default implementation of this new trait is `NoOpFieldNamingMode` that is basically an identity function.
For specific naming conventions there are new objects in the packages `org.scanamo.generic.auto` and `org.scanamo.generic.semiauto`, new objects are:
* `kebabCase`
* `pascalCase`
* `snakeCase`

So, if the users want Scanamo to generate DynamoFormats for classes that have a related table with snake case fields in it, they just need to add this import: `import org.scanamo.generic.auto.snakeCase._`.

Alternatively, users can create their own implementations of `FieldNamingMode ` and mix it with `Derivation` trait.