### PR TITLE
Upgrade to cats-effect v3.1.1, preparing for sbt v1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion in ThisBuild := "2.12.14"
 crossScalaVersions in ThisBuild := Seq("2.12.14", "2.13.6")
 
 val catsVersion = "2.6.1"
-val catsEffectVersion = "2.5.1"
+val catsEffectVersion = "3.1.1"
 val zioVersion = "1.0.9"
 
 lazy val stdOptions = Seq(

--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -27,7 +27,7 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 
 class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
   final private def eff[A <: AnyRef](fut: => CompletableFuture[A]): F[A] =
-    F.async { cb =>
+    F.async_ { cb =>
       fut.handle[Unit] { (a, x) =>
         if (a eq null)
           x match {

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -10,6 +10,7 @@ import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.fixtures._
 import org.scanamo.generic.auto._
+import cats.effect.unsafe.implicits.global
 
 class ScanamoCatsSpec extends AnyFunSpec with Matchers {
   val client = LocalDynamoDB.client()


### PR DESCRIPTION
The new, stricter eviction logic in sbt v1.5 (see https://github.com/sbt/sbt/pull/6221) spotted that the versions of `cats-effect` used by Scanamo were suspected to be binary incompatible:

```
[error] (zio / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.typelevel:cats-effect_2.12:3.1.1 (early-semver) is selected over 2.5.1
[error] 	    +- org.scanamo:scanamo-zio_2.12:1.0.0-M15+101-13c581a6-SNAPSHOT (depends on 3.1.1)
[error] 	    +- co.fs2:fs2-core_2.12:3.0.3                         (depends on 3.1.1)
[error] 	    +- org.typelevel:cats-effect_2.12:2.5.1               (depends on 2.5.1)
[error]
[error]
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```

Upgrading to use cats-effect v3.1.1 for consistency meant:

* Using `async_` rather than `async` (which has an updated method signature that supports cancellation) - see https://typelevel.org/cats-effect/docs/migration-guide#async
* Using `cats.effect.unsafe.implicits.global` in tests, where no `IORuntime` was available - an alternative way to do this would be using https://github.com/typelevel/cats-effect-testing/#scalatest . See also https://typelevel.org/cats-effect/docs/migration-guide#io