### PR TITLE
Scala 3 prep: Upgrade to magnolia 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,9 +131,9 @@ lazy val scanamo = (project in file("scanamo"))
   .settings(
     libraryDependencies ++= Seq(
       awsDynamoDB,
-      "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.0",
-      "org.typelevel"          %% "cats-free"          % catsVersion,
-      "com.propensive"         %% "magnolia"           % "0.12.7",
+      "org.scala-lang.modules"       %% "scala-java8-compat" % "1.0.0",
+      "org.typelevel"                %% "cats-free"          % catsVersion,
+      "com.softwaremill.magnolia1_2" %% "magnolia"           % "1.0.0-M5",
       // Use Joda for custom conversion example
       "org.joda"           % "joda-convert"    % "2.2.1"   % Provided,
       "joda-time"          % "joda-time"       % "2.10.10" % Test,

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/AutoDerivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/AutoDerivation.scala
@@ -16,7 +16,7 @@
 
 package org.scanamo.generic
 
-import magnolia._
+import magnolia1._
 
 import org.scanamo.DynamoFormat
 import scala.reflect.macros.whitebox

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/Derivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/Derivation.scala
@@ -21,7 +21,7 @@ import cats.syntax.bifunctor._
 import cats.syntax.parallel._
 import org.scanamo.{ DynamoFormat, DynamoObject, DynamoValue }
 import org.scanamo._
-import magnolia._
+import magnolia1._
 
 private[scanamo] trait Derivation {
   type Typeclass[A] = DynamoFormat[A]

--- a/scanamo/src/main/scala-2.x/org/scanamo/generic/SemiautoDerivation.scala
+++ b/scanamo/src/main/scala-2.x/org/scanamo/generic/SemiautoDerivation.scala
@@ -16,7 +16,7 @@
 
 package org.scanamo.generic
 
-import magnolia.Magnolia
+import magnolia1.Magnolia
 import org.scanamo.DynamoFormat
 
 import scala.language.experimental.macros


### PR DESCRIPTION
Only the most recent releases of the Magnolia library are available for both Scala 2 and 3 - this is since the project maintainership moved to the https://github.com/softwaremill organisation. Note that as part of this move, there's an updated group id, and package name of `magnolia1` - some details about that here: https://github.com/softwaremill/magnolia/issues/327