### PR TITLE
Fix `docs/update` sbt task so IntelliJ BSP import succeeds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,6 +255,7 @@ lazy val docs = (project in file("docs"))
     commonSettings,
     micrositeSettings,
     noPublishSettings,
+    evictionErrorLevel := Level.Info, // until Akka 2.6.16 released - see https://github.com/akka/akka/pull/30375
     ghpagesNoJekyll := false,
     git.remoteRepo := "git@github.com:scanamo/scanamo.git",
     mdocVariables := Map(


### PR DESCRIPTION
With the update to sbt v1.5 in https://github.com/scanamo/scanamo/pull/1167 we realised that the `alpakka` subproject in Scanamo had a semver issue that needed handling. sbt v1.5 treats the eviction problems it encounters more seriously than previous versions of sbt, raising a fatal error rather than a warning, so this blocked the `alpakka` subproject from building - but as it turned out, the error _wasn't_ indicative of a serious incompatibility issue (see https://github.com/akka/akka/pull/30375). Consequently, we just set `evictionErrorLevel := Level.Info` [on the `alpakka` subproject](https://github.com/scanamo/scanamo/pull/1167/files#r672207910) and everything built again.

However, I hadn't taken into account that the `docs` subproject depends on `alpakka`, and when IntelliJ BSP import runs, it executes `docs/update`, which would consequently fail with a fatal eviction error (difficult to spot from the IntelliJ interface, which just says `sbt task failed, see log for details` unless you click on the root node):

```
sbt:root> docs/update
[error] stack trace is suppressed; run last docs / update for the full output
[error] (docs / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.scala-lang.modules:scala-java8-compat_2.12:1.0.0 (early-semver) is selected over 0.8.0
[error] 	    +- org.scanamo:scanamo_2.12:1.0.0-M15+103-86bea461-SNAPSHOT (depends on 1.0.0)
[error] 	    +- org.scanamo:scanamo-testkit_2.12:1.0.0-M15+103-86bea461-SNAPSHOT (depends on 1.0.0)
[error] 	    +- com.typesafe.akka:akka-actor_2.12:2.5.31           (depends on 0.8.0)
[error]
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
[error] Total time: 1 s, completed 19 Jul 2021, 10:57:57
```

![image](https://user-images.githubusercontent.com/52038/126150614-38808e95-5768-4685-bfcb-d732efb70617.png)

This doesn't happen if you just execute `update`, but does for `docs/update`. However, this issue can be fixed by additionally setting `evictionErrorLevel := Level.Info` on the `docs` subproject as well as `alpakka` - having done that, IntelliJ BSP import succeeds:

![image](https://user-images.githubusercontent.com/52038/126149878-f3ef7ebc-2fae-4344-ad2d-3555b4034b3b.png)

Many thanks to Dmitrii Naumenko (@unkarjedy) at JetBrains for [figuring this out](https://youtrack.jetbrains.com/issue/SCL-19190#focus=Comments-27-5053352.0-0)!

Once Akka 2.6.16 is released, we should be able to remove both `evictionErrorLevel` settings, as there will no longer be any eviction error, and eviction errors will be fatal throughout the project so if they are fatal for BSP import, they'll also be fatal for regular compilation, so there will no longer be a confusing situation about cause.