### PR TITLE
Improve transaction error-handling capabilities

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -18,6 +18,7 @@ package org.scanamo
 
 import cats.{ Monad, MonoidK }
 import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
+import org.scanamo.ops.ScanamoOps.Results.*
 import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query.*
 import org.scanamo.request.*
@@ -80,7 +81,7 @@ object ScanamoFree {
 
   def transactionalWrite(
     actions: List[TransactionalWriteAction]
-  ): ScanamoOps[TransactWriteItemsResponse] = {
+  ): ScanamoOps[Transact[TransactWriteItemsResponse]] = {
     val transactionWriteRequest =
       actions.foldLeft(ScanamoTransactWriteRequest(Seq.empty, Seq.empty, Seq.empty, Seq.empty)) { case (acc, action) =>
         action match {
@@ -102,12 +103,12 @@ object ScanamoFree {
 
   def transactPutAllTable[T](
     tableName: String
-  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResponse] =
+  )(items: List[T])(implicit f: DynamoFormat[T]): ScanamoOps[Transact[TransactWriteItemsResponse]] =
     transactPutAll(items.map(tableName -> _))
 
   def transactPutAll[T](
     tableAndItems: List[(String, T)]
-  )(implicit f: DynamoFormat[T]): ScanamoOps[TransactWriteItemsResponse] = {
+  )(implicit f: DynamoFormat[T]): ScanamoOps[Transact[TransactWriteItemsResponse]] = {
     val dItems = tableAndItems.map { case (tableName, itm) =>
       TransactPutItem(tableName, f.write(itm), None)
     }
@@ -117,12 +118,12 @@ object ScanamoFree {
 
   def transactUpdateAllTable(
     tableName: String
-  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[TransactWriteItemsResponse] =
+  )(items: List[(UniqueKey[_], UpdateExpression)]): ScanamoOps[Transact[TransactWriteItemsResponse]] =
     transactUpdateAll(items.map(tableName -> _))
 
   def transactUpdateAll(
     tableAndItems: List[(String, (UniqueKey[_], UpdateExpression))]
-  ): ScanamoOps[TransactWriteItemsResponse] = {
+  ): ScanamoOps[Transact[TransactWriteItemsResponse]] = {
     val items = tableAndItems.map { case (tableName, (key, updateExpression)) =>
       TransactUpdateItem(tableName, key.toDynamoObject, updateExpression, None)
     }
@@ -132,12 +133,12 @@ object ScanamoFree {
 
   def transactDeleteAllTable(
     tableName: String
-  )(items: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =
+  )(items: List[UniqueKey[_]]): ScanamoOps[Transact[TransactWriteItemsResponse]] =
     transactDeleteAll(items.map(tableName -> _))
 
   def transactDeleteAll(
     tableAndItems: List[(String, UniqueKey[_])]
-  ): ScanamoOps[TransactWriteItemsResponse] = {
+  ): ScanamoOps[Transact[TransactWriteItemsResponse]] = {
     val items = tableAndItems.map { case (tableName, key) =>
       TransactDeleteItem(tableName, key.toDynamoObject, None)
     }

--- a/scanamo/src/main/scala/org/scanamo/Table.scala
+++ b/scanamo/src/main/scala/org/scanamo/Table.scala
@@ -18,6 +18,7 @@ package org.scanamo
 
 import cats.{ Monad, MonoidK }
 import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
+import org.scanamo.ops.ScanamoOps.Results.*
 import org.scanamo.ops.{ ScanamoOps, ScanamoOpsT }
 import org.scanamo.query.*
 import org.scanamo.request.{ ScanamoQueryOptions, ScanamoQueryRequest, ScanamoScanRequest }
@@ -174,15 +175,15 @@ case class Table[V: DynamoFormat](name: String) {
   def descending =
     TableWithOptions(name, ScanamoQueryOptions.default).descending
 
-  def transactPutAll(vs: List[V]): ScanamoOps[TransactWriteItemsResponse] =
+  def transactPutAll(vs: List[V]): ScanamoOps[Transact[TransactWriteItemsResponse]] =
     ScanamoFree.transactPutAllTable(name)(vs)
 
   def transactUpdateAll(
     vs: List[(UniqueKey[_], UpdateExpression)]
-  ): ScanamoOps[TransactWriteItemsResponse] =
+  ): ScanamoOps[Transact[TransactWriteItemsResponse]] =
     ScanamoFree.transactUpdateAllTable(name)(vs)
 
-  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[TransactWriteItemsResponse] =
+  def transactDeleteAll(vs: List[UniqueKey[_]]): ScanamoOps[Transact[TransactWriteItemsResponse]] =
     ScanamoFree.transactDeleteAllTable(name)(vs)
 }
 

--- a/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/ScanamoOpsA.scala
@@ -32,13 +32,15 @@ final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[Batc
 final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResponse]
 final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResponse]
 final case class ConditionalUpdate(req: ScanamoUpdateRequest) extends ScanamoOpsA[Conditional[UpdateItemResponse]]
-final case class TransactWriteAll(req: ScanamoTransactWriteRequest) extends ScanamoOpsA[TransactWriteItemsResponse]
+final case class TransactWriteAll(req: ScanamoTransactWriteRequest)
+    extends ScanamoOpsA[Transact[TransactWriteItemsResponse]]
 
 object ScanamoOps {
   import cats.free.Free.liftF
 
   object Results {
     type Conditional[T] = Either[ConditionalCheckFailedException, T]
+    type Transact[T] = Either[TransactionCanceledException, T]
   }
 
   private def lF[Result](req: ScanamoOpsA[Result]): ScanamoOps[Result] = liftF[ScanamoOpsA, Result](req)
@@ -54,8 +56,11 @@ object ScanamoOps {
   def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResponse] = lF(BatchWrite(req))
   def batchGet(req: BatchGetItemRequest): ScanamoOps[BatchGetItemResponse] = lF(BatchGet(req))
   def update(req: ScanamoUpdateRequest): ScanamoOps[UpdateItemResponse] = lF(Update(req))
-  def conditionalUpdate(req: ScanamoUpdateRequest): ScanamoOps[Conditional[UpdateItemResponse]] =
-    lF(ConditionalUpdate(req))
-  def transactWriteAll(req: ScanamoTransactWriteRequest): ScanamoOps[TransactWriteItemsResponse] =
-    lF(TransactWriteAll(req))
+  def conditionalUpdate(req: ScanamoUpdateRequest): ScanamoOps[Conditional[UpdateItemResponse]] = lF(
+    ConditionalUpdate(req)
+  )
+  def transactWriteAll(req: ScanamoTransactWriteRequest): ScanamoOps[Transact[TransactWriteItemsResponse]] = lF(
+    TransactWriteAll(req)
+  )
+
 }

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -740,7 +740,7 @@ class ScanamoTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
         val ops1 = for {
           _ <- gremlinTable.putAll(Set(Gremlin(1, wet = false)))
           _ <- forecastTable.putAll(Set(Forecast("London", "Sun", None)))
-          _ <- ScanamoFree.transactionalWrite(
+          result <- ScanamoFree.transactionalWrite(
             List(
               TransactionalWriteAction
                 .Put(t1, Gremlin(3, wet = true)),
@@ -749,7 +749,7 @@ class ScanamoTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
               TransactionalWriteAction.ConditionCheck(t1, UniqueKey(KeyEquals("number", 1)), "wet" === true)
             )
           )
-        } yield ()
+        } yield result
 
         scanamo.exec(ops1) shouldBe a[Left[TransactionCanceledException, _]]
 

--- a/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/ScanamoTest.scala
@@ -751,11 +751,7 @@ class ScanamoTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
           )
         } yield ()
 
-        assertThrows[TransactionCanceledException] {
-          scanamo.exec(ops1) should equal(
-            (List(Right(Gremlin(1, wet = false))), List(Right(Forecast("London", "Sun", None))))
-          )
-        }
+        scanamo.exec(ops1) shouldBe a[Left[TransactionCanceledException, _]]
 
         val ops2 = for {
           gremlins <- gremlinTable.scan()


### PR DESCRIPTION
This is based on the 2nd of the 2 distinct changes proposed in PR https://github.com/scanamo/scanamo/pull/1776, which I'm now separating out into 2 PRs (this will now be the *1st* to be merged). Luciano Preissler's original description for _this_ change in https://github.com/scanamo/scanamo/pull/1776 was:

> Exposes TransactionCanceledException:
> This enhancement strengthens error handling capabilities, enabling users
> to distinguish between different transaction cancellation scenarios, thereby
> facilitating improved troubleshooting and error resolution.

### Changing method return values (requires breaking binary compatibility)

This change exposes `TransactionCanceledException` by changing the result type of _transaction_ operations to `Either[TransactionCanceledException, TransactWriteItemsResponse]`, rather than just simply `TransactWriteItemsResponse`.

This pattern is very similar to one used for our 3 _conditional_ operations (`put`, `update` & `delete`), which use a result type of `Either[ConditionalCheckFailedException, T]` - we're following an established pattern here, but a change of method signature does mean that binary compatibility is broken - so the next release of Scanamo will get a major version bump.


The changes here are somewhat smaller than the original changes in PR https://github.com/scanamo/scanamo/pull/1776, due to the refactoring in https://github.com/scanamo/scanamo/pull/1786.