### PR TITLE
Remove Ruby Sass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ jobs:
         - rvm reload
         - rvm use 2.6.0 --install --fuzzy
         - gem update --system
-        - gem install sass
         - gem install jekyll -v 4.0.0
       script: sbt $SBTOPTS ++$TRAVIS_SCALA_VERSION startDynamodbLocal makeMicrosite stopDynamodbLocal
     - &release


### PR DESCRIPTION
I believe Jekyll does not require this Gem as of v4.0.0.

This is unrelated to the Travis build currently failing due to https://www.moncefbelyamani.com/how-to-fix-undefined-local-variable-or-method-d-for-gem-specification-class/ - I've fixed that by deleting the Travis cache