### PR TITLE
Fix 404ing docs links

### DIFF
--- a/docs/docs/conditional-operations.md
+++ b/docs/docs/conditional-operations.md
@@ -6,7 +6,7 @@ position: 3
 
 ## Conditional Operations
 
-Modifying operations ([Put](operations.md#put-and-get), [Delete](operations.md#delete), [Update](operations.md#update)) can be performed conditionally, so that they only have an effect if some state of the DynamoDB table is true at the time of execution.
+Modifying operations ([Put](operations.html#put-and-get), [Delete](operations.html#delete), [Update](operations.html#update)) can be performed conditionally, so that they only have an effect if some state of the DynamoDB table is true at the time of execution.
 
 ```scala mdoc:silent
 import org.scanamo._

--- a/docs/docs/filters.md
+++ b/docs/docs/filters.md
@@ -6,8 +6,8 @@ position: 4
 
 ## Filters
 
-[Scans](operations.md#scan) and [Queries](operations.md#query) can be filtered within Dynamo, preventing the memory, network and marshalling overhead of filtering on the client.
- 
+[Scans](operations.html#scan) and [Queries](operations.html#query) can be filtered within Dynamo, preventing the memory, network and marshalling overhead of filtering on the client.
+
 Note that these filters do *not* reduce the [consumed capacity](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html) in Dynamo. Even though a filter may lead to a small number of results being
 returned, it could still exhaust the provisioned capacity or force the provisioned capacity to autoscale up to an expensive level.
 
@@ -32,7 +32,7 @@ LocalDynamoDB.withTable(client)("Station")("line" -> S, "name" -> S) {
       Station("Metropolitan", "Croxley", 7),
       Station("Jubilee", "Canons Park", 5)
     ))
-    filteredStations <- 
+    filteredStations <-
       stationTable
         .filter("zone" < 8)
         .query("line" === "Metropolitan" and ("name" beginsWith "C"))

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -32,7 +32,7 @@ import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
- 
+
 val client = LocalDynamoDB.syncClient()
 val scanamo = Scanamo(client)
 val farmersTableResult = LocalDynamoDB.createTable(client)("farmer")("name" -> S)
@@ -49,11 +49,11 @@ scanamo.exec(table.put(Farmer("McDonald", 156L, Farm(List("sheep", "cow")))))
 scanamo.exec(table.get("name" === "McDonald"))
 ```
 
-Scanamo supports most other DynamoDB [operations](operations.md), beyond
+Scanamo supports most other DynamoDB [operations](operations.html), beyond
 the basic `Put` and `Get`.
 
 The translation between Dynamo items and Scala types is handled by a type class
-called [DynamoFormat](dynamo-format.md).
+called [DynamoFormat](dynamo-format.html).
 
 Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 

--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Operations 
+title: Operations
 position: 1
 ---
 
@@ -11,18 +11,18 @@ Scanamo supports all the DynamoDB operations that interact with individual items
  * [Put](#put-and-get) for adding a new item, or replacing an existing one
  * [Get](#put-and-get) for retrieving an item by a fully specified key
  * [Delete](#delete) for removing an item
- * [Update](#update) for updating some portion of the fields of an item, whilst leaving the rest 
+ * [Update](#update) for updating some portion of the fields of an item, whilst leaving the rest
  as is
  * [Scan](#scan) for retrieving all elements of a table
  * [Query](#query) for retrieving all elements with a given hash-key and a range key that matches
  some criteria
- 
-Scanamo also supports [batched operations](batch-operations.md), [conditional operations](conditional-operations.md) 
-and queries against [secondary indexes](using-indexes.md).
- 
+
+Scanamo also supports [batched operations](batch-operations.html), [conditional operations](conditional-operations.html)
+and queries against [secondary indexes](using-indexes.html).
+
 ### Put and Get
 
-Often when using DynamoDB, the primary use case is simply putting objects into 
+Often when using DynamoDB, the primary use case is simply putting objects into
 Dynamo and subsequently retrieving them:
 
 ```scala mdoc:silent
@@ -49,7 +49,7 @@ scanamo.exec {
 }
 ```
 
-Note that when using `Table` no operations are actually executed against DynamoDB until `exec` is called. 
+Note that when using `Table` no operations are actually executed against DynamoDB until `exec` is called.
 
 ### Delete
 
@@ -96,7 +96,7 @@ val teamTable = Table[Team]("teams")
 scanamo.exec {
   for {
     _ <- teamTable.put(Team("Watford", 1, List("Blissett"), Some("Harry the Hornet")))
-    updated <- teamTable.update("name" === "Watford", 
+    updated <- teamTable.update("name" === "Watford",
       set("goals", 2) and append("scorers", "Barnes") and remove("mascot"))
   } yield updated
 }
@@ -124,7 +124,7 @@ case class FavouriteUpdate(name: String, colour: Option[String], number: Option[
 
 def updateFavourite(fu: FavouriteUpdate): Option[ScanamoOps[Either[DynamoReadError, Favourites]]] = {
   val updates: List[UpdateExpression] = List(
-    fu.colour.map(c => set("colour", c)), 
+    fu.colour.map(c => set("colour", c)),
     fu.number.map(n => set("number", n))
   ).flatten
   NonEmptyList.fromList(updates).map(ups =>
@@ -154,7 +154,7 @@ Further examples, showcasing different types of update can be found in the scala
 
 ### Scan
 
-If you want to go through all elements of a table, or index, Scanamo 
+If you want to go through all elements of a table, or index, Scanamo
 supports scanning it:
 
 ```scala mdoc:silent


### PR DESCRIPTION
Internal docs links are pointing to the source filename rather than the generated page