### PR TITLE
Remove instance-method version of `coercedXmap`

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala
@@ -56,8 +56,6 @@ trait DynamoFormat[T] {
 
   def iso[U](r: T => U, w: U => T): DynamoFormat[U] = DynamoFormat.iso(r, w)(this)
   def xmap[U](r: T => Either[DynamoReadError, U], w: U => T): DynamoFormat[U] = DynamoFormat.xmap(r, w)(this)
-  def coercedXmap[U](read: T => U, write: U => T): DynamoFormat[U] =
-    DynamoFormat.coercedXmap(read, write)(this, implicitly)
 }
 
 object DynamoFormat extends PlatformSpecificFormat {


### PR DESCRIPTION
The instance method version of `coercedXmap` on the `DynamoFormat` trait delegates to the static `DynamoFormat.coercedXmap` method - but that requires an implicit `ClassTag` for `T`, the `Throwable` type that it's allowed to coerce:

https://github.com/scanamo/scanamo/blob/4f79e47e1387c98a48120114050853d86c8df0c5/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala#L122-L126

The instance method version of `coercedXmap` can't know what that `Throwable` type is, so far as I can see, with it's current signature?

https://github.com/scanamo/scanamo/blob/4f79e47e1387c98a48120114050853d86c8df0c5/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala#L59-L60

The Scala 3 compiler spots this, and errors with a `No ClassTag available` message:

```
[error] -- Error: /home/roberto/development/scanamo/scanamo/src/main/scala/org/scanamo/DynamoFormat.scala:60:58
[error] 60 |    DynamoFormat.coercedXmap(read, write)(this, implicitly)
[error]    |                                                          ^
[error]    | No ClassTag available for T
[error]    |
[error]    | where:    T is a type variable with constraint >: Null and <: Throwable
```

...the Scala 2.13 compiler doesn't seem to have a problem with it, but probably should?!

As the `coercedXmap` instance method does not actually allow users to specify what subtype of `Throwable` they want to coerce, I suspect it's unused. Indeed, all the tests continue to compile with it removed. Consequently, I think it makes sense to delete it.
