### PR TITLE
Preparatory work for Scala 3, set `-Xsource:3` scalac flag

### DIFF
--- a/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
+++ b/alpakka/src/test/scala/org/scanamo/ScanamoAlpakkaSpec.scala
@@ -122,7 +122,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val ops = for {
         _ <- farmers.putAll(dataSet)
         _ <- farmers.deleteAll("name" in dataSet.map(_.name))
-        fs <- farmers.scan
+        fs <- farmers.scan()
       } yield fs
 
       scanamo.exec(ops).runForeach(_ should equal(List.empty))
@@ -135,7 +135,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", None))
         _ <- forecasts.update("location" === "London", set("weather", "Sun"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops).runForeach(_ should equal(List(Right(Forecast("London", "Sun", None)))))
@@ -173,7 +173,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.scan
+        bs <- bears.scan()
       } yield bs
 
       scanamo
@@ -189,7 +189,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val lemmings = Table[Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
-        ls <- lemmings.scan
+        ls <- lemmings.scan()
       } yield ls
 
       scanamo.exec(ops).runForeach(_.size should equal(100))
@@ -202,7 +202,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.limit(1).scan
+        bs <- bears.limit(1).scan()
       } yield bs
       scanamo.exec(ops).runForeach(_ should equal(List(Right(Bear("Pooh", "honey", None)))))
     }
@@ -215,7 +215,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
-        bs <- bears.index(i).limit(1).scan
+        bs <- bears.index(i).limit(1).scan()
       } yield bs
       scanamo
         .exec(ops)
@@ -235,9 +235,9 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
-          _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" === "Graham" and "alias" === "Guardianista").scan
-          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and "alias" === "Kanga").scan
+          _ <- bears.index(i).limit(1).scan()
+          res2 <- bears.index(i).limit(1).from("name" === "Graham" and "alias" === "Guardianista").scan()
+          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and "alias" === "Kanga").scan()
         } yield res2 ::: res3
       } yield bs
 
@@ -377,10 +377,10 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
         val ops = for {
           _ <- stationTable.putAll(stations)
           ts1 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(LiverpoolStreet))
           ts3 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(CamdenTown))
           ts5 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 1 and 1))
         } yield (ts1, ts2, ts3, ts4, ts5)
@@ -424,7 +424,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
-        rs <- rabbits.scan
+        rs <- rabbits.scan()
       } yield rs
 
       scanamo.exec(result).runForeach(_.size should equal(100))
@@ -773,7 +773,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", Some("umbrella")))
         _ <- forecasts.update("location" === "London", setIfNotExists("equipment", "shades"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops).runForeach(_ should equal(List(Right(Forecast("London", "Sun", Some("umbrella"))))))
@@ -786,7 +786,7 @@ class ScanamoAlpakkaSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matc
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Sun", None))
         _ <- forecasts.update("location" === "London", setIfNotExists("equipment", "shades"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops).runForeach(_ should equal(List(Right(Forecast("London", "Sun", Some("shades"))))))

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,12 @@ lazy val stdOptions = Seq(
   "-encoding",
   "UTF-8",
   "-feature",
-  "-unchecked",
-  "-target:jvm-1.8"
+  "-unchecked"
 )
 
 lazy val std2xOptions = Seq(
+  "-Xsource:3", // https://docs.scala-lang.org/scala3/guides/migration/tooling-tour.html#the-scala-213-compiler
+  "-target:jvm-1.8",
   "-Xfatal-warnings",
   "-language:higherKinds",
   "-language:existentials",
@@ -137,7 +138,7 @@ lazy val scanamo = (project in file("scanamo"))
       "org.joda"           % "joda-convert"             % "2.2.1"       % Provided,
       "joda-time"          % "joda-time"                % "2.10.10"     % Test,
       "org.scalatest"     %% "scalatest"                % "3.2.9"       % Test,
-      "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test,
+      "org.scalatestplus" %% "scalacheck-1-15"          % "3.2.9.0"     % Test,
       "org.scalacheck"    %% "scalacheck"               % "1.15.4"      % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -47,23 +47,6 @@ def extraOptions(scalaVersion: String) =
     case _ => Seq.empty
   }
 
-def platformSpecificSources(conf: String, baseDirectory: File)(versions: String*) =
-  List("scala" :: versions.toList.map("scala-" + _): _*).map { version =>
-    baseDirectory.getParentFile / "src" / conf / version
-  }.filter(_.exists)
-
-def crossPlatformSources(scalaVer: String, conf: String, baseDir: File, isDotty: Boolean) =
-  CrossVersion.partialVersion(scalaVer) match {
-    case Some((2, x)) if x <= 11 =>
-      platformSpecificSources(conf, baseDir)("2.11", "2.x")
-    case Some((2, x)) if x >= 12 =>
-      platformSpecificSources(conf, baseDir)("2.12+", "2.12", "2.x")
-    case _ if isDotty =>
-      platformSpecificSources(conf, baseDir)("2.12+", "dotty")
-    case _ =>
-      Nil
-  }
-
 val commonSettings = Seq(
   organization := "org.scanamo",
   organizationName := "Scanamo",

--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -26,10 +26,10 @@ import java.util.concurrent.CompletionException
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 
 class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
-  final private def eff[A <: AnyRef](fut: => CompletableFuture[A]): F[A] =
+  final private def eff[A](fut: => CompletableFuture[A]): F[A] =
     F.async_ { cb =>
       fut.handle[Unit] { (a, x) =>
-        if (a eq null)
+        if (a == null)
           x match {
             case t: CompletionException => cb(Left(t.getCause))
             case t                      => cb(Left(t))
@@ -48,7 +48,7 @@ class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) e
         eff(client.putItem(JavaRequests.put(req))).attempt
           .flatMap(
             _.fold(
-              _ match {
+              {
                 case e: ConditionalCheckFailedException => F.delay(Left(e))
                 case t                                  => F.raiseError(t) // raise error as opposed to swallowing
               },

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -25,7 +25,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         f <- farmers.get("name" === "McDonald")
       } yield f
 
-      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](result).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](result).unsafeRunSync() should equal(
         Some(Right(Farmer("McDonald", 156, Farm(List("sheep", "cow")))))
       )
     }
@@ -43,7 +43,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
 
       scanamo
         .exec[(Option[Either[DynamoReadError, Farmer]], Boolean)](result)
-        .unsafeRunSync should equal(
+        .unsafeRunSync() should equal(
         (Some(Right(Farmer("Maggot", 75, Farm(List("dog"))))), true)
       )
     }
@@ -56,7 +56,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         e <- engines.get("name" === "Thomas" and "number" === 1)
       } yield e
 
-      scanamo.exec[Option[Either[DynamoReadError, Engine]]](result).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, Engine]]](result).unsafeRunSync() should equal(
         Some(Right(Engine("Thomas", 1)))
       )
     }
@@ -71,7 +71,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         c <- cities.consistently.get("name" === "Nashville")
       } yield c
 
-      scanamo.exec[Option[Either[DynamoReadError, City]]](result).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, City]]](result).unsafeRunSync() should equal(
         Some(Right(City("Nashville", "US")))
       )
     }
@@ -89,7 +89,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
             f <- farmers.get("name" === "McGregor")
           } yield f
         }
-        .unsafeRunSync should equal(None)
+        .unsafeRunSync() should equal(None)
     }
   }
 
@@ -106,10 +106,10 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- farmers.putAll(dataSet)
         _ <- farmers.deleteAll("name" in dataSet.map(_.name))
-        fs <- farmers.scan
+        fs <- farmers.scan()
       } yield fs
 
-      scanamo.exec[List[Either[DynamoReadError, Farmer]]](ops).unsafeRunSync should equal(List.empty)
+      scanamo.exec[List[Either[DynamoReadError, Farmer]]](ops).unsafeRunSync() should equal(List.empty)
     }
   }
 
@@ -119,10 +119,10 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", None))
         _ <- forecasts.update("location" === "London", set("weather", "Sun"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
-      scanamo.exec[List[Either[DynamoReadError, Forecast]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Forecast]]](ops).unsafeRunSync() should equal(
         List(Right(Forecast("London", "Sun", None)))
       )
     }
@@ -142,7 +142,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         results <- forecasts.scan()
       } yield results
 
-      scanamo.exec[List[Either[DynamoReadError, Forecast]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Forecast]]](ops).unsafeRunSync() should equal(
         List(Right(Forecast("London", "Rain", Some("umbrella"))), Right(Forecast("Birmingham", "Sun", None)))
       )
     }
@@ -155,10 +155,10 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.scan
+        bs <- bears.scan()
       } yield bs
 
-      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync() should equal(
         List(Right(Bear("Pooh", "honey", None)), Right(Bear("Yogi", "picnic baskets", None)))
       )
     }
@@ -167,10 +167,10 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val lemmings = Table[Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
-        ls <- lemmings.scan
+        ls <- lemmings.scan()
       } yield ls
 
-      scanamo.exec[List[Either[DynamoReadError, Lemming]]](ops).unsafeRunSync.size should equal(100)
+      scanamo.exec[List[Either[DynamoReadError, Lemming]]](ops).unsafeRunSync().size should equal(100)
     }
   }
 
@@ -180,9 +180,9 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.limit(1).scan
+        bs <- bears.limit(1).scan()
       } yield bs
-      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync() should equal(
         List(Right(Bear("Pooh", "honey", None)))
       )
     }
@@ -210,7 +210,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         list <- items.scanPaginatedM[SIO](1)
       } yield list
 
-      scanamo.execT(ScanamoCats.ToIterant)(ops).toListL.unsafeRunSync should contain theSameElementsAs expected
+      scanamo.execT(ScanamoCats.ToIterant)(ops).toListL.unsafeRunSync() should contain theSameElementsAs expected
     }
   }
 
@@ -240,7 +240,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         .execT(ScanamoCats.ToStream)(ops)
         .compile
         .toList
-        .unsafeRunSync
+        .unsafeRunSync()
         .flatten should contain theSameElementsAs expected
     }
   }
@@ -252,9 +252,9 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
-        bs <- bears.index(i).limit(1).scan
+        bs <- bears.index(i).limit(1).scan()
       } yield bs
-      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync() should equal(
         List(Right(Bear("Graham", "quinoa", Some("Guardianista"))))
       )
     }
@@ -268,13 +268,13 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
-          _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" === "Graham" and ("alias" === "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and ("alias" === "Kanga")).scan
+          _ <- bears.index(i).limit(1).scan()
+          res2 <- bears.index(i).limit(1).from("name" === "Graham" and ("alias" === "Guardianista")).scan()
+          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and ("alias" === "Kanga")).scan()
         } yield res2 ::: res3
       } yield bs
 
-      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Bear]]](ops).unsafeRunSync() should equal(
         List(Right(Bear("Yogi", "picnic baskets", Some("Kanga"))), Right(Bear("Pooh", "honey", Some("Winnie"))))
       )
     }
@@ -303,7 +303,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
             List[Either[org.scanamo.DynamoReadError, Animal]]
           )
         ](ops)
-        .unsafeRunSync should equal(
+        .unsafeRunSync() should equal(
         (
           List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2)), Right(Animal("Pig", 3))),
           List(Right(Animal("Pig", 1)), Right(Animal("Pig", 2))),
@@ -327,7 +327,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         ts <- transports.query("mode" === "Underground" and ("line" beginsWith "C"))
       } yield ts
 
-      scanamo.exec[List[Either[DynamoReadError, Transport]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Transport]]](ops).unsafeRunSync() should equal(
         List(Right(Transport("Underground", "Central", "Red")), Right(Transport("Underground", "Circle", "Yellow")))
       )
     }
@@ -347,7 +347,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         rs <- transports.limit(1).query("mode" === "Underground" and ("line" beginsWith "C"))
       } yield rs
 
-      scanamo.exec[List[Either[DynamoReadError, Transport]]](result).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Transport]]](result).unsafeRunSync() should equal(
         List(Right(Transport("Underground", "Central", "Red")))
       )
     }
@@ -376,7 +376,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
               )
         } yield rs
 
-        scanamo.exec[List[Either[DynamoReadError, Transport]]](result).unsafeRunSync should equal(
+        scanamo.exec[List[Either[DynamoReadError, Transport]]](result).unsafeRunSync() should equal(
           List(Right(Transport("Underground", "Northern", "Black")))
         )
     }
@@ -400,10 +400,10 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         val ops = for {
           _ <- stationTable.putAll(stations)
           ts1 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(LiverpoolStreet))
           ts3 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(CamdenTown))
           ts5 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 1 and 1))
         } yield (ts1, ts2, ts3, ts4, ts5)
@@ -418,7 +418,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
               List[Either[org.scanamo.DynamoReadError, Station]]
             )
           ](ops)
-          .unsafeRunSync should equal(
+          .unsafeRunSync() should equal(
           (
             List(Right(CamdenTown), Right(GoldersGreen), Right(Hainault)),
             List.empty,
@@ -438,7 +438,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         _ <- farmersTable.put(Worker("Fred", "McDonald", Some(54)))
         farmerWithNoAge <- farmersTable.filter(attributeNotExists("age")).query("firstName" === "Fred")
       } yield farmerWithNoAge
-      scanamo.exec[List[Either[DynamoReadError, Worker]]](farmerOps).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Worker]]](farmerOps).unsafeRunSync() should equal(
         List(Right(Worker("Fred", "Perry", None)))
       )
     }
@@ -449,10 +449,10 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
-        rs <- rabbits.scan
+        rs <- rabbits.scan()
       } yield rs
 
-      scanamo.exec[List[Either[DynamoReadError, Rabbit]]](result).unsafeRunSync.size should equal(100)
+      scanamo.exec[List[Either[DynamoReadError, Rabbit]]](result).unsafeRunSync().size should equal(100)
     }
   }
 
@@ -472,7 +472,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
           fs1 <- farmers.getAll(UniqueKeys(KeyList("name", Set("Boggis", "Bean"))))
           fs2 <- farmers.getAll("name" in Set("Boggis", "Bean"))
         } yield (fs1, fs2))
-        .unsafeRunSync should equal(
+        .unsafeRunSync() should equal(
         (
           Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))),
           Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey")))))
@@ -488,7 +488,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
           _ <- doctors.putAll(Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
           ds <- doctors.getAll("actor" -> "regeneration" =*= Set("McCoy" -> 9, "Ecclestone" -> 11))
         } yield ds)
-        .unsafeRunSync should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
+        .unsafeRunSync() should equal(Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
     }
   }
 
@@ -502,7 +502,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
           _ <- farmsTable.putAll(farms)
           fs <- farmsTable.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
         } yield fs)
-        .unsafeRunSync should equal(farms.map(Right(_)))
+        .unsafeRunSync() should equal(farms.map(Right(_)))
     }
   }
 
@@ -516,7 +516,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
           _ <- farmsTable.putAll(farms)
           fs <- farmsTable.consistently.getAll(UniqueKeys(KeyList("id", farms.map(_.id))))
         } yield fs)
-        .unsafeRunSync should equal(farms.map(Right(_)))
+        .unsafeRunSync() should equal(farms.map(Right(_)))
     }
   }
 
@@ -528,7 +528,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         result <- farmersTable.putAndReturn(PutReturn.OldValue)(Farmer("McDonald", 50L, Farm(List("chicken", "cow"))))
       } yield result
 
-      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync() should equal(
         Some(Right(Farmer("McDonald", 156L, Farm(List("sheep", "cow")))))
       )
     }
@@ -541,7 +541,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         result <- farmersTable.putAndReturn(PutReturn.OldValue)(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield result
 
-      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync() should equal(
         None
       )
     }
@@ -558,7 +558,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         farmerWithNewStock <- farmersTable.get("name" === "McDonald")
       } yield farmerWithNewStock
 
-      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync() should equal(
         Some(Right(Farmer("McDonald", 156, Farm(List("sheep", "chicken")))))
       )
     }
@@ -576,7 +576,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         _ <- farmersTable.when("age" between 58 and 59).put(Farmer("Butch", 57, Farm(List("dinosaur"))))
         farmerButch <- farmersTable.get("name" === "Butch")
       } yield farmerButch
-      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync should equal(
+      scanamo.exec[Option[Either[DynamoReadError, Farmer]]](farmerOps).unsafeRunSync() should equal(
         Some(Right(Farmer("Butch", 57, Farm(List("chicken")))))
       )
     }
@@ -593,7 +593,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         remainingGremlins <- gremlinsTable.scan()
       } yield remainingGremlins
 
-      scanamo.exec[List[Either[DynamoReadError, Gremlin]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Gremlin]]](ops).unsafeRunSync() should equal(
         List(Right(Gremlin(1, false)))
       )
     }
@@ -608,7 +608,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         items <- itemsTable.scan()
       } yield items
 
-      scanamo.exec[List[Either[DynamoReadError, Item]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Item]]](ops).unsafeRunSync() should equal(
         List(Right(Item("one")), Right(Item("two")))
       )
     }
@@ -626,7 +626,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
           items2 <- itemsTable2.scan()
         } yield items1 ::: items2
 
-        scanamo.exec[List[Either[DynamoReadError, Item]]](ops).unsafeRunSync should equal(
+        scanamo.exec[List[Either[DynamoReadError, Item]]](ops).unsafeRunSync() should equal(
           List(Right(Item("one")), Right(Item("two")))
         )
       }
@@ -650,7 +650,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         items <- forecastTable.scan()
       } yield items
 
-      scanamo.exec[List[Either[DynamoReadError, Forecast]]](ops).unsafeRunSync should equal(
+      scanamo.exec[List[Either[DynamoReadError, Forecast]]](ops).unsafeRunSync() should equal(
         List(
           Right(Forecast("Amsterdam", "Cloud", None)),
           Right(Forecast("London", "Rain", None)),
@@ -685,7 +685,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
 
         scanamo
           .exec[(List[Either[DynamoReadError, Gremlin]], List[Either[DynamoReadError, Forecast]])](ops)
-          .unsafeRunSync should equal(
+          .unsafeRunSync() should equal(
           (
             List(Right(Gremlin(2, wet = true)), Right(Gremlin(1, wet = false))),
             List(Right(Forecast("Amsterdam", "Fog", None)), Right(Forecast("London", "Rain", None)))
@@ -712,7 +712,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
         items <- forecastTable.scan()
       } yield items
 
-      scanamo.exec(ops).unsafeRunSync should equal(
+      scanamo.exec(ops).unsafeRunSync() should equal(
         List(Right(Forecast("Manchester", "Rain", None)))
       )
     }
@@ -741,7 +741,7 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
           forecasts <- forecastTable.scan()
         } yield (gremlins, forecasts)
 
-        scanamo.exec(ops).unsafeRunSync should equal(
+        scanamo.exec(ops).unsafeRunSync() should equal(
           (List(Right(Gremlin(1, wet = false))), List(Right(Forecast("Amsterdam", "Fog", None))))
         )
       }

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -87,7 +87,7 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
           final val iterator = new Iterator[String] {
             private[this] val underlying = xs.keySet.iterator
             final def hasNext = underlying.hasNext
-            final def next = underlying.next
+            final def next() = underlying.next
           }
         }
       case Pure(xs)       => xs.keys
@@ -104,7 +104,7 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
           final val iterator = new Iterator[DynamoValue] {
             private[this] val underlying = xs.values.iterator
             final def hasNext = underlying.hasNext
-            final def next = DynamoValue.fromAttributeValue(underlying.next)
+            final def next() = DynamoValue.fromAttributeValue(underlying.next)
           }
         }
       case Pure(xs)       => xs.values

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -98,7 +98,7 @@ object ScanamoFree {
   def transactUpdateAll(
     tableAndItems: List[(String, (UniqueKey[_], UpdateExpression))]
   ): ScanamoOps[TransactWriteItemsResponse] = {
-    val items = tableAndItems.map { case (tableName, (key, updateExpression)) ⇒
+    val items = tableAndItems.map { case (tableName, (key, updateExpression)) =>
       TransactUpdateItem(tableName, key.toDynamoObject, updateExpression, None)
     }
     ScanamoOps.transactWriteAll(ScanamoTransactWriteRequest(Seq.empty, items, Seq.empty))
@@ -112,7 +112,7 @@ object ScanamoFree {
   def transactDeleteAll(
     tableAndItems: List[(String, UniqueKey[_])]
   ): ScanamoOps[TransactWriteItemsResponse] = {
-    val items = tableAndItems.map { case (tableName, key) ⇒
+    val items = tableAndItems.map { case (tableName, key) =>
       TransactDeleteItem(tableName, key.toDynamoObject, None)
     }
     ScanamoOps.transactWriteAll(ScanamoTransactWriteRequest(Seq.empty, Seq.empty, items))

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -16,9 +16,9 @@
 
 package org.scanamo
 
-import cats.{ ~>, Id, Monad }
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import cats.{Id, Monad, catsInstancesForId, ~>}
 import org.scanamo.ops._
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 /** Provides a simplified interface for reading and writing case classes to DynamoDB
   *

--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -166,7 +166,7 @@ package object ops {
     }
 
     def transactItems(req: ScanamoTransactWriteRequest): TransactWriteItemsRequest = {
-      val putItems = req.putItems.map { item ⇒
+      val putItems = req.putItems.map { item =>
         TransactWriteItem.builder
           .put(
             software.amazon.awssdk.services.dynamodb.model.Put.builder
@@ -177,7 +177,7 @@ package object ops {
           .build
       }
 
-      val updateItems = req.updateItems.map { item ⇒
+      val updateItems = req.updateItems.map { item =>
         val update = software.amazon.awssdk.services.dynamodb.model.Update.builder
           .tableName(item.tableName)
           .updateExpression(item.updateExpression.expression)
@@ -185,13 +185,13 @@ package object ops {
           .key(item.key.toJavaMap)
 
         val updateWithAvs = DynamoObject(item.updateExpression.dynamoValues).toExpressionAttributeValues
-          .fold(update)(avs ⇒ update.expressionAttributeValues(avs))
+          .fold(update)(avs => update.expressionAttributeValues(avs))
           .build
 
         TransactWriteItem.builder.update(updateWithAvs).build
       }
 
-      val deleteItems = req.deleteItems.map { item ⇒
+      val deleteItems = req.deleteItems.map { item =>
         TransactWriteItem.builder
           .delete(
             software.amazon.awssdk.services.dynamodb.model.Delete.builder

--- a/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
@@ -163,7 +163,7 @@ object ConditionExpression {
             }
             ._1
           RequestCondition(
-            s"""#$namePlaceholder IN ${attributeValues.mapKeys(':' + _).keys.mkString("(", ",", ")")}""",
+            s"""#$namePlaceholder IN ${attributeValues.mapKeys(k => s":$k").keys.mkString("(", ",", ")")}""",
             attributeName.attributeNames(s"#$prefix"),
             Some(attributeValues)
           )

--- a/scanamo/src/test/scala-2.x/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/ScanamoAsyncTest.scala
@@ -108,7 +108,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
       val ops = for {
         _ <- farmers.putAll(dataSet)
         _ <- farmers.deleteAll("name" in dataSet.map(_.name))
-        fs <- farmers.scan
+        fs <- farmers.scan()
       } yield fs
 
       scanamo.exec(ops).futureValue should equal(List.empty)
@@ -121,7 +121,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", None))
         _ <- forecasts.update("location" === "London", set("weather", "Sun"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops).futureValue should equal(List(Right(Forecast("London", "Sun", None))))
@@ -155,7 +155,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.scan
+        bs <- bears.scan()
       } yield bs
 
       scanamo.exec(ops).futureValue should equal(
@@ -167,7 +167,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
       val lemmings = Table[Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
-        ls <- lemmings.scan
+        ls <- lemmings.scan()
       } yield ls
 
       scanamo.exec(ops).futureValue.size should equal(100)
@@ -180,7 +180,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.limit(1).scan
+        bs <- bears.limit(1).scan()
       } yield bs
       scanamo.exec(ops).futureValue should equal(List(Right(Bear("Pooh", "honey", None))))
     }
@@ -193,7 +193,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
-        bs <- bears.index(i).limit(1).scan
+        bs <- bears.index(i).limit(1).scan()
       } yield bs
       scanamo.exec(ops).futureValue should equal(
         List(Right(Bear("Graham", "quinoa", Some("Guardianista"))))
@@ -209,9 +209,9 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
-          _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" === "Graham" and "alias" === "Guardianista").scan
-          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and "alias" === "Kanga").scan
+          _ <- bears.index(i).limit(1).scan()
+          res2 <- bears.index(i).limit(1).from("name" === "Graham" and "alias" === "Guardianista").scan()
+          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and "alias" === "Kanga").scan()
         } yield res2 ::: res3
       } yield bs
 
@@ -382,10 +382,10 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
         val ops = for {
           _ <- stationTable.putAll(stations)
           ts1 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(LiverpoolStreet))
           ts3 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(CamdenTown))
           ts5 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 1 and 1))
         } yield (ts1, ts2, ts3, ts4, ts5)
@@ -421,7 +421,7 @@ class ScanamoAsyncTest extends AnyFunSpec with Matchers with BeforeAndAfterAll w
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
-        rs <- rabbits.scan
+        rs <- rabbits.scan()
       } yield rs
 
       scanamo.exec(result).futureValue.size should equal(100)

--- a/scanamo/src/test/scala-2.x/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/ScanamoTest.scala
@@ -97,7 +97,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- farmers.putAll(dataSet)
         _ <- farmers.deleteAll("name" in dataSet.map(_.name))
-        fs <- farmers.scan
+        fs <- farmers.scan()
       } yield fs
 
       scanamo.exec(ops) should equal(List.empty)
@@ -110,7 +110,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", None))
         _ <- forecasts.update("location" === "London", set("weather", "Sun"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops) should equal(List(Right(Forecast("London", "Sun", None))))
@@ -144,7 +144,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.scan
+        bs <- bears.scan()
       } yield bs
 
       scanamo.exec(ops) should equal(
@@ -156,7 +156,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val lemmings = Table[Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
-        ls <- lemmings.scan
+        ls <- lemmings.scan()
       } yield ls
 
       scanamo.exec(ops).size should equal(100)
@@ -169,7 +169,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.limit(1).scan
+        bs <- bears.limit(1).scan()
       } yield bs
       scanamo.exec(ops) should equal(List(Right(Bear("Pooh", "honey", None))))
     }
@@ -182,7 +182,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
-        bs <- bears.index(i).limit(1).scan
+        bs <- bears.index(i).limit(1).scan()
       } yield bs
       scanamo.exec(ops) should equal(List(Right(Bear("Graham", "quinoa", Some("Guardianista")))))
     }
@@ -196,9 +196,9 @@ class ScanamoTest extends AnyFunSpec with Matchers {
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
-          _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" === "Graham" and "alias" === "Guardianista").scan
-          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and "alias" === "Kanga").scan
+          _ <- bears.index(i).limit(1).scan()
+          res2 <- bears.index(i).limit(1).from("name" === "Graham" and "alias" === "Guardianista").scan()
+          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and "alias" === "Kanga").scan()
         } yield res2 ::: res3
       } yield bs
 
@@ -343,10 +343,10 @@ class ScanamoTest extends AnyFunSpec with Matchers {
         val ops = for {
           _ <- stationTable.putAll(stations)
           ts1 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(LiverpoolStreet))
           ts3 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(CamdenTown))
           ts5 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 1 and 1))
         } yield (ts1, ts2, ts3, ts4, ts5)
@@ -382,7 +382,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
-        rs <- rabbits.scan
+        rs <- rabbits.scan()
       } yield rs
 
       scanamo.exec(result).size should equal(100)
@@ -671,7 +671,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", Some("umbrella")))
         _ <- forecasts.update("location" === "London", setIfNotExists("equipment", "shades"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops) should equal(List(Right(Forecast("London", "Rain", Some("umbrella")))))
@@ -684,7 +684,7 @@ class ScanamoTest extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Sun", None))
         _ <- forecasts.update("location" === "London", setIfNotExists("equipment", "shades"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       scanamo.exec(ops) should equal(List(Right(Forecast("London", "Sun", Some("shades")))))

--- a/scanamo/src/test/scala-2.x/org/scanamo/TableTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/TableTest.scala
@@ -72,7 +72,7 @@ class TableTest extends AnyFunSpec with Matchers {
       val operations = for {
         _ <- farm.putAll(dataSet)
         _ <- farm.deleteAll("name" in dataSet.map(_.name))
-        scanned <- farm.scan
+        scanned <- farm.scan()
       } yield scanned.toList
       scanamo.exec(operations) should be(Nil)
     }
@@ -641,7 +641,7 @@ class TableTest extends AnyFunSpec with Matchers {
                 "line" === "Jubilee"
               )
             )
-            .scan
+            .scan()
       } yield filteredStations
 
       scanamo.exec(ops) should be(
@@ -666,7 +666,7 @@ class TableTest extends AnyFunSpec with Matchers {
             Station("Jubilee", "Canons Park", 5)
           )
         )
-        filteredStations <- stationTable.filter(AttributeName.of("line") contains "opo").scan
+        filteredStations <- stationTable.filter(AttributeName.of("line") contains "opo").scan()
       } yield filteredStations
 
       scanamo.exec(ops) should contain theSameElementsAs (

--- a/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -101,7 +101,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- farmers.putAll(dataSet)
         _ <- farmers.deleteAll("name" in dataSet.map(_.name))
-        fs <- farmers.scan
+        fs <- farmers.scan()
       } yield fs
 
       unsafeRun(zio.exec(ops)) should equal(List.empty)
@@ -114,7 +114,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Rain", None))
         _ <- forecasts.update("location" === "London", set("weather", "Sun"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       unsafeRun(zio.exec(ops)) should equal(List(Right(Forecast("London", "Sun", None))))
@@ -148,7 +148,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.scan
+        bs <- bears.scan()
       } yield bs
 
       unsafeRun(zio.exec(ops)) should equal(
@@ -160,7 +160,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val lemmings = Table[Lemming](t)
       val ops = for {
         _ <- lemmings.putAll(List.fill(100)(Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet)
-        ls <- lemmings.scan
+        ls <- lemmings.scan()
       } yield ls
 
       unsafeRun(zio.exec(ops)).size should equal(100)
@@ -173,7 +173,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- bears.put(Bear("Pooh", "honey", None))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
-        bs <- bears.limit(1).scan
+        bs <- bears.limit(1).scan()
       } yield bs
       unsafeRun(zio.exec(ops)) should equal(List(Right(Bear("Pooh", "honey", None))))
     }
@@ -212,7 +212,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
         _ <- bears.put(Bear("Pooh", "honey", Some("Winnie")))
         _ <- bears.put(Bear("Yogi", "picnic baskets", None))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
-        bs <- bears.index(i).limit(1).scan
+        bs <- bears.index(i).limit(1).scan()
       } yield bs
       unsafeRun(zio.exec(ops)) should equal(List(Right(Bear("Graham", "quinoa", Some("Guardianista")))))
     }
@@ -226,9 +226,9 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
         _ <- bears.put(Bear("Yogi", "picnic baskets", Some("Kanga")))
         _ <- bears.put(Bear("Graham", "quinoa", Some("Guardianista")))
         bs <- for {
-          _ <- bears.index(i).limit(1).scan
-          res2 <- bears.index(i).limit(1).from("name" === "Graham" and ("alias" === "Guardianista")).scan
-          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and ("alias" === "Kanga")).scan
+          _ <- bears.index(i).limit(1).scan()
+          res2 <- bears.index(i).limit(1).from("name" === "Graham" and ("alias" === "Guardianista")).scan()
+          res3 <- bears.index(i).limit(1).from("name" === "Yogi" and ("alias" === "Kanga")).scan()
         } yield res2 ::: res3
       } yield bs
 
@@ -346,10 +346,10 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
         val ops = for {
           _ <- stationTable.putAll(stations)
           ts1 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts2 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(LiverpoolStreet))
           ts3 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 2 and 4))
-          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan } yield ts
+          ts4 <- for { _ <- deletaAllStations(stationTable, stations); ts <- stationTable.scan() } yield ts
           _ <- stationTable.putAll(Set(CamdenTown))
           ts5 <- stationTable.index(i).query("mode" === "Underground" and ("zone" between 1 and 1))
         } yield (ts1, ts2, ts3, ts4, ts5)
@@ -385,7 +385,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val rabbits = Table[Rabbit](t)
       val result = for {
         _ <- rabbits.putAll(List.fill(100)(Rabbit(util.Random.nextString(500))).toSet)
-        rs <- rabbits.scan
+        rs <- rabbits.scan()
       } yield rs
 
       unsafeRun(zio.exec(result)).size should equal(100)
@@ -680,7 +680,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Sun", Some("umbrella")))
         _ <- forecasts.update("location" === "London", setIfNotExists("equipment", "shades"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       unsafeRun(zio.exec(ops)) should equal(List(Right(Forecast("London", "Sun", Some("umbrella")))))
@@ -693,7 +693,7 @@ class ScanamoZioSpec extends AnyFunSpec with Matchers {
       val ops = for {
         _ <- forecasts.put(Forecast("London", "Sun", None))
         _ <- forecasts.update("location" === "London", setIfNotExists("equipment", "shades"))
-        fs <- forecasts.scan
+        fs <- forecasts.scan()
       } yield fs
 
       unsafeRun(zio.exec(ops)) should equal(List(Right(Forecast("London", "Sun", Some("shades")))))


### PR DESCRIPTION
_Here's a few things to move the codebase closer to compatibility with Scala 3 (without actually activating Scala 3 compilation at this point):_

## `-Xsource:3` scalac flag

The [`-Xsource:3`](https://docs.scala-lang.org/scala3/guides/migration/tooling-tour.html#the-scala-213-compiler) flag is an option that's been added to the latest releases of the Scala 2 compiler - it aims to enforce a bit more Scala 3 compatibility in the source code.

## Fixing Scala compiler...

### ...Errors 

* Fix Scala 3.0.0 `E057 Type Mismatch Error` compiler errors in Scanamo interpreter classes with some DRY refactors.

### ....Warnings

#### Scala 3

* In Scala 3, defining implicits requires a type declaration. Once you have that type declared, you can also sometimes use a more-compact [SAM](https://www.scala-lang.org/news/2.12.0/#lambda-syntax-for-sam-types) declaration.
* String concatenation with `+` is discouraged by Scala 3

#### Scala 2.13

* The `⇒` symbol was deprecated in favour of `=>` in Scala 2.13 (see scala/scala-dev#585) - Scala 3 doesn't emit a warning for it at the moment, but will do once https://github.com/lampepfl/dotty/pull/13136 is merged.
* Avoid auto-application to `()`, deprecated in Scala 2.13

## Remove unused methods in `build.sbt`

The `platformSpecificSources()` & `crossPlatformSources()` methods added to build.sbt with https://github.com/scanamo/scanamo/pull/828 were unused, and don't seem to be needed for Scala 3 support.