### PR TITLE
Reinstate fatal severity of sbt eviction errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,9 @@ lazy val zio = (project in file("zio"))
   )
   .dependsOn(scanamo, testkit % "test->test")
 
+// Necessary until Alpakka uses Akka 2.6.16 or later - see https://github.com/akka/akka/pull/30375
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
+
 lazy val alpakka = (project in file("alpakka"))
   .settings(
     commonSettings,
@@ -211,7 +214,6 @@ lazy val alpakka = (project in file("alpakka"))
       "org.scalatest"      %% "scalatest"                    % "3.2.9"  % Test,
       "org.scalacheck"     %% "scalacheck"                   % "1.15.4" % Test
     ),
-    evictionErrorLevel := Level.Info, // until Akka 2.6.16 released - see https://github.com/akka/akka/pull/30375
     Test / fork := true,
     // unidoc can work out links to other project, but scalac can't
     Compile / doc / scalacOptions += "-no-link-warnings"
@@ -239,7 +241,6 @@ lazy val docs = (project in file("docs"))
     commonSettings,
     micrositeSettings,
     noPublishSettings,
-    evictionErrorLevel := Level.Info, // until Akka 2.6.16 released - see https://github.com/akka/akka/pull/30375
     ghpagesNoJekyll := false,
     git.remoteRepo := "git@github.com:scanamo/scanamo.git",
     mdocVariables := Map(


### PR DESCRIPTION
With PRs https://github.com/scanamo/scanamo/pull/1167 (upgrading to sbt v1.5) & https://github.com/scanamo/scanamo/pull/1176 we made _all_ of sbt's new eviction errors non-fatal, but it turns that wasn't necessary - we can just compensate specifically for the problematic `scala-java8-compat` dependency with a `libraryDependencySchemes` setting, which _won't_ disable eviction errors for all other dependencies.

Many thanks to @ennru for finding that out and [passing it](https://github.com/akka/alpakka/pull/2688#issuecomment-981676632) on! Now I look closer at the sbt v1.5.0 release notes, I see this [was mentioned](https://github.com/sbt/sbt/releases/tag/v1.5.0#:~:text=If%20the%20user,effect%22%20%25%20VersionScheme.Always), I just missed it I guess :disappointed: .

