### PR TITLE
gitignore files that new developers will commonly encounter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ target/
 *dynamodb-local
 travis-deploy-key
 sbt.json
+.idea
+.bloop
+.bsp
+


### PR DESCRIPTION
Both IntelliJ and Bloop can create a lot of files that aren't meant to be committed to source control, and for new contributors coming to Scanamo, the big list of files they'll see when they come to contribute a commit can be quite intimidating. IntelliJ is a common IDE for Scala developers, even more so amongst [less-experienced devs](https://user-images.githubusercontent.com/52038/125192188-7133c500-e23e-11eb-829c-6b49a5135d9a.jpg).

One possible way of handling this is asking all contributors to add entries to their personal, user-specific, global git settings, which would avoid lengthening the .gitignore file committed within the repo itself. However, if that's the route we want to take, the very minimum we should do is *document this* for new contributors in the `CONTRIBUTING.md` file. At that point, it feels to me that it must be better to add common requirements in a machine-readable format in the .gitignore file, rather than writing more verbose human-friendly instructions in the `CONTRIBUTING.md`!