### PR TITLE
Fix NPE in DynamoResultStream

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -90,7 +90,8 @@ private[scanamo] object DynamoResultStream {
     final def lastEvaluatedKey(res: ScanResponse) =
       Option(res.lastEvaluatedKey).filterNot(_.isEmpty).map(DynamoObject(_))
 
-    final def scannedCount(res: ScanResponse) = Option(res.scannedCount().intValue())
+    final def scannedCount(res: ScanResponse) =
+      Option(res).flatMap(sr => Option(sr.scannedCount())).flatMap(sc => Option(sc.intValue()))
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))
     final def withLimit(limit: Int) =
@@ -108,7 +109,8 @@ private[scanamo] object DynamoResultStream {
     final def lastEvaluatedKey(res: QueryResponse) =
       Option(res.lastEvaluatedKey).filterNot(_.isEmpty).map(DynamoObject(_))
 
-    final def scannedCount(res: QueryResponse) = Option(res.scannedCount().intValue())
+    final def scannedCount(res: QueryResponse) =
+      Option(res).flatMap(sr => Option(sr.scannedCount())).flatMap(sc => Option(sc.intValue()))
     final def withExclusiveStartKey(key: DynamoObject) =
       req => req.copy(options = req.options.copy(exclusiveStartKey = Some(key)))
     final def withLimit(limit: Int) =


### PR DESCRIPTION
The NPE occurs when scannedCount underlying field is null. Simple map on Option doesn't help as apparently there's implicit cast from Java Integer  to Scala Int happening and it would still fail with NPE, therefore chain of flatMaps.

It would be great if merge of this PR would result in new build published to Maven. Thanks in advance!