### PR TITLE
Improved index paging

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -16,12 +16,12 @@
 
 package org.scanamo
 
-import cats.{Monad, MonoidK}
-import org.scanamo.DynamoResultStream.{QueryResponseStream, ScanResponseStream}
-import org.scanamo.ops.{ScanamoOps, ScanamoOpsT}
-import org.scanamo.query.{Condition, ConditionExpression, IndexKey, Query}
-import org.scanamo.request.{ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest}
-import software.amazon.awssdk.services.dynamodb.model.{QueryResponse, ScanResponse}
+import cats.{ Monad, MonoidK }
+import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
+import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
+import org.scanamo.query.{ Condition, ConditionExpression, IndexKey, Query }
+import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
+import software.amazon.awssdk.services.dynamodb.model.{ QueryResponse, ScanResponse }
 
 /** Represents a secondary index on a DynamoDB table.
   *

--- a/scanamo/src/main/scala/org/scanamo/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/package.scala
@@ -18,6 +18,7 @@ package org
 
 import org.scanamo.query._
 import org.scanamo.update._
+
 import scala.language.implicitConversions
 
 package object scanamo {
@@ -77,6 +78,14 @@ package object scanamo {
 
     implicit class OrConditionExpression[X: ConditionExpression](x: X) {
       def or[Y: ConditionExpression](y: Y): OrCondition[X, Y] = OrCondition(x, y)
+    }
+
+    /** Syntax for `AndEqualsCondition` instances over a pair of `KeyEquals` with an `and` method to support
+      * construction of index keys of 3 properties.
+      */
+    implicit class AndEqualsConditionOps[H, S](ae: AndEqualsCondition[KeyEquals[H], KeyEquals[S]]) {
+      def and[I](ke: KeyEquals[I]): IndexKey3[KeyEquals[H], KeyEquals[S], KeyEquals[I]] =
+        IndexKey3(ae.hashEquality, ae.rangeEquality, ke)
     }
 
     @deprecated("use uncurried `set(attr, value)` syntax", "1.0")

--- a/scanamo/src/main/scala/org/scanamo/query/IndexKey.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/IndexKey.scala
@@ -1,0 +1,126 @@
+package org.scanamo.query
+
+import cats.implicits._
+import org.scanamo.DynamoObject
+
+/** A lawless typeclass functionally identical to [[UniqueKeyCondition]] but used to constrain a different set values
+  * to be used as index keys.
+  */
+trait IndexKey[T] {
+  type K
+  def toDynamoObject(t: T): DynamoObject
+  def fromDynamoObject(key: K, dvs: DynamoObject): Option[T]
+  def key(t: T): K
+}
+
+/** An index key with 3 properties to support paginating indexes whose key structure has a property that does not
+  * overlap with that of the parent table.
+  */
+final case class IndexKey3[A, B, C](a: A, b: B, c: C) {
+  def and[D](d: D): IndexKey4[A, B, C, D] = IndexKey4(a, b, c, d)
+}
+
+/** An index key with 4 properties to support paginating indexes having both a hash key and a sort key that do not
+  * overlap with those of the parent table.
+  */
+final case class IndexKey4[A, B, C, D](a: A, b: B, c: C, d: D)
+
+object IndexKey {
+  type Aux[T, K0] = IndexKey[T] { type K = K0 }
+
+  def toDynamoObject[T, K](t: T)(implicit T: IndexKey.Aux[T, K]): DynamoObject = T.toDynamoObject(t)
+
+  /** Summon of an instance for `IndexKey3`.
+    */
+  def of3[A, B, C](implicit
+    K: IndexKey.Aux[IndexKey3[KeyEquals[A], KeyEquals[B], KeyEquals[C]], (AttributeName, AttributeName, AttributeName)]
+  ): Aux[IndexKey3[KeyEquals[A], KeyEquals[B], KeyEquals[C]], (AttributeName, AttributeName, AttributeName)] = K
+
+  /** Summoner of an instance for `IndexKey3` where the types of the underlying properties are the same.
+    */
+  def of3Hom[A](implicit
+    K: IndexKey.Aux[IndexKey3[KeyEquals[A], KeyEquals[A], KeyEquals[A]], (AttributeName, AttributeName, AttributeName)]
+  ): Aux[IndexKey3[KeyEquals[A], KeyEquals[A], KeyEquals[A]], (AttributeName, AttributeName, AttributeName)] = K
+
+  def of4[A, B, C, D](implicit
+    K: IndexKey.Aux[IndexKey4[KeyEquals[A], KeyEquals[B], KeyEquals[C], KeyEquals[D]],
+                    (AttributeName, AttributeName, AttributeName, AttributeName)
+    ]
+  ): Aux[IndexKey4[KeyEquals[A], KeyEquals[B], KeyEquals[C], KeyEquals[D]],
+         (AttributeName, AttributeName, AttributeName, AttributeName)
+  ] = K
+
+  def of4Hom[A](implicit
+    K: IndexKey.Aux[IndexKey4[KeyEquals[A], KeyEquals[A], KeyEquals[A], KeyEquals[A]],
+                    (AttributeName, AttributeName, AttributeName, AttributeName)
+    ]
+  ): Aux[IndexKey4[KeyEquals[A], KeyEquals[A], KeyEquals[A], KeyEquals[A]],
+         (AttributeName, AttributeName, AttributeName, AttributeName)
+  ] = K
+
+  /** `IndexKey` instance for `AndEqualsCondition[KeyEquals[H], KeyEquals[S]]` to support established syntax.
+    */
+  implicit def andEquals[H, S](implicit
+    HS: UniqueKeyCondition[AndEqualsCondition[KeyEquals[H], KeyEquals[S]]]
+  ): IndexKey[AndEqualsCondition[KeyEquals[H], KeyEquals[S]]] {
+    type K = HS.K
+  } =
+    new IndexKey[AndEqualsCondition[KeyEquals[H], KeyEquals[S]]] {
+      type K = HS.K
+      final def toDynamoObject(t: AndEqualsCondition[KeyEquals[H], KeyEquals[S]]): DynamoObject =
+        HS.toDynamoObject(t)
+      final def fromDynamoObject(key: K, dvs: DynamoObject): Option[AndEqualsCondition[KeyEquals[H], KeyEquals[S]]] =
+        HS.fromDynamoObject(key, dvs)
+      final def key(t: AndEqualsCondition[KeyEquals[H], KeyEquals[S]]): K = HS.key(t)
+    }
+
+  /* `IndexKey` instances for `IndexKey3` and `IndexKey4`, supporting established syntax over index keys of 3-4
+   * properties. */
+
+  implicit def indexKey3[H, R, S](implicit
+    H: UniqueKeyCondition[KeyEquals[H]],
+    R: UniqueKeyCondition[KeyEquals[R]],
+    S: UniqueKeyCondition[KeyEquals[S]]
+  ): IndexKey[IndexKey3[KeyEquals[H], KeyEquals[R], KeyEquals[S]]] { type K = (H.K, R.K, S.K) } =
+    new IndexKey[IndexKey3[KeyEquals[H], KeyEquals[R], KeyEquals[S]]] {
+      type K = (H.K, R.K, S.K)
+      final def toDynamoObject(t: IndexKey3[KeyEquals[H], KeyEquals[R], KeyEquals[S]]): DynamoObject =
+        H.toDynamoObject(t.a) <> R.toDynamoObject(t.b) <> S.toDynamoObject(t.c)
+      final def fromDynamoObject(key: K,
+                                 dvs: DynamoObject
+      ): Option[IndexKey3[KeyEquals[H], KeyEquals[R], KeyEquals[S]]] =
+        (H.fromDynamoObject(key._1, dvs), R.fromDynamoObject(key._2, dvs), S.fromDynamoObject(key._3, dvs))
+          .mapN(IndexKey3(_, _, _))
+      final def key(t: IndexKey3[KeyEquals[H], KeyEquals[R], KeyEquals[S]]): K = (H.key(t.a), R.key(t.b), S.key(t.c))
+    }
+
+  implicit def indexKey4[TH, TS, IH, IS](implicit
+    TH: UniqueKeyCondition[KeyEquals[TH]],
+    TS: UniqueKeyCondition[KeyEquals[TS]],
+    IH: UniqueKeyCondition[KeyEquals[IH]],
+    IS: UniqueKeyCondition[KeyEquals[IS]]
+  ): IndexKey[IndexKey4[KeyEquals[TH], KeyEquals[TS], KeyEquals[IH], KeyEquals[IS]]] {
+    type K = (TH.K, TS.K, IH.K, IS.K)
+  } =
+    new IndexKey[IndexKey4[KeyEquals[TH], KeyEquals[TS], KeyEquals[IH], KeyEquals[IS]]] {
+      type K = (TH.K, TS.K, IH.K, IS.K)
+
+      final def toDynamoObject(t: IndexKey4[KeyEquals[TH], KeyEquals[TS], KeyEquals[IH], KeyEquals[IS]]): DynamoObject =
+        TH.toDynamoObject(t.a) <> TS.toDynamoObject(t.b) <> IH.toDynamoObject(t.c) <> IS.toDynamoObject(t.d)
+
+      final def fromDynamoObject(key: (TH.K, TS.K, IH.K, IS.K),
+                                 dvs: DynamoObject
+      ): Option[IndexKey4[KeyEquals[TH], KeyEquals[TS], KeyEquals[IH], KeyEquals[IS]]] =
+        (
+          TH.fromDynamoObject(key._1, dvs),
+          TS.fromDynamoObject(key._2, dvs),
+          IH.fromDynamoObject(key._3, dvs),
+          IS.fromDynamoObject(key._4, dvs)
+        )
+          .mapN(IndexKey4(_, _, _, _))
+
+      final def key(t: IndexKey4[KeyEquals[TH], KeyEquals[TS], KeyEquals[IH], KeyEquals[IS]]): K =
+        (TH.key(t.a), TS.key(t.b), IH.key(t.c), IS.key(t.d))
+    }
+
+}

--- a/scanamo/src/test/scala-2.x/org/scanamo/SecondaryIndexTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/SecondaryIndexTest.scala
@@ -146,9 +146,7 @@ class SecondaryIndexTest extends AnyFunSpec with Matchers {
           ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(index.from(_).scan())
         } yield ts
         scanamo.exec(ops) should be(
-          List(
-            Right(Transport("Underground", "Central", "R")),
-            Right(Transport("Underground", "Circle", "Y")))
+          List(Right(Transport("Underground", "Central", "R")), Right(Transport("Underground", "Circle", "Y")))
         )
     }
   }

--- a/scanamo/src/test/scala-2.x/org/scanamo/SecondaryIndexTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/SecondaryIndexTest.scala
@@ -146,7 +146,9 @@ class SecondaryIndexTest extends AnyFunSpec with Matchers {
           ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(index.from(_).scan())
         } yield ts
         scanamo.exec(ops) should be(
-          List(Right(Transport("Underground", "Circle", "Y")), Right(Transport("Underground", "Metropolitan", "M")))
+          List(
+            Right(Transport("Underground", "Central", "R")),
+            Right(Transport("Underground", "Circle", "Y")))
         )
     }
   }

--- a/scanamo/src/test/scala-2.x/org/scanamo/SecondaryIndexTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/SecondaryIndexTest.scala
@@ -1,11 +1,13 @@
 package org.scanamo
 
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
+import cats.implicits._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
-import org.scanamo.syntax._
 import org.scanamo.generic.auto._
+import org.scanamo.ops.ScanamoOps
+import org.scanamo.query.IndexKey
+import org.scanamo.syntax._
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType._
 
 object SecondaryIndexTest {
   case class Transport(mode: String, line: String, colour: String)
@@ -58,7 +60,7 @@ class SecondaryIndexTest extends AnyFunSpec with Matchers {
           )
         )
         scalaMIT <- githubProjects.index(i).query("language" === "Scala" and "license" === "MIT")
-      } yield scalaMIT.toList
+      } yield scalaMIT
       scanamo.exec(operations) should be(
         List(
           Right(GithubProject("typelevel", "cats", "Scala", "MIT")),
@@ -92,7 +94,7 @@ class SecondaryIndexTest extends AnyFunSpec with Matchers {
               .query(
                 ("mode" === "Underground" and ("colour" beginsWith "Bl"))
               )
-        } yield somethingBeginningWithBl.toList
+        } yield somethingBeginningWithBl
         scanamo.exec(operations) should be(List(Right(Transport("Underground", "Picadilly", "Blue"))))
     }
   }
@@ -116,10 +118,99 @@ class SecondaryIndexTest extends AnyFunSpec with Matchers {
               .index(i)
               .filter("line" beginsWith "C")
               .query("mode" === "Underground")
-        } yield somethingBeginningWithC.toList
+        } yield somethingBeginningWithC
         scanamo.exec(operations) should be(
           List(Right(Transport("Underground", "Central", "Red")), Right(Transport("Underground", "Circle", "Yellow")))
         )
+    }
+
+  }
+
+  it("Scans the table and returns the raw DynamoDB result") {
+
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
+      (t, i) =>
+        val table = Table[Transport](t)
+        val index = table.index(i)
+        val ops = for {
+          _ <- table.putAll(
+            Set(
+              Transport("Underground", "Circle", "Y"),
+              Transport("Underground", "Metropolitan", "M"),
+              Transport("Underground", "Central", "R")
+            )
+          )
+          res <- index.limit(1).scan0
+          indexKey = IndexKey.of3Hom[String]
+          lastKey = indexKey.fromDynamoObject(("mode", "line", "colour"), DynamoObject(res.lastEvaluatedKey))
+          ts <- lastKey.fold(List.empty[Either[DynamoReadError, Transport]].pure[ScanamoOps])(index.from(_).scan())
+        } yield ts
+        scanamo.exec(ops) should be(
+          List(Right(Transport("Underground", "Circle", "Y")), Right(Transport("Underground", "Metropolitan", "M")))
+        )
+    }
+  }
+
+  it("Page an index with a composite key having only 1 property in common with its parent table") {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("mode" -> S, "line" -> S)("mode" -> S, "colour" -> S) {
+      (t, i) =>
+        val table = Table[Transport](t)
+        val index = table.index(i)
+        val operations = for {
+          _ <- table.putAll(
+            Set(
+              Transport("Underground", "Circle", "Yellow"),
+              Transport("Underground", "Metropolitan", "Magenta"),
+              Transport("Underground", "Central", "Red"),
+              Transport("Underground", "Picadilly", "Blue"),
+              Transport("Underground", "Northern", "Black")
+            )
+          )
+          indexPageAfterBlue <-
+            index
+              .from("mode" === "Underground" and "line" === "Picadilly" and "colour" === "Blue")
+              .query("mode" === "Underground")
+        } yield indexPageAfterBlue
+        scanamo.exec(operations) should be(
+          List(
+            Right(Transport("Underground", "Metropolitan", "Magenta")),
+            Right(Transport("Underground", "Central", "Red")),
+            Right(Transport("Underground", "Circle", "Yellow"))
+          )
+        )
+    }
+
+  }
+
+  it("Page an index with a composite key having no properties in common with its parent table") {
+    LocalDynamoDB.withRandomTableWithSecondaryIndex(client)("organisation" -> S, "repository" -> S)(
+      "language" -> S,
+      "license" -> S
+    ) { (t, i) =>
+      val table = Table[GithubProject](t)
+      val index = table.index(i)
+      val operations = for {
+        _ <- table.putAll(
+          Set(
+            GithubProject("typelevel", "cats", "Scala", "MIT"),
+            GithubProject("typelevel", "scalacheck", "Scala", "BSD 3"),
+            GithubProject("localytics", "sbt-dynamodb", "Scala", "MIT"),
+            GithubProject("tpolecat", "tut", "Scala", "MIT"),
+            GithubProject("guardian", "scanamo", "Scala", "Apache 2")
+          )
+        )
+        scalaMIT <- index
+          .limit(1)
+          .from(
+            "organisation" === "guardian" and "repository" === "scanamo" and "language" === "Scala" and "license" === "Apache 2"
+          )
+          .query("language" === "Scala")
+      } yield scalaMIT
+      scanamo.exec(operations) should be(
+        List(
+          Right(GithubProject("typelevel", "scalacheck", "Scala", "BSD 3"))
+        )
+      )
     }
 
   }


### PR DESCRIPTION
This PR aims to improve the situation around paging over indexes by adding a couple features (loosely defined), as well as a change to `SecondaryIndex#from`:

1. Enables access to the underlying response from DynamoDB when querying or scanning an index. This is simply the addition of `scan0` and `query0` to `SecondaryIndex`.
2. Enables the construction of index keys having 3-4 properties using the established syntax.
3. Changes the signature of `SecondaryIndex#from` to constrain it against `IndexKey`.

The last one is potentially controversial so here is the reasoning (and of course if someone has a clearer vision of a better approach, I'd love to hear it and help if I can - new here):

Previously,  `SecondaryIndex#from` had the same constraints as `Table#from` (`UniqueKeyCondition`), however this is insufficient given the keys for indexes can and often do differ in their structure. That is, it is common to have a secondary index with a different hash key, sort key, or both. When paging over an index, the last evaluated key must contain all properties comprising both the key of the index and that of its parent table. As far as I can tell the only way to construct such a key would be to provide another instance of `UniqueKeyCondition` over some type with additional properties. However, that would then make it possible to pass invalid/impossible keys to `Table#from`, which will only ever have 1 or 2 properties.

This change breaks that, which could break existing uses of `SecondaryIndex#from`. However as they have different requirements in reality, this seems appropriate. Further, with the exception of any code that has implemented its own workaround by providing (potentially dangerous) instances of `UniqueKeyCondition`, the support for the established syntax should keep those source compatible.

Even with workarounds in terms of `UniqueKeyCondition`, I still don't see that it's possible to get the underlying response when interacting with an index. This means that one would have to compute the last evaluated key (which is possible), but still couldn't know if there was actually a subsequent page.

Again if someone has a better vision/approach, I'd be glad to help or just see it merged (this is a blocking issue for my team's adoption)! Thanks to all committers + maintainers for a great library ❤️ 