### PR TITLE
Upgrade to sbt v1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ scalaVersion in ThisBuild := "2.12.14"
 crossScalaVersions in ThisBuild := Seq("2.12.14", "2.13.6")
 
 val catsVersion = "2.6.1"
-val catsEffectVersion = "2.5.1"
+val catsEffectVersion = "3.1.1"
 val zioVersion = "1.0.9"
 
 lazy val stdOptions = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-scalaVersion in ThisBuild := "2.12.14"
-crossScalaVersions in ThisBuild := Seq("2.12.14", "2.13.6")
+ThisBuild / scalaVersion := "2.12.14"
+ThisBuild / crossScalaVersions := Seq("2.12.14", "2.13.6")
 
 val catsVersion = "2.6.1"
 val catsEffectVersion = "3.1.1"
@@ -80,7 +80,7 @@ val commonSettings = Seq(
      else
        mainScalacOptions).filter(_ != "-Xfatal-warnings")
   },
-  scalacOptions in (Compile, console) := (scalacOptions in Test).value,
+  Compile / console / scalacOptions := (Test / scalacOptions).value,
   autoAPIMappings := true,
   apiURL := Some(url("http://www.scanamo.org/latest/api/")),
   dynamoDBLocalDownloadDir := file(".dynamodb-local"),
@@ -188,8 +188,8 @@ lazy val catsEffect = (project in file("cats"))
       "org.scalatest"  %% "scalatest"   % "3.2.9"  % Test,
       "org.scalacheck" %% "scalacheck"  % "1.15.4" % Test
     ),
-    fork in Test := true,
-    scalacOptions in (Compile, doc) += "-no-link-warnings"
+    Test / fork := true,
+    Compile / doc / scalacOptions += "-no-link-warnings"
   )
   .dependsOn(scanamo, testkit % "test->test")
 
@@ -208,8 +208,8 @@ lazy val zio = (project in file("zio"))
       "org.scalatest"  %% "scalatest"        % "3.2.9"    % Test,
       "org.scalacheck" %% "scalacheck"       % "1.15.4"   % Test
     ),
-    fork in Test := true,
-    scalacOptions in (Compile, doc) += "-no-link-warnings"
+    Test / fork := true,
+    Compile / doc / scalacOptions += "-no-link-warnings"
   )
   .dependsOn(scanamo, testkit % "test->test")
 
@@ -227,9 +227,10 @@ lazy val alpakka = (project in file("alpakka"))
       "org.scalatest"      %% "scalatest"                    % "3.2.9"  % Test,
       "org.scalacheck"     %% "scalacheck"                   % "1.15.4" % Test
     ),
-    fork in Test := true,
+    evictionErrorLevel := Level.Info, // until Akka 2.6.16 released - see https://github.com/akka/akka/pull/30375
+    Test / fork := true,
     // unidoc can work out links to other project, but scalac can't
-    scalacOptions in (Compile, doc) += "-no-link-warnings"
+    Compile / doc / scalacOptions += "-no-link-warnings"
   )
   .dependsOn(scanamo, testkit % "test->test")
 
@@ -264,7 +265,7 @@ lazy val docs = (project in file("docs"))
   .dependsOn(scanamo % "compile->test", alpakka % "compile", refined % "compile")
 
 val publishingSettings = Seq(
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   scmInfo := Some(
     ScmInfo(
       url("https://github.com/scanamo/scanamo"),

--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -27,7 +27,7 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 
 class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
   final private def eff[A <: AnyRef](fut: => CompletableFuture[A]): F[A] =
-    F.async { cb =>
+    F.async_ { cb =>
       fut.handle[Unit] { (a, x) =>
         if (a eq null)
           x match {

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -10,6 +10,7 @@ import org.scanamo.query._
 import org.scanamo.syntax._
 import org.scanamo.fixtures._
 import org.scanamo.generic.auto._
+import cats.effect.unsafe.implicits.global
 
 class ScanamoCatsSpec extends AnyFunSpec with Matchers {
   val client = LocalDynamoDB.client()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.4


### PR DESCRIPTION
The changes required by this update are:

* Removing use of the [deprecated sbt-0.13-style-DSL **` in `** syntax](https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#Migrating+to+slash+syntax)
* Tweaks for sbt v1.5 eviction errors (see sbt/sbt#6221):
  * Upgrade `cats-effect` to v3.1.1 - see https://github.com/scanamo/scanamo/pull/1166, which should be merged before this PR
  * Set `evictionErrorLevel := Level.Info`, because while we can fix `cats-effect`, we can't currently fix `akka-http` - the current latest version of `akka-http` suffers from a semver issue with `scala-java8-compat` - see akka/akka#30375 :
  ```
  [info] 	* org.scala-lang.modules:scala-java8-compat_2.12:1.0.0 (early-semver) is selected over 0.8.0
  [info] 	    +- org.scanamo:scanamo_2.12:1.0.0-M15+99-399e98af+20210710-2246-SNAPSHOT (depends on 1.0.0)
  [info] 	    +- com.typesafe.akka:akka-actor_2.12:2.5.31           (depends on 0.8.0)
  ```