### PR TITLE
Fix #1184 (`cats-effect` version conflict) by dropping Monix for now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,10 +165,7 @@ lazy val catsEffect = (project in file("cats"))
       "org.typelevel"  %% "cats-free"   % catsVersion,
       "org.typelevel"  %% "cats-core"   % catsVersion,
       "org.typelevel"  %% "cats-effect" % catsEffectVersion,
-      "io.monix"       %% "monix"       % "3.4.0"  % Provided,
-      "co.fs2"         %% "fs2-core"    % "2.5.6"  % Provided,
-      "io.monix"       %% "monix"       % "3.4.0"  % Test,
-      "co.fs2"         %% "fs2-core"    % "2.5.6"  % Test,
+      "co.fs2"         %% "fs2-core"    % "3.1.0",
       "org.scalatest"  %% "scalatest"   % "3.2.9"  % Test,
       "org.scalacheck" %% "scalacheck"  % "1.15.4" % Test
     ),

--- a/cats/src/main/scala/org/scanamo/ScanamoCats.scala
+++ b/cats/src/main/scala/org/scanamo/ScanamoCats.scala
@@ -20,7 +20,6 @@ import cats.{ ~>, Monad }
 import cats.effect.Async
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import fs2.Stream
-import monix.tail.Iterant
 import org.scanamo.ops.{ CatsInterpreter, ScanamoOps, ScanamoOpsT }
 
 class ScanamoCats[F[_]: Async](client: DynamoDbAsyncClient) {
@@ -34,11 +33,6 @@ class ScanamoCats[F[_]: Async](client: DynamoDbAsyncClient) {
 
 object ScanamoCats {
   def apply[F[_]: Async](client: DynamoDbAsyncClient): ScanamoCats[F] = new ScanamoCats(client)
-
-  def ToIterant[F[_]: Async]: F ~> Iterant[F, *] =
-    new (F ~> Iterant[F, *]) {
-      def apply[A](fa: F[A]): Iterant[F, A] = Iterant.liftF(fa)
-    }
 
   def ToStream[F[_]: Async]: F ~> Stream[F, *] =
     new (F ~> Stream[F, *]) {

--- a/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
+++ b/cats/src/test/scala/org/scanamo/ScanamoCatsSpec.scala
@@ -188,32 +188,6 @@ class ScanamoCatsSpec extends AnyFunSpec with Matchers {
     }
   }
 
-  it("should stream full table scan to a Monix Iterant") {
-    import monix.tail.Iterant
-
-    type SIO[A] = Iterant[IO, A]
-
-    LocalDynamoDB.usingRandomTable(client)("name" -> S) { t =>
-      val list = List(
-        Item("item #1"),
-        Item("item #2"),
-        Item("item #3"),
-        Item("item #4"),
-        Item("item #5"),
-        Item("item #6")
-      )
-      val expected = list.map(i => List(Right(i)))
-
-      val items = Table[Item](t)
-      val ops = for {
-        _ <- items.putAll(list.toSet).toFreeT[SIO]
-        list <- items.scanPaginatedM[SIO](1)
-      } yield list
-
-      scanamo.execT(ScanamoCats.ToIterant)(ops).toListL.unsafeRunSync() should contain theSameElementsAs expected
-    }
-  }
-
   it("should stream full table scan to an FS2 stream") {
     import fs2.Stream
 


### PR DESCRIPTION
This change updates to the latest version of `fs2-core`, which is now compatible with `cats-effect` v3.1.1 (introduced in
https://github.com/scanamo/scanamo/pull/1166). Unfortunately there's not yet a version of `monix` that supports `cats-effect` v3.1.1, so we're dropping support for Monix for now - the actual implementation code within Scanamo for the Monix support is only 4 lines, so can probably be easily copied into an end-user project if it's needed!

Sbt is capable of warning us about version conflicts in dependencies, but gave no warning of the `cats-effect` version conflict, I think because the `fs2-core` & `monix` dependencies were marked as already `Provided`. My guess as to why the `Provided` marker was used is that the `scanamo-cats-effect` artifact gave support for both `fs2-core` & `monix`,but in general a consuming project is likely to only be using one of those - by declaring the two dependencies as `Provided`, neither will be implicitly pulled in as a transitive dependency of `scanamo-cats-effect` when used in the end-user project - giving the end-user-project freedom to just explicitly declare a dependency on the one they want to use (another approach to this problem would be to split the `scanamo-cats-effect` artifact into two separate modules). As we've dropped Monix support, and there's now only `fs2-core` support, I've changed the `fs2-core` dependency to be explicit, which will give us the benefit of sbt version-conflict warnings in future.

See also https://github.com/scanamo/scanamo/issues/1184