### PR TITLE
Extract common `exec` & `execT` methods into new `ScanamoClient`

### DIFF
--- a/cats/src/main/scala/org/scanamo/ScanamoCats.scala
+++ b/cats/src/main/scala/org/scanamo/ScanamoCats.scala
@@ -17,19 +17,12 @@
 package org.scanamo
 
 import cats.effect.Async
-import cats.{ ~>, Monad }
+import cats.~>
 import fs2.Stream
-import org.scanamo.ops.{ CatsInterpreter, ScanamoOps, ScanamoOpsT }
+import org.scanamo.ops.CatsInterpreter
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
-class ScanamoCats[F[_]: Async](client: DynamoDbAsyncClient) {
-  final private val interpreter = new CatsInterpreter(client)
-
-  final def exec[A](op: ScanamoOps[A]): F[A] = op.foldMap(interpreter)
-
-  final def execT[M[_]: Monad, A](hoist: F ~> M)(op: ScanamoOpsT[M, A]): M[A] =
-    op.foldMap(interpreter andThen hoist)
-}
+class ScanamoCats[F[_]: Async] private (client: DynamoDbAsyncClient) extends ScanamoClient(new CatsInterpreter(client))
 
 object ScanamoCats {
   def apply[F[_]: Async](client: DynamoDbAsyncClient): ScanamoCats[F] = new ScanamoCats(client)

--- a/scanamo/src/main/scala/org/scanamo/ScanamoAsync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoAsync.scala
@@ -16,27 +16,15 @@
 
 package org.scanamo
 
-import cats.{ ~>, Monad }
 import org.scanamo.ops.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext
 
 /** Interprets Scanamo operations in an asynchronous context: Scala futures.
   */
-final class ScanamoAsync private (client: DynamoDbAsyncClient)(implicit ec: ExecutionContext) {
-
-  private val interpreter = new ScanamoAsyncInterpreter(client)
-
-  /** Execute the operations built with [[org.scanamo.Table]]
-    */
-  def exec[A](op: ScanamoOps[A]): Future[A] = op.foldMap(interpreter)
-
-  /** Execute the operations built with [[org.scanamo.Table]] with effects in the monad `M` threaded in.
-    */
-  def execT[M[_]: Monad, A](hoist: Future ~> M)(op: ScanamoOpsT[M, A]): M[A] =
-    op.foldMap(interpreter andThen hoist)
-}
+final class ScanamoAsync private (client: DynamoDbAsyncClient)(implicit ec: ExecutionContext)
+    extends ScanamoClient(new ScanamoAsyncInterpreter(client))
 
 object ScanamoAsync {
   def apply(client: DynamoDbAsyncClient)(implicit ec: ExecutionContext): ScanamoAsync = new ScanamoAsync(client)

--- a/scanamo/src/main/scala/org/scanamo/ScanamoClient.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoClient.scala
@@ -1,0 +1,21 @@
+package org.scanamo
+
+import cats.{ ~>, Monad }
+import org.scanamo.ops.{ ScanamoOps, ScanamoOpsA, ScanamoOpsT }
+
+/** A common super-class for all Scanamo client classes. Use one of the convenience constructors in `ScanamoAsync`,
+  * `Scanamo`, `ScanamoCats`, `ScanamoZio`, `ScanamoPekko`, etc, to make an instance of this class.
+  *
+  * The `exec()` method is the main entry point for executing Scanamo operations.
+  */
+class ScanamoClient[F[_]: Monad](interpreter: ScanamoOpsA ~> F) {
+
+  /** Execute the operations built with [[org.scanamo.Table]]
+    */
+  def exec[A](op: ScanamoOps[A]): F[A] = op.foldMap(interpreter)
+
+  /** Execute the operations built with [[org.scanamo.Table]] with effects in the monad `M` threaded in.
+    */
+  def execT[M[_]: Monad, A](hoist: F ~> M)(op: ScanamoOpsT[M, A]): M[A] =
+    op.foldMap(interpreter andThen hoist)
+}

--- a/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoSync.scala
@@ -16,7 +16,7 @@
 
 package org.scanamo
 
-import cats.{ ~>, Id, Monad }
+import cats.{ ~>, Id }
 import org.scanamo.ops.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
@@ -24,17 +24,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
   *
   * To avoid blocking, use [[org.scanamo.ScanamoAsync]]
   */
-final class Scanamo private (client: DynamoDbClient) {
-  private val interpreter = new ScanamoSyncInterpreter(client)
-
-  /** Execute the operations built with [[org.scanamo.Table]]
-    */
-  def exec[A](op: ScanamoOps[A]): A = op.foldMap(interpreter)
-
-  /** Execute the operations built with [[org.scanamo.Table]] with effects in the monad `M` threaded in.
-    */
-  def execT[M[_]: Monad, A](hoist: Id ~> M)(op: ScanamoOpsT[M, A]): M[A] =
-    op.foldMap(interpreter andThen hoist)
+final class Scanamo private (client: DynamoDbClient) extends ScanamoClient(new ScanamoSyncInterpreter(client)) {
+  override def exec[A](op: ScanamoOps[A]): A = super.exec(op) // overridden to explicitly return `A` rather than `Id[A]`
 }
 
 object Scanamo {

--- a/scanamo/src/test/scala/org/scanamo/TableTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/TableTest.scala
@@ -657,13 +657,11 @@ class TableTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
         filteredStations <- stationTable.filter(AttributeName.of("line") contains "opo").scan()
       } yield filteredStations
 
-      scanamo.exec(ops) should contain theSameElementsAs (
-        List(
-          Right(Station("Metropolitan", "Chalfont & Latimer", 8)),
-          Right(Station("Metropolitan", "Chorleywood", 7)),
-          Right(Station("Metropolitan", "Rickmansworth", 7)),
-          Right(Station("Metropolitan", "Croxley", 7))
-        )
+      scanamo.exec(ops) should contain theSameElementsAs List(
+        Right(Station("Metropolitan", "Chalfont & Latimer", 8)),
+        Right(Station("Metropolitan", "Chorleywood", 7)),
+        Right(Station("Metropolitan", "Rickmansworth", 7)),
+        Right(Station("Metropolitan", "Croxley", 7))
       )
     }
   }

--- a/zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -16,7 +16,7 @@
 
 package org.scanamo
 
-import cats.{ ~>, Monad }
+import cats.~>
 import org.scanamo.ops.*
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
@@ -24,15 +24,7 @@ import zio.IO
 import zio.interop.catz.*
 import zio.stream.{ Stream, ZStream }
 
-class ScanamoZio private (client: DynamoDbAsyncClient) {
-  final private val interpreter: ScanamoOpsA ~> IO[DynamoDbException, *] =
-    new ZioInterpreter(client)
-
-  final def exec[A](op: ScanamoOps[A]): IO[DynamoDbException, A] = op.foldMap(interpreter)
-
-  final def execT[M[_]: Monad, A](hoist: IO[DynamoDbException, *] ~> M)(op: ScanamoOpsT[M, A]): M[A] =
-    op.foldMap(interpreter andThen hoist)
-}
+class ScanamoZio private (client: DynamoDbAsyncClient) extends ScanamoClient(new ZioInterpreter(client))
 
 object ScanamoZio {
   def apply(client: DynamoDbAsyncClient): ScanamoZio = new ScanamoZio(client)


### PR DESCRIPTION
The 5 Scanamo client objects (`Scanamo`, `ScanamoAsync` `CatsScanamo`, `ZioScanamo`, `PekkoScanamo`) all have common `exec` & `execT` methods with almost completely identical implementations. This change introduces a new common `ScanamoClient` super-class for all 5 client objects that implements those methods.


Result: less code! ✨ 

<img width="220" alt="image" src="https://github.com/user-attachments/assets/bdb15946-79e0-418d-b4e9-1fc4a5c8981c">


### Do we need the subtype instance classes?!

I was tempted to remove the 5 subtype instance classes altogether, as there's not much need for them from the Scanamo implementation side - we could get by with just the 5 singleton objects providing `apply()` methods to construct `ScanamoClient` instances - but there are some wrinkles with that:

* Existing code in consumers of the Scanamo library will typically hand around instance references with the type of the subtype (ie `scanamo: ScanamoAsync`) - they've had no alternative before. We can't remove the subtype instance class without forcing a lot of users to switch to using `scanamo: ScanamoClient[Future]` (which is also less readable!). Swapping in some type aliases, eg `type ScanamoAsync = ScanamoClient[Future]` might help here, but I won't try that here.
* `PekkoScanamo` provides an additional `execFuture` method, which is Pekko-specific - no idea if it's used, but I guess we shouldn't delete it.
* Although `ScanamoClient[Id]` should be able to cleanly implement `Scanamo` without alteration (because `type Id[A] = A`), it turns out that this would mean that _some_ consuming code would have to be altered for the Scala 2 compiler (the Scala 3.3.3 compiler did not have this problem).

...so the 5 subtype instance class definitions continue to exist for now.

### See also

* https://github.com/scanamo/scanamo/pull/1786 for a subsequent refactor that also reduces code.