### PR TITLE
Includes conditions expressions for transactions Put. 

### DIFF
--- a/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
+++ b/cats/src/main/scala/org/scanamo/ops/CatsInterpreter.scala
@@ -26,7 +26,7 @@ import cats.syntax.option.*
 import java.util.concurrent.CompletableFuture
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import java.util.concurrent.CompletionException
-import software.amazon.awssdk.services.dynamodb.model.{ConditionalCheckFailedException, TransactionCanceledException}
+import software.amazon.awssdk.services.dynamodb.model.{ ConditionalCheckFailedException, TransactionCanceledException }
 
 class CatsInterpreter[F[_]](client: DynamoDbAsyncClient)(implicit F: Async[F]) extends (ScanamoOpsA ~> F) {
   final private def eff[A](fut: => CompletableFuture[A]): F[A] =

--- a/pekko/src/main/scala/org/scanamo/ops/PekkoInterpreter.scala
+++ b/pekko/src/main/scala/org/scanamo/ops/PekkoInterpreter.scala
@@ -25,7 +25,29 @@ import cats.syntax.either.*
 import cats.~>
 import org.apache.pekko.actor.ClassicActorSystemProvider
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
-import software.amazon.awssdk.services.dynamodb.model.{BatchGetItemRequest, BatchGetItemResponse, BatchWriteItemRequest, BatchWriteItemResponse, ConditionalCheckFailedException, DeleteItemRequest, DeleteItemResponse, DynamoDbRequest, DynamoDbResponse, GetItemRequest, GetItemResponse, PutItemRequest, PutItemResponse, QueryRequest, QueryResponse, ScanRequest, ScanResponse, TransactWriteItemsResponse, TransactionCanceledException, UpdateItemRequest, UpdateItemResponse}
+import software.amazon.awssdk.services.dynamodb.model.{
+  BatchGetItemRequest,
+  BatchGetItemResponse,
+  BatchWriteItemRequest,
+  BatchWriteItemResponse,
+  ConditionalCheckFailedException,
+  DeleteItemRequest,
+  DeleteItemResponse,
+  DynamoDbRequest,
+  DynamoDbResponse,
+  GetItemRequest,
+  GetItemResponse,
+  PutItemRequest,
+  PutItemResponse,
+  QueryRequest,
+  QueryResponse,
+  ScanRequest,
+  ScanResponse,
+  TransactWriteItemsResponse,
+  TransactionCanceledException,
+  UpdateItemRequest,
+  UpdateItemResponse
+}
 
 import java.util.concurrent.CompletionException
 

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -78,7 +78,7 @@ object ScanamoFree {
 
   def transactionalWrite(
     actions: List[TransactionalWriteAction]
-  ): ScanamoOps[TransactWriteItemsResponse] = {
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  = {
     val transactionWriteRequest =
       actions.foldLeft(ScanamoTransactWriteRequest(Seq.empty, Seq.empty, Seq.empty, Seq.empty)) { case (acc, action) =>
         action match {
@@ -100,12 +100,12 @@ object ScanamoFree {
 
   def transactPutAllTable[T](
     tableName: String
-  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResponse] =
+  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  =
     transactPutAll(items.map(tableName -> _))
 
   def transactPutAll[T](
     tableAndItems: List[(String, T)]
-  )(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResponse] = {
+  )(implicit f: DynamoFormat[T]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] = {
     val dItems = tableAndItems.map { case (tableName, itm) =>
       TransactPutItem(tableName, f.write(itm), None)
     }
@@ -115,12 +115,12 @@ object ScanamoFree {
 
   def transactUpdateAllTable(
     tableName: String
-  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResponse] =
+  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  =
     transactUpdateAll(items.map(tableName -> _))
 
   def transactUpdateAll(
     tableAndItems: List[(String, (UniqueKey[_], UpdateExpression))]
-  ): ScanamoOps[TransactWriteItemsResponse] = {
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  = {
     val items = tableAndItems.map { case (tableName, (key, updateExpression)) =>
       TransactUpdateItem(tableName, key.toDynamoObject, updateExpression, None)
     }
@@ -130,12 +130,12 @@ object ScanamoFree {
 
   def transactDeleteAllTable(
     tableName: String
-  )(items: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =
+  )(items: List[UniqueKey[_]]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  =
     transactDeleteAll(items.map(tableName -> _))
 
   def transactDeleteAll(
     tableAndItems: List[(String, UniqueKey[_])]
-  ): ScanamoOps[TransactWriteItemsResponse] = {
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] = {
     val items = tableAndItems.map { case (tableName, key) =>
       TransactDeleteItem(tableName, key.toDynamoObject, None)
     }

--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -78,7 +78,7 @@ object ScanamoFree {
 
   def transactionalWrite(
     actions: List[TransactionalWriteAction]
-  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  = {
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] = {
     val transactionWriteRequest =
       actions.foldLeft(ScanamoTransactWriteRequest(Seq.empty, Seq.empty, Seq.empty, Seq.empty)) { case (acc, action) =>
         action match {
@@ -100,7 +100,9 @@ object ScanamoFree {
 
   def transactPutAllTable[T](
     tableName: String
-  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  =
+  )(items: List[T])(implicit
+    f: DynamoFormat[T]
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     transactPutAll(items.map(tableName -> _))
 
   def transactPutAll[T](
@@ -115,12 +117,14 @@ object ScanamoFree {
 
   def transactUpdateAllTable(
     tableName: String
-  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  =
+  )(
+    items: List[(UniqueKey[_], UpdateExpression)]
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     transactUpdateAll(items.map(tableName -> _))
 
   def transactUpdateAll(
     tableAndItems: List[(String, (UniqueKey[_], UpdateExpression))]
-  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  = {
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] = {
     val items = tableAndItems.map { case (tableName, (key, updateExpression)) =>
       TransactUpdateItem(tableName, key.toDynamoObject, updateExpression, None)
     }
@@ -130,7 +134,7 @@ object ScanamoFree {
 
   def transactDeleteAllTable(
     tableName: String
-  )(items: List[UniqueKey[_]]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]]  =
+  )(items: List[UniqueKey[_]]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     transactDeleteAll(items.map(tableName -> _))
 
   def transactDeleteAll(

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -16,12 +16,12 @@
 
 package org.scanamo
 
-import cats.{ Monad, MonoidK }
-import software.amazon.awssdk.services.dynamodb.model.{ QueryResponse, ScanResponse, TransactWriteItemsResponse }
-import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
-import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
-import org.scanamo.query._
-import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
+import cats.{Monad, MonoidK}
+import software.amazon.awssdk.services.dynamodb.model.{QueryResponse, ScanResponse, TransactWriteItemsResponse, TransactionCanceledException}
+import org.scanamo.DynamoResultStream.{QueryResponseStream, ScanResponseStream}
+import org.scanamo.ops.{ScanamoOps, ScanamoOpsT}
+import org.scanamo.query.*
+import org.scanamo.request.{ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest}
 import org.scanamo.update.UpdateExpression
 
 /** Represents a DynamoDB table that operations can be performed against
@@ -174,15 +174,15 @@ case class Table[V: DynamoFormat](name: String) {
   def descending =
     TableWithOptions(name, ScanamoQueryOptions.default).descending
 
-  def transactPutAll(vs: List[V]): ScanamoOps[TransactWriteItemsResponse] =
+  def transactPutAll(vs: List[V]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     ScanamoFree.transactPutAllTable(name)(vs)
 
   def transactUpdateAll(
     vs: List[(UniqueKey[_], UpdateExpression)]
-  ): ScanamoOps[TransactWriteItemsResponse] =
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     ScanamoFree.transactUpdateAllTable(name)(vs)
 
-  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =
+  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     ScanamoFree.transactDeleteAllTable(name)(vs)
 }
 

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -16,12 +16,17 @@
 
 package org.scanamo
 
-import cats.{Monad, MonoidK}
-import software.amazon.awssdk.services.dynamodb.model.{QueryResponse, ScanResponse, TransactWriteItemsResponse, TransactionCanceledException}
-import org.scanamo.DynamoResultStream.{QueryResponseStream, ScanResponseStream}
-import org.scanamo.ops.{ScanamoOps, ScanamoOpsT}
+import cats.{ Monad, MonoidK }
+import software.amazon.awssdk.services.dynamodb.model.{
+  QueryResponse,
+  ScanResponse,
+  TransactWriteItemsResponse,
+  TransactionCanceledException
+}
+import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
+import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query.*
-import org.scanamo.request.{ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest}
+import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
 import org.scanamo.update.UpdateExpression
 
 /** Represents a DynamoDB table that operations can be performed against
@@ -182,7 +187,9 @@ case class Table[V: DynamoFormat](name: String) {
   ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     ScanamoFree.transactUpdateAllTable(name)(vs)
 
-  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
+  def transactDeleteAll(
+    vs: List[UniqueKey[_]]
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
     ScanamoFree.transactDeleteAllTable(name)(vs)
 }
 

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
@@ -34,7 +34,7 @@ final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGet
 final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResponse]
 final case class ConditionalUpdate(req: ScanamoUpdateRequest)
     extends ScanamoOpsA[Either[ConditionalCheckFailedException, UpdateItemResponse]]
-final case class TransactWriteAll(req: ScanamoTransactWriteRequest) extends ScanamoOpsA[TransactWriteItemsResponse]
+final case class TransactWriteAll(req: ScanamoTransactWriteRequest) extends ScanamoOpsA[Either[TransactionCanceledException, TransactWriteItemsResponse]]
 
 object ScanamoOps {
   import cats.free.Free.liftF
@@ -63,6 +63,7 @@ object ScanamoOps {
     liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, UpdateItemResponse]](ConditionalUpdate(req))
   def transactWriteAll(
     req: ScanamoTransactWriteRequest
-  ): ScanamoOps[TransactWriteItemsResponse] =
-    liftF[ScanamoOpsA, TransactWriteItemsResponse](TransactWriteAll(req))
+  ): ScanamoOps[Either[TransactionCanceledException, TransactWriteItemsResponse]] =
+    liftF[ScanamoOpsA, Either[TransactionCanceledException, TransactWriteItemsResponse]](TransactWriteAll(req))
+
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
@@ -34,7 +34,8 @@ final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGet
 final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResponse]
 final case class ConditionalUpdate(req: ScanamoUpdateRequest)
     extends ScanamoOpsA[Either[ConditionalCheckFailedException, UpdateItemResponse]]
-final case class TransactWriteAll(req: ScanamoTransactWriteRequest) extends ScanamoOpsA[Either[TransactionCanceledException, TransactWriteItemsResponse]]
+final case class TransactWriteAll(req: ScanamoTransactWriteRequest)
+    extends ScanamoOpsA[Either[TransactionCanceledException, TransactWriteItemsResponse]]
 
 object ScanamoOps {
   import cats.free.Free.liftF

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoSyncInterpreter.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoSyncInterpreter.scala
@@ -19,7 +19,7 @@ package org.scanamo.ops
 import cats.*
 import cats.syntax.either.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.model.{ ConditionalCheckFailedException, TransactionCanceledException }
 
 /** Interpret Scanamo operations using blocking requests to DynamoDB with any transport errors or semantic errors within
   * DynamoDB thrown as exceptions.
@@ -56,6 +56,8 @@ class ScanamoSyncInterpreter(client: DynamoDbClient) extends (ScanamoOpsA ~> Id)
           client.updateItem(JavaRequests.update(req))
         }
       case TransactWriteAll(req) =>
-        client.transactWriteItems(JavaRequests.transactItems(req))
+        Either.catchOnly[TransactionCanceledException] {
+          client.transactWriteItems(JavaRequests.transactItems(req))
+        }
     }
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -167,13 +167,15 @@ package object ops {
 
     def transactItems(req: ScanamoTransactWriteRequest): TransactWriteItemsRequest = {
       val putItems = req.putItems.map { item =>
+        val putBuilder = software.amazon.awssdk.services.dynamodb.model.Put.builder
+          .item(item.item.asObject.getOrElse(DynamoObject.empty).toJavaMap)
+          .tableName(item.tableName)
+        val putBuilderWithCondition = item.condition.fold(putBuilder)(condition =>
+          putBuilder.conditionExpression(condition.expression).expressionAttributeNames(condition.attributeNames.asJava)
+        )
+
         TransactWriteItem.builder
-          .put(
-            software.amazon.awssdk.services.dynamodb.model.Put.builder
-              .item(item.item.asObject.getOrElse(DynamoObject.empty).toJavaMap)
-              .tableName(item.tableName)
-              .build
-          )
+          .put(putBuilderWithCondition.build)
           .build
       }
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -740,7 +740,7 @@ class ScanamoTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
         val ops1 = for {
           _ <- gremlinTable.putAll(Set(Gremlin(1, wet = false)))
           _ <- forecastTable.putAll(Set(Forecast("London", "Sun", None)))
-          _ <- ScanamoFree.transactionalWrite(
+          result <- ScanamoFree.transactionalWrite(
             List(
               TransactionalWriteAction
                 .Put(t1, Gremlin(3, wet = true)),
@@ -749,13 +749,10 @@ class ScanamoTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
               TransactionalWriteAction.ConditionCheck(t1, UniqueKey(KeyEquals("number", 1)), "wet" === true)
             )
           )
-        } yield ()
+        } yield result
 
-        assertThrows[TransactionCanceledException] {
-          scanamo.exec(ops1) should equal(
-            (List(Right(Gremlin(1, wet = false))), List(Right(Forecast("London", "Sun", None))))
-          )
-        }
+        scanamo.exec(ops1) shouldBe a[Left[TransactionCanceledException,_]]
+
 
         val ops2 = for {
           gremlins <- gremlinTable.scan()


### PR DESCRIPTION
Hello Scanamo maintainers,

I've made some enhancements to the Scanamo Scala library to improve its functionality. Below is a detailed summary of the changes:

Include conditions for put items in ScanamoTransactWriteRequest:
Implemented the ability to specify request conditions for put items within ScanamoTransactWriteRequest. This enhancement empowers users to define conditions that must be met for transactional put operations to succeed, it complements the already implemented support for transactions conditions .

Exposes TransactionCanceledException:
This enhancement strengthens error handling capabilities, enabling users to distinguish between different transaction cancellation scenarios, thereby facilitating improved troubleshooting and error resolution.

These changes have been running successfully in our production environment since mid-March without any observed issues. This feature is particularly crucial for us as it enables the implementation of transactions and optimistic locks with Scanamo.

Thank you.