### PR TITLE
Respect conditions in `ScanamoTransactWriteRequest`

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -102,13 +102,15 @@ package object ops {
 
     def transactItems(req: ScanamoTransactWriteRequest): TransactWriteItemsRequest = {
       val putItems = req.putItems.map { item =>
+        val putBuilder = software.amazon.awssdk.services.dynamodb.model.Put.builder
+          .tableName(item.tableName)
+          .item(item.item.asObject.orEmpty.toJavaMap)
+        val putBuilderWithCondition = item.condition.fold(putBuilder)(condition =>
+          putBuilder.conditionExpression(condition.expression).expressionAttributeNames(condition.attributeNames.asJava)
+        )
+
         TransactWriteItem.builder
-          .put(
-            software.amazon.awssdk.services.dynamodb.model.Put.builder
-              .tableName(item.tableName)
-              .item(item.item.asObject.orEmpty.toJavaMap)
-              .build
-          )
+          .put(putBuilderWithCondition.build)
           .build
       }
 


### PR DESCRIPTION
This is based on the 1st of the 2 distinct changes proposed in PR #1776, which I'm separating out into 2 PRs.  Luciano Preissler's description for this change in https://github.com/scanamo/scanamo/pull/1776 was:

> Include conditions for put items in ScanamoTransactWriteRequest:
> Implemented the ability to specify request conditions for put items within ScanamoTransactWriteRequest. This enhancement empowers users to define conditions that must be met for transactional put operations to succeed, it complements the already implemented support for transactions conditions .

The `condition` fields on `TransactPutItem`, `TransactUpdateItem` & `TransactDeleteItem` were originally added with PR #650, but code respecting those fields wasn't included at that time, and left for future work: https://github.com/scanamo/scanamo/pull/650/files#r392613997

This change now, respecting those fields, means that if Scanamo users set a `condition` on a transaction action, that condition _will_ get sent to DynamoDB and so _will_ affect the execution of the transaction - where previously it would have been ignored.

### Remaining work for this PR

- [ ] Create tests that exercise this new functionality, and provide an example of how to use it _(incidentally, this PR is based on top of https://github.com/scanamo/scanamo/pull/1787 because it will probably be useful for testing this PR, testing will involve checking for `TransactionCanceledException`s to indicate that a condition has failed)_
- [ ] Add condition support for `TransactUpdateItem` & `TransactDeleteItem` as well as `TransactPutItem` in `JavaRequests.transactItems()` - the `condition` field is present in all 3 of them, for consistency, it shouldn't work for only **1** of them!
- [ ] _Consider_ updating the `TransactionalWriteAction` API introduced with https://github.com/scanamo/scanamo/pull/1629 so that it also supports conditions on `Put`, `Update` & `Delete` - though as this API isn't as friendly as other parts of the Scanamo API, I'm considering introducing a new API for composing transactions, and possibly deprecating the `TransactionalWriteAction` API in any case.