### PR TITLE
Add support for multi-action write transactions

### DIFF
--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -92,6 +92,7 @@ class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) e
               a => F.delay(Right(a))
             )
           )
-      case TransactWriteAll(req) => eff(client.transactWriteItems(JavaRequests.transactItems(req)))
+      case TransactWriteAll(req) =>
+        eff(client.transactWriteItems(JavaRequests.transactItems(req)))
     }
 }

--- a/scanamo/src/main/scala/org/scanamo/DynamoReadError.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoReadError.scala
@@ -16,8 +16,8 @@
 
 package org.scanamo
 
-import cats.data.NonEmptyList
 import cats.Show
+import cats.data.NonEmptyList
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 
 sealed abstract class ScanamoError

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -154,7 +154,9 @@ case class Table[V: DynamoFormat](name: String) {
   def transactPutAll(vs: List[V]): ScanamoOps[TransactWriteItemsResponse] =
     ScanamoFree.transactPutAllTable(name)(vs)
 
-  def transactUpdateAll(vs: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResponse] =
+  def transactUpdateAll(
+    vs: List[(UniqueKey[_], UpdateExpression)]
+  ): ScanamoOps[TransactWriteItemsResponse] =
     ScanamoFree.transactUpdateAllTable(name)(vs)
 
   def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =

--- a/scanamo/src/main/scala/org/scanamo/TransactionalWriteAction.scala
+++ b/scanamo/src/main/scala/org/scanamo/TransactionalWriteAction.scala
@@ -1,0 +1,23 @@
+package org.scanamo
+
+import org.scanamo.query.{ ConditionExpression, UniqueKey }
+import org.scanamo.update.UpdateExpression
+
+sealed trait TransactionalWriteAction
+
+object TransactionalWriteAction {
+  case class Put[V](tableName: String, item: V)(implicit format: DynamoFormat[V]) extends TransactionalWriteAction {
+    def asDynamoValue = format.write(item)
+  }
+
+  case class Update(tableName: String, key: UniqueKey[_], expression: UpdateExpression) extends TransactionalWriteAction
+
+  case class Delete(tableName: String, key: UniqueKey[_]) extends TransactionalWriteAction
+
+  case class ConditionCheck[T](tableName: String, key: UniqueKey[_], condition: T)(implicit
+    conditionExpression: ConditionExpression[T]
+  ) extends TransactionalWriteAction {
+    def asRequestCondition = conditionExpression.apply(condition).runEmptyA.value
+  }
+
+}

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
@@ -61,6 +61,8 @@ object ScanamoOps {
     req: ScanamoUpdateRequest
   ): ScanamoOps[Either[ConditionalCheckFailedException, UpdateItemResponse]] =
     liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, UpdateItemResponse]](ConditionalUpdate(req))
-  def transactWriteAll(req: ScanamoTransactWriteRequest): ScanamoOps[TransactWriteItemsResponse] =
+  def transactWriteAll(
+    req: ScanamoTransactWriteRequest
+  ): ScanamoOps[TransactWriteItemsResponse] =
     liftF[ScanamoOpsA, TransactWriteItemsResponse](TransactWriteAll(req))
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoSyncInterpreter.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoSyncInterpreter.scala
@@ -16,8 +16,8 @@
 
 package org.scanamo.ops
 
-import cats._
-import cats.syntax.either._
+import cats.*
+import cats.syntax.either.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 
@@ -55,6 +55,7 @@ class ScanamoSyncInterpreter(client: DynamoDbClient) extends (ScanamoOpsA ~> Id)
         Either.catchOnly[ConditionalCheckFailedException] {
           client.updateItem(JavaRequests.update(req))
         }
-      case TransactWriteAll(req) => client.transactWriteItems(JavaRequests.transactItems(req))
+      case TransactWriteAll(req) =>
+        client.transactWriteItems(JavaRequests.transactItems(req))
     }
 }

--- a/scanamo/src/main/scala/org/scanamo/request/ScanamoRequest.scala
+++ b/scanamo/src/main/scala/org/scanamo/request/ScanamoRequest.scala
@@ -92,9 +92,15 @@ case class TransactDeleteItem(
   key: DynamoObject,
   condition: Option[RequestCondition]
 )
+case class TransactConditionCheck(
+  tableName: String,
+  key: DynamoObject,
+  condition: RequestCondition
+)
 
 case class ScanamoTransactWriteRequest(
   putItems: Seq[TransactPutItem],
   updateItems: Seq[TransactUpdateItem],
-  deleteItems: Seq[TransactDeleteItem]
+  deleteItems: Seq[TransactDeleteItem],
+  conditionCheck: Seq[TransactConditionCheck]
 )

--- a/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoAsyncTest.scala
@@ -689,4 +689,37 @@ class ScanamoAsyncTest
       }
     }
   }
+
+  it("transact multiple write actions (put, update, delete) across multiple tables") {
+    LocalDynamoDB.usingRandomTable(client)("number" -> N) { t1 =>
+      LocalDynamoDB.usingRandomTable(client)("location" -> S) { t2 =>
+        val gremlinTable = Table[Gremlin](t1)
+        val forecastTable = Table[Forecast](t2)
+
+        val ops = for {
+          _ <- gremlinTable.putAll(Set(Gremlin(1, wet = false), Gremlin(2, wet = true)))
+          _ <- forecastTable.putAll(Set(Forecast("London", "Sun", None), Forecast("Amsterdam", "Fog", None)))
+          _ <- ScanamoFree.transactionalWrite(
+            List(
+              TransactionalWriteAction
+                .Put(t1, Gremlin(3, wet = true)),
+              TransactionalWriteAction
+                .Put(t2, Forecast("Berlin", "Wind", None)),
+              TransactionalWriteAction.Update(t1, UniqueKey(KeyEquals("number", 2)), set("wet", false)),
+              TransactionalWriteAction.Delete(t2, UniqueKey(KeyEquals("location", "Amsterdam")))
+            )
+          )
+          gremlins <- gremlinTable.scan()
+          forecasts <- forecastTable.scan()
+        } yield (gremlins, forecasts)
+
+        scanamo.exec(ops).futureValue should equal(
+          (
+            List(Right(Gremlin(2, wet = false)), Right(Gremlin(1, wet = false)), Right(Gremlin(3, wet = true))),
+            List(Right(Forecast("London", "Sun", None)), Right(Forecast("Berlin", "Wind", None)))
+          )
+        )
+      }
+    }
+  }
 }

--- a/zio/src/main/scala/org/scanamo/ops/ZioInterpreter.scala
+++ b/zio/src/main/scala/org/scanamo/ops/ZioInterpreter.scala
@@ -55,6 +55,7 @@ private[scanamo] class ZioInterpreter(client: DynamoDbAsyncClient) extends (Scan
         eff(client.updateItem(JavaRequests.update(req)))
       case ConditionalUpdate(req) =>
         effEitherConditionalCheckFailed(client.updateItem(JavaRequests.update(req)))
-      case TransactWriteAll(req) => eff(client.transactWriteItems(JavaRequests.transactItems(req)))
+      case TransactWriteAll(req) =>
+        eff(client.transactWriteItems(JavaRequests.transactItems(req)))
     }
 }


### PR DESCRIPTION
This PR provides support for multi-action write requests (as detailed in the Dynamo spec [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html))

Currently the Scanamo API allows only write requests of the same type (Put, Update, Delete) to be grouped together in a single transaction (i.e. `transactPutAll`, `transactUpdateAll`, `transactDeleteAll`).

This change introduces `transactionWrite` which accepts multiple TransactionWriteActions. These actions could be a mix of `Put`, `Update`, `Delete` or `ConditionCheck` types and can span multiple tables.