### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,17 +65,3 @@ jobs:
         uses: actions/checkout@v4
       - name: test docs
         run: sbt +doc
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [check,test_docs]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout current branch
-        uses: actions/checkout@v4
-      - name: release
-        run: sbt ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    with:
+      GITHUB_APP_ID: 838920
+      SONATYPE_PROFILE_NAME: 'org.scanamo'
+      SONATYPE_CREDENTIAL_HOST: 'oss.sonatype.org'
+      SONATYPE_USERNAME: 'scanamo'
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,8 @@ scalafmtCheck
 scalafmtSbtCheck
 ```
 
+# Publishing a new release
 
-Releasing
----------
-
-Creating a git tag is all that is required to trigger GitHub Actions to publish an artifact to Maven 
-Central for both Scala 2.12 and Scala 2.13 once the build is complete.
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing releases (both full & preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,9 @@
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
+
 addSbtPlugin("com.localytics"    % "sbt-dynamodb"              % "2.0.3")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.2" )
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release"            % "1.5.12")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"             % "2.0.11")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"              % "2.4.6")
 addSbtPlugin("ch.epfl.scala"     % "sbt-bloop"                 % "1.5.6")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "1.0.3-SNAPSHOT"


### PR DESCRIPTION
As mentioned in https://github.com/scanamo/scanamo/issues/1763, we're switching to use `gha-scala-library-release-workflow` for releasing the Scanamo to Maven Central. This is a change from the release process based on `sbt-ci-release` that was introduced with https://github.com/scanamo/scanamo/pull/280 - it used to be that to trigger a release, we would push a git tag with a manually-selected version number (eg `v1.0.3`), the new process is now to run the `Release` workflow manually, which will automatically determine a version number based on the version-compatibility checks performed by `sbt-version-policy`.

In order to do this, we've had to follow the one-off organisation-setup steps in:

https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/org-setup.md

...which included creating a GitHub App for the Scanamo organisation:

https://github.com/apps/scala-library-release-scanamo

Additionally, this PR contains the per-repo modifications required by:

https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md

## Remaining steps

* Merge this PR, perform an initial release with the new setup
* Properly enable the version-compatibility checks, as they had to be disabled due to v1.0.2 failing and https://github.com/guardian/gha-scala-library-release-workflow/issues/33