### PR TITLE
Update to magnolia v1.0.0-M7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,8 @@ lazy val scanamo = (project in file("scanamo"))
       awsDynamoDB,
       "org.scala-lang.modules"       %% "scala-java8-compat" % "1.0.1",
       "org.typelevel"                %% "cats-free"          % catsVersion,
-      "com.softwaremill.magnolia1_2" %% "magnolia"           % "1.0.0-M5",
+      "com.softwaremill.magnolia1_2" %% "magnolia"           % "1.0.0-M7",
+      "org.scala-lang"                % "scala-reflect"      % scalaVersion.value,
       // Use Joda for custom conversion example
       "org.joda"           % "joda-convert"    % "2.2.1"    % Provided,
       "joda-time"          % "joda-time"       % "2.10.12"  % Test,


### PR DESCRIPTION
This upgrade requires dealing with a change introduced with magnolia [v1.0.0-M6](https://github.com/softwaremill/magnolia/releases/tag/scala2-v1.0.0-M6), which switched method names [from `combine`/`dispatch` to `join`/`split`](https://github.com/softwaremill/magnolia/issues/247).

This PR replaces the auto-PR #1221.