### PR TITLE
Bump dynamodb version to 2.21.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val root = (project in file("."))
 addCommandAlias("makeMicrosite", "docs/makeMicrosite")
 addCommandAlias("publishMicrosite", "docs/publishMicrosite")
 
-val awsDynamoDB = "software.amazon.awssdk" % "dynamodb" % "2.20.146"
+val awsDynamoDB = "software.amazon.awssdk" % "dynamodb" % "2.21.2"
 
 lazy val refined = (project in file("refined"))
   .settings(


### PR DESCRIPTION
Projects that depend on scanamo are facing eviction notices due to the `awssdk` version being one minor release behind.