### PR TITLE
Add SecondaryIndex methods exposing raw response

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -196,7 +196,10 @@ object ScanamoFree {
   ): ScanamoOpsT[M, List[Either[DynamoReadError, T]]] =
     ScanResponseStream.streamTo[M, T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default), pageSize)
 
-  def scan0[T: DynamoFormat](tableName: String): ScanamoOps[ScanResponse] =
+  @deprecated("use `scanRaw`", "1.0")
+  def scan0[T: DynamoFormat](tableName: String): ScanamoOps[ScanResponse] = scanRaw[T](tableName)
+
+  def scanRaw[T: DynamoFormat](tableName: String): ScanamoOps[ScanResponse] =
     ScanamoOps.scan(ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default))
 
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
@@ -208,7 +211,10 @@ object ScanamoFree {
     QueryResponseStream
       .streamTo[M, T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default), pageSize)
 
-  def query0[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[QueryResponse] =
+  @deprecated("use `queryRaw`", "1.0")
+  def query0[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[QueryResponse] = queryRaw[T](tableName)(query)
+
+  def queryRaw[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[QueryResponse] =
     ScanamoOps.query(ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default))
 
   def update[T: DynamoFormat](

--- a/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
+++ b/scanamo/src/main/scala/org/scanamo/SecondaryIndex.scala
@@ -16,11 +16,12 @@
 
 package org.scanamo
 
-import cats.{ Monad, MonoidK }
-import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
-import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
-import org.scanamo.query.{ Condition, ConditionExpression, Query, UniqueKey, UniqueKeyCondition }
-import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
+import cats.{Monad, MonoidK}
+import org.scanamo.DynamoResultStream.{QueryResponseStream, ScanResponseStream}
+import org.scanamo.ops.{ScanamoOps, ScanamoOpsT}
+import org.scanamo.query.{Condition, ConditionExpression, Query, UniqueKey, UniqueKeyCondition}
+import org.scanamo.request.{ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest}
+import software.amazon.awssdk.services.dynamodb.model.{QueryResponse, ScanResponse}
 
 /** Represents a secondary index on a DynamoDB table.
   *
@@ -31,6 +32,10 @@ sealed abstract class SecondaryIndex[V] {
   /** Scan a secondary index
     */
   def scan(): ScanamoOps[List[Either[DynamoReadError, V]]]
+
+  /** Scans the index and returns the raw DynamoDB result.
+    */
+  def scanRaw: ScanamoOps[ScanResponse]
 
   /** Performs a scan with the ability to introduce effects into the computation. This is
     * useful for huge tables when you don't want to load the whole of it in memory, but
@@ -52,6 +57,10 @@ sealed abstract class SecondaryIndex[V] {
   /** Run a query against keys in a secondary index
     */
   def query(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]]
+
+  /** Queries the index and returns the raw DynamoDB result.
+    */
+  def queryRaw(query: Query[_]): ScanamoOps[QueryResponse]
 
   /** Performs a query with the ability to introduce effects into the computation. This is
     * useful for huge tables when you don't want to load the whole of it in memory, but
@@ -103,10 +112,13 @@ private[scanamo] case class SecondaryIndexWithOptions[V: DynamoFormat](
   def descending: SecondaryIndexWithOptions[V] =
     copy(queryOptions = queryOptions.copy(ascending = false))
   def scan() = ScanResponseStream.stream[V](ScanamoScanRequest(tableName, Some(indexName), queryOptions)).map(_._1)
+  def scanRaw: ScanamoOps[ScanResponse] = ScanamoOps.scan(ScanamoScanRequest(tableName, Some(indexName), queryOptions))
   def scanPaginatedM[M[_]: Monad: MonoidK](pageSize: Int) =
     ScanResponseStream.streamTo[M, V](ScanamoScanRequest(tableName, Some(indexName), queryOptions), pageSize)
   def query(query: Query[_]) =
     QueryResponseStream.stream[V](ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions)).map(_._1)
+  def queryRaw(query: Query[_]): ScanamoOps[QueryResponse] =
+    ScanamoOps.query(ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions))
   def queryPaginatedM[M[_]: Monad: MonoidK](query: Query[_], pageSize: Int) =
     QueryResponseStream.streamTo[M, V](ScanamoQueryRequest(tableName, Some(indexName), query, queryOptions), pageSize)
 }

--- a/scanamo/src/test/scala-2.x/org/scanamo/TableTest.scala
+++ b/scanamo/src/test/scala-2.x/org/scanamo/TableTest.scala
@@ -502,7 +502,7 @@ class TableTest extends AnyFunSpec with Matchers {
             Transport("Underground", "Central", "R")
           )
         )
-        res <- table.limit(1).scan0
+        res <- table.limit(1).scanRaw
         uniqueKeyCondition =
           UniqueKeyCondition[AndEqualsCondition[KeyEquals[String], KeyEquals[String]], (AttributeName, AttributeName)]
         lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.lastEvaluatedKey))
@@ -549,7 +549,7 @@ class TableTest extends AnyFunSpec with Matchers {
             Transport("Bus", "234", "R")
           )
         )
-        res <- table.limit(1).query0("mode" === "Bus" and "line" === "234")
+        res <- table.limit(1).queryRaw("mode" === "Bus" and "line" === "234")
         uniqueKeyCondition =
           UniqueKeyCondition[AndEqualsCondition[KeyEquals[String], KeyEquals[String]], (AttributeName, AttributeName)]
         lastKey = uniqueKeyCondition.fromDynamoObject(("mode", "line"), DynamoObject(res.lastEvaluatedKey))


### PR DESCRIPTION
`Table` has provides `scan0` and `query0` to access the raw response, for which a common use-case is to access the last evaluated (ie paging) key. `SecondaryIndex` lacks these methods, making it impossible to page indexes. Per #1324, this slimmed-down PR adds those methods so that paged queries are at least possible on indexes. However the larger issue around paging indexes (ie, the impossibility to safely form a complete index paging key in common use-cases) still stands. This PR is at least a workaround until the larger issue can be addressed.