### PR TITLE
Run release job only when tag is pushed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,7 @@ jobs:
       - name: gen microsite
         run: sbt startDynamodbLocal makeMicrosite stopDynamodbLocal
   release:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: [check,gen_microsite]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: release


### PR DESCRIPTION
This PR fixes release workflow error.

Release job for snapshot repository always faied as seen in https://github.com/scanamo/scanamo/pull/1577, which is (probably) because no credentials is found for new s01.oss.sonatype.org repository.