### PR TITLE
#255 stripping attribute name of non-alphanumeric characters

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/query/AttributeName.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/AttributeName.scala
@@ -27,7 +27,10 @@ case class AttributeName(components: List[String], index: Option[Int]) {
     )((p, i) => s"$p[$i]")
 
   def attributeNames(prefix: String): Map[String, String] =
-    Map(components.map(s => s"$prefix$s" -> s): _*)
+    Map(components.map(s => {
+      val alphaNumericS = s.replaceAll("[^A-Za-z0-9]", "")
+      s"$prefix$alphaNumericS" -> s
+    }): _*)
 
   def \(component: String) = copy(components = components :+ component)
 


### PR DESCRIPTION
I was running into a similar issue as @madanepuri where a non-alphanumeric attribute name in my dynamodb table is throwing an `AmazonDynamoDBException`. I found the discussion between @madanepuri and @regiskuckaertz on Gitter which led to the creation of #255. 

Problem:
Say a query being made based on an attribute "animal-name" === "elephant",
Currently, the attribute names of the query would internally map as:
ExpressionAttributeNames: Map("#Ranimal-name" -> "animal-name")
which would still result in an `AmazonDynamoDBException: 'ExpressionAttributeNames contains invalid key: Syntax error; key: "#Ranimal-name"...`

A possible solution to this problem is to strip the non-alphanumeric characters in the attributeNames map key, as @madanepuri suggested. This MR implements that solution.