### PR TITLE
Simplify processing of `RequestCondition` attribute values - make them non-optional

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -16,10 +16,8 @@
 
 package org.scanamo
 
-import cats.Parallel
-import cats.kernel.Monoid
-import cats.syntax.apply.*
-import cats.syntax.semigroup.*
+import cats.implicits.*
+import cats.{ Monoid, Parallel }
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 import java.util.{ HashMap, Map as JMap }
@@ -375,4 +373,9 @@ object DynamoObject {
     m.putAll(ys)
     m
   }
+
+  /** Technically, this isn't a Monoid - it's not strictly associative (combining `Map`s can arbitrarily annihilate
+    * different keys), making it just a 'unital magma'... practically though, the difference shouldn't be a problem.
+    */
+  implicit val m: Monoid[DynamoObject] = Monoid.instance(empty, _ <> _)
 }

--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -18,6 +18,7 @@ package org.scanamo
 
 import cats.data.NonEmptyList
 import cats.free.{ Free, FreeT }
+import cats.implicits.*
 import org.scanamo.request.*
 import software.amazon.awssdk.services.dynamodb.model.*
 
@@ -42,11 +43,10 @@ package object ops {
           queryRefinement(_.options.exclusiveStartKey)((r, k) => r.exclusiveStartKey(k.toJavaMap)),
           queryRefinement(_.options.filter) { (r, f) =>
             val requestCondition = f.apply.runEmptyA.value
-            requestCondition.dynamoValues.toExpressionAttributeValues
-              .foldLeft(
-                r.filterExpression(requestCondition.expression)
-                  .expressionAttributeNames(requestCondition.attributeNames.asJava)
-              )(_ expressionAttributeValues _)
+            val attributes = requestCondition.attributes
+            val builder =
+              r.filterExpression(requestCondition.expression).expressionAttributeNames(attributes.names.asJava)
+            attributes.values.toExpressionAttributeValues.foldLeft(builder)(_ expressionAttributeValues _)
           }
         )
         .reduceLeft(_.compose(_))(
@@ -80,17 +80,16 @@ package object ops {
         )
 
       requestCondition.fold {
-        val requestWithCondition = requestBuilder.expressionAttributeNames(queryCondition.attributeNames.asJava)
-        queryCondition.dynamoValues.toExpressionAttributeValues
+        val requestWithCondition = requestBuilder.expressionAttributeNames(queryCondition.attributes.names.asJava)
+        queryCondition.attributes.values.toExpressionAttributeValues
           .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
       } { condition =>
+        val attributes = queryCondition.attributes |+| condition.attributes
+
         val requestWithCondition = requestBuilder
           .filterExpression(condition.expression)
-          .expressionAttributeNames((queryCondition.attributeNames ++ condition.attributeNames).asJava)
-        val attributeValues = queryCondition.dynamoValues <> condition.dynamoValues
-
-        attributeValues.toExpressionAttributeValues
-          .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
+          .expressionAttributeNames(attributes.names.asJava)
+        attributes.values.toExpressionAttributeValues.foldLeft(requestWithCondition)(_ expressionAttributeValues _)
       }.build
     }
 
@@ -104,9 +103,9 @@ package object ops {
         .fold(request) { condition =>
           val requestWithCondition = request
             .conditionExpression(condition.expression)
-            .expressionAttributeNames(condition.attributeNames.asJava)
+            .expressionAttributeNames(condition.attributes.names.asJava)
 
-          condition.dynamoValues.toExpressionAttributeValues
+          condition.attributes.values.toExpressionAttributeValues
             .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
         }
         .build
@@ -122,32 +121,30 @@ package object ops {
         .fold(request) { condition =>
           val requestWithCondition = request
             .conditionExpression(condition.expression)
-            .expressionAttributeNames(condition.attributeNames.asJava)
+            .expressionAttributeNames(condition.attributes.names.asJava)
 
-          condition.dynamoValues.toExpressionAttributeValues
+          condition.attributes.values.toExpressionAttributeValues
             .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
         }
         .build
     }
 
     def update(req: ScanamoUpdateRequest): UpdateItemRequest = {
-      val attributeNames: Map[String, String] = req.condition.map(_.attributeNames).foldLeft(req.attributeNames)(_ ++ _)
-      val attributeValues: DynamoObject = req.condition.map(_.dynamoValues).foldLeft(req.dynamoValues)(_ <> _)
       val request = UpdateItemRequest.builder
         .tableName(req.tableName)
         .key(req.key.toJavaMap)
-        .updateExpression(req.updateExpression)
+        .updateExpression(req.updateAndCondition.update.expression)
         .returnValues(ReturnValue.ALL_NEW)
-        .expressionAttributeNames(attributeNames.asJava)
+        .expressionAttributeNames(req.updateAndCondition.attributes.names.asJava)
 
       val requestWithCondition =
-        req.condition.fold(request)(condition => request.conditionExpression(condition.expression))
+        req.updateAndCondition.condition.fold(request)(condition => request.conditionExpression(condition.expression))
 
-      attributeValues.toExpressionAttributeValues
+      req.updateAndCondition.attributes.values.toExpressionAttributeValues
         .fold(requestWithCondition) { avs =>
-          if (req.addEmptyList)
+          if (req.updateAndCondition.update.addEmptyList)
             avs.put(":emptyList", DynamoValue.EmptyList)
-          requestWithCondition expressionAttributeValues avs
+          requestWithCondition.expressionAttributeValues(avs)
         }
         .build
     }
@@ -167,11 +164,11 @@ package object ops {
       val updateItems = req.updateItems.map { item =>
         val update = software.amazon.awssdk.services.dynamodb.model.Update.builder
           .tableName(item.tableName)
-          .updateExpression(item.updateExpression.expression)
-          .expressionAttributeNames(item.updateExpression.attributeNames.asJava)
+          .updateExpression(item.updateAndCondition.update.expression)
+          .expressionAttributeNames(item.updateAndCondition.update.attributes.names.asJava)
           .key(item.key.toJavaMap)
 
-        val updateWithAvs = DynamoObject(item.updateExpression.dynamoValues).toExpressionAttributeValues
+        val updateWithAvs = item.updateAndCondition.update.attributes.values.toExpressionAttributeValues
           .fold(update)(avs => update.expressionAttributeValues(avs))
           .build
 
@@ -193,9 +190,9 @@ package object ops {
           .key(item.key.toJavaMap)
           .tableName(item.tableName)
           .conditionExpression(item.condition.expression)
-          .expressionAttributeNames(item.condition.attributeNames.asJava)
+          .expressionAttributeNames(item.condition.attributes.names.asJava)
 
-        val checkWithAvs = item.condition.dynamoValues.toExpressionAttributeValues
+        val checkWithAvs = item.condition.attributes.values.toExpressionAttributeValues
           .foldLeft(check)(_ expressionAttributeValues _)
           .build
 

--- a/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
@@ -17,13 +17,12 @@
 package org.scanamo.query
 
 import cats.data.State
-import cats.syntax.either.*
-import cats.syntax.functor.*
+import cats.implicits.*
 import org.scanamo.*
 import org.scanamo.ops.ScanamoOps
 import org.scanamo.ops.ScanamoOps.Results.*
-import org.scanamo.request.{ RequestCondition, ScanamoDeleteRequest, ScanamoPutRequest, ScanamoUpdateRequest }
-import org.scanamo.update.UpdateExpression
+import org.scanamo.request.*
+import org.scanamo.update.{ UpdateAndCondition, UpdateExpression }
 import software.amazon.awssdk.services.dynamodb.model.{ AttributeValue, DeleteItemResponse, PutItemResponse }
 
 final case class ConditionalOperation[V, T](tableName: String, t: T)(implicit
@@ -84,11 +83,7 @@ final case class ConditionalOperation[V, T](tableName: String, t: T)(implicit
         ScanamoUpdateRequest(
           tableName,
           key.toDynamoObject,
-          update.expression,
-          update.attributeNames,
-          DynamoObject(update.dynamoValues),
-          update.addEmptyList,
-          Some(expr(t).runEmptyA.value)
+          UpdateAndCondition(update, Some(expr(t).runEmptyA.value))
         )
       )
       .map(
@@ -100,11 +95,7 @@ final case class ConditionalOperation[V, T](tableName: String, t: T)(implicit
 trait ConditionExpression[-T] { self =>
   def apply(x: T): State[Int, RequestCondition]
 
-  def contramap[S](f: S => T): ConditionExpression[S] =
-    new ConditionExpression[S] {
-      def apply(x: S): State[Int, RequestCondition] = self(f(x))
-    }
-
+  def contramap[S](f: S => T): ConditionExpression[S] = (x: S) => self(f(x))
 }
 
 object ConditionExpression {
@@ -118,20 +109,16 @@ object ConditionExpression {
   implicit def attributeValueEqualsCondition[V: DynamoFormat]: ConditionExpression[(AttributeName, V)] =
     keyEqualsCondition.contramap { case (attr, v) => KeyEquals(attr, v) }
 
-  implicit def keyEqualsCondition[V: DynamoFormat]: ConditionExpression[KeyEquals[V]] =
-    new ConditionExpression[KeyEquals[V]] {
-      override def apply(key: KeyEquals[V]): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"equalsCondition$cpt"
-          val attributeName = key.key
-          val namePlaceholder = attributeName.placeholder(prefix)
-          val valuePlaceholder = s"conditionAttributeValue$cpt"
-          RequestCondition(
-            s"#$namePlaceholder = :$valuePlaceholder",
-            attributeName.attributeNames(s"#$prefix"),
-            DynamoObject(valuePlaceholder -> key.v)
-          )
-        }
+  implicit def keyEqualsCondition[V: DynamoFormat]: ConditionExpression[KeyEquals[V]] = (key: KeyEquals[V]) =>
+    State.inspect { cpt =>
+      val prefix = s"equalsCondition$cpt"
+      val attributeName = key.key
+      val namePlaceholder = attributeName.placeholder(prefix)
+      val valuePlaceholder = s"conditionAttributeValue$cpt"
+      RequestCondition(
+        s"#$namePlaceholder = :$valuePlaceholder",
+        AttributeNamesAndValues(attributeName.attributeNames(s"#$prefix"), DynamoObject(valuePlaceholder -> key.v))
+      )
     }
 
   @deprecated("Use `attr in values` syntax", "1.0")
@@ -142,132 +129,97 @@ object ConditionExpression {
   implicit def attributeValueInCondition[V: DynamoFormat]: ConditionExpression[(AttributeName, Set[V])] =
     keyListCondition.contramap { case (attr, vs) => KeyList(attr, vs) }
 
-  implicit def keyListCondition[V: DynamoFormat]: ConditionExpression[KeyList[V]] =
-    new ConditionExpression[KeyList[V]] {
-      override def apply(keys: KeyList[V]): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"inCondition$cpt"
-          val attributeName = keys.key
-          val namePlaceholder = attributeName.placeholder(prefix)
-          val valuePlaceholder = s"conditionAttributeValue$cpt"
-          val attributeValues = keys.values
-            .foldLeft(DynamoObject.empty -> 0) { case ((m, i), v) =>
-              (m <> DynamoObject(s"$valuePlaceholder$i" -> v)) -> (i + 1)
-            }
-            ._1
-          RequestCondition(
-            s"""#$namePlaceholder IN ${attributeValues.mapKeys(k => s":$k").keys.mkString("(", ",", ")")}""",
-            attributeName.attributeNames(s"#$prefix"),
-            attributeValues
-          )
+  implicit def keyListCondition[V: DynamoFormat]: ConditionExpression[KeyList[V]] = (keys: KeyList[V]) =>
+    State.inspect { cpt =>
+      val prefix = s"inCondition$cpt"
+      val attributeName = keys.key
+      val namePlaceholder = attributeName.placeholder(prefix)
+      val valuePlaceholder = s"conditionAttributeValue$cpt"
+      val attributeValues = keys.values
+        .foldLeft(DynamoObject.empty -> 0) { case ((m, i), v) =>
+          (m <> DynamoObject(s"$valuePlaceholder$i" -> v)) -> (i + 1)
         }
+        ._1
+      RequestCondition(
+        s"""#$namePlaceholder IN ${attributeValues.mapKeys(k => s":$k").keys.mkString("(", ",", ")")}""",
+        AttributeNamesAndValues(attributeName.attributeNames(s"#$prefix"), attributeValues)
+      )
     }
 
-  implicit def attributeExistsCondition: ConditionExpression[AttributeExists] =
-    new ConditionExpression[AttributeExists] {
-      override def apply(t: AttributeExists): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"attributeExists$cpt"
-          RequestCondition(
-            s"attribute_exists(#${t.key.placeholder(prefix)})",
-            t.key.attributeNames(s"#$prefix"),
-            DynamoObject.empty
-          )
-        }
+  implicit def attributeExistsCondition: ConditionExpression[AttributeExists] = (t: AttributeExists) =>
+    State.inspect { cpt =>
+      val prefix = s"attributeExists$cpt"
+      RequestCondition(
+        s"attribute_exists(#${t.key.placeholder(prefix)})",
+        AttributeNamesAndValues(t.key.attributeNames(s"#$prefix"), DynamoObject.empty)
+      )
     }
 
-  implicit def attributeNotExistsCondition: ConditionExpression[AttributeNotExists] =
-    new ConditionExpression[AttributeNotExists] {
-      override def apply(t: AttributeNotExists): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"attributeNotExists$cpt"
-          RequestCondition(
-            s"attribute_not_exists(#${t.key.placeholder(prefix)})",
-            t.key.attributeNames(s"#$prefix"),
-            DynamoObject.empty
-          )
-        }
+  implicit def attributeNotExistsCondition: ConditionExpression[AttributeNotExists] = (t: AttributeNotExists) =>
+    State.inspect { cpt =>
+      val prefix = s"attributeNotExists$cpt"
+      RequestCondition(
+        s"attribute_not_exists(#${t.key.placeholder(prefix)})",
+        AttributeNamesAndValues(t.key.attributeNames(s"#$prefix"), DynamoObject.empty)
+      )
     }
 
-  implicit val containsCondition: ConditionExpression[Contains] =
-    new ConditionExpression[Contains] {
-      override def apply(t: Contains): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"contains$cpt"
-          val valuePlaceholder = s"containsAttributeValue$cpt"
-          RequestCondition(
-            s"contains(#${t.key.placeholder(prefix)}, :$valuePlaceholder)",
-            t.key.attributeNames(s"#$prefix"),
-            DynamoObject(valuePlaceholder -> DynamoValue.fromString(t.value))
-          )
-        }
+  implicit val containsCondition: ConditionExpression[Contains] = (t: Contains) =>
+    State.inspect { cpt =>
+      val prefix = s"contains$cpt"
+      val valuePlaceholder = s"containsAttributeValue$cpt"
+      RequestCondition(
+        s"contains(#${t.key.placeholder(prefix)}, :$valuePlaceholder)",
+        AttributeNamesAndValues(
+          t.key.attributeNames(s"#$prefix"),
+          DynamoObject(valuePlaceholder -> DynamoValue.fromString(t.value))
+        )
+      )
     }
 
-  implicit def notCondition[T](implicit pcs: ConditionExpression[T]): ConditionExpression[Not[T]] =
-    new ConditionExpression[Not[T]] {
-      override def apply(not: Not[T]): State[Int, RequestCondition] =
-        pcs(not.condition).map { conditionToNegate =>
-          conditionToNegate.copy(expression = s"NOT(${conditionToNegate.expression})")
-        }
+  implicit def notCondition[T](implicit pcs: ConditionExpression[T]): ConditionExpression[Not[T]] = (not: Not[T]) =>
+    pcs(not.condition).map { conditionToNegate =>
+      conditionToNegate.copy(expression = s"NOT(${conditionToNegate.expression})")
     }
 
-  implicit def beginsWithCondition[V: DynamoFormat]: ConditionExpression[BeginsWith[V]] =
-    new ConditionExpression[BeginsWith[V]] {
-      override def apply(b: BeginsWith[V]): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"beginsWith$cpt"
-          val valuePlaceholder = s"conditionAttributeValue$cpt"
-          RequestCondition(
-            s"begins_with(#${b.key.placeholder(prefix)}, :$valuePlaceholder)",
-            b.key.attributeNames(s"#$prefix"),
-            DynamoObject(valuePlaceholder -> b.v)
-          )
-        }
+  implicit def beginsWithCondition[V: DynamoFormat]: ConditionExpression[BeginsWith[V]] = (b: BeginsWith[V]) =>
+    State.inspect { cpt =>
+      val prefix = s"beginsWith$cpt"
+      val valuePlaceholder = s"conditionAttributeValue$cpt"
+      RequestCondition(
+        s"begins_with(#${b.key.placeholder(prefix)}, :$valuePlaceholder)",
+        AttributeNamesAndValues(b.key.attributeNames(s"#$prefix"), DynamoObject(valuePlaceholder -> b.v))
+      )
     }
 
-  implicit def betweenCondition[V: DynamoFormat]: ConditionExpression[Between[V]] =
-    new ConditionExpression[Between[V]] {
-
-      override def apply(b: Between[V]): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"between$cpt"
-          val lowerPh = s"lower$cpt"
-          val upperPh = s"upper$cpt"
-          RequestCondition(
-            s"#${b.key.placeholder(prefix)} BETWEEN :$lowerPh and :$upperPh",
-            b.key.attributeNames(s"#$prefix"),
-            DynamoObject(lowerPh -> b.lo, upperPh -> b.hi)
-          )
-        }
+  implicit def betweenCondition[V: DynamoFormat]: ConditionExpression[Between[V]] = (b: Between[V]) =>
+    State.inspect { cpt =>
+      val prefix = s"between$cpt"
+      val lowerPh = s"lower$cpt"
+      val upperPh = s"upper$cpt"
+      RequestCondition(
+        s"#${b.key.placeholder(prefix)} BETWEEN :$lowerPh and :$upperPh",
+        AttributeNamesAndValues(b.key.attributeNames(s"#$prefix"), DynamoObject(lowerPh -> b.lo, upperPh -> b.hi))
+      )
     }
 
-  implicit def keyIsCondition[V: DynamoFormat]: ConditionExpression[KeyIs[V]] =
-    new ConditionExpression[KeyIs[V]] {
-      override def apply(k: KeyIs[V]): State[Int, RequestCondition] =
-        State.inspect { cpt =>
-          val prefix = s"keyIs$cpt"
-          val valuePlaceholder = s"conditionAttributeValue$cpt"
-          RequestCondition(
-            s"#${k.key.placeholder(prefix)} ${k.operator.op} :$valuePlaceholder",
-            k.key.attributeNames(s"#$prefix"),
-            DynamoObject(valuePlaceholder -> k.v)
-          )
-        }
+  implicit def keyIsCondition[V: DynamoFormat]: ConditionExpression[KeyIs[V]] = (k: KeyIs[V]) =>
+    State.inspect { cpt =>
+      val prefix = s"keyIs$cpt"
+      val valuePlaceholder = s"conditionAttributeValue$cpt"
+      RequestCondition(
+        s"#${k.key.placeholder(prefix)} ${k.operator.op} :$valuePlaceholder",
+        AttributeNamesAndValues(k.key.attributeNames(s"#$prefix"), DynamoObject(valuePlaceholder -> k.v))
+      )
     }
 
   implicit def andCondition[L: ConditionExpression, R: ConditionExpression]: ConditionExpression[AndCondition[L, R]] =
-    new ConditionExpression[AndCondition[L, R]] {
-      override def apply(and: AndCondition[L, R]): State[Int, RequestCondition] =
-        combineConditions(and.l, and.r, "AND")
-    }
+    (and: AndCondition[L, R]) => combineConditions(and.l, and.r, "AND")
 
   implicit def orCondition[L: ConditionExpression, R: ConditionExpression]: ConditionExpression[OrCondition[L, R]] =
-    new ConditionExpression[OrCondition[L, R]] {
-      override def apply(or: OrCondition[L, R]): State[Int, RequestCondition] =
-        combineConditions(or.l, or.r, "OR")
-    }
+    (or: OrCondition[L, R]) => combineConditions(or.l, or.r, "OR")
 
-  private def combineConditions[L, R](l: L, r: R, combininingOperator: String)(implicit
+  private def combineConditions[L, R](l: L, r: R, combiningOperator: String)(implicit
     lce: ConditionExpression[L],
     rce: ConditionExpression[R]
   ): State[Int, RequestCondition] =
@@ -276,9 +228,8 @@ object ConditionExpression {
       _ <- State.modify[Int](_ + 1)
       r <- rce(r)
     } yield RequestCondition(
-      s"(${l.expression} $combininingOperator ${r.expression})",
-      l.attributeNames ++ r.attributeNames,
-      l.dynamoValues <> r.dynamoValues
+      s"(${l.expression} $combiningOperator ${r.expression})",
+      l.attributes |+| r.attributes
     )
 }
 
@@ -288,8 +239,8 @@ case class OrCondition[L: ConditionExpression, R: ConditionExpression](l: L, r: 
 
 case class Condition[T](t: T)(implicit T: ConditionExpression[T]) {
   def apply: State[Int, RequestCondition] = T.apply(t)
-  def and[Y: ConditionExpression](other: Y) = AndCondition(t, other)
-  def or[Y: ConditionExpression](other: Y) = OrCondition(t, other)
+  def and[Y: ConditionExpression](other: Y): AndCondition[T, Y] = AndCondition(t, other)
+  def or[Y: ConditionExpression](other: Y): OrCondition[T, Y] = OrCondition(t, other)
 }
 
 object Condition {

--- a/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala
@@ -129,7 +129,7 @@ object ConditionExpression {
           RequestCondition(
             s"#$namePlaceholder = :$valuePlaceholder",
             attributeName.attributeNames(s"#$prefix"),
-            Some(DynamoObject(valuePlaceholder -> key.v))
+            DynamoObject(valuePlaceholder -> key.v)
           )
         }
     }
@@ -158,7 +158,7 @@ object ConditionExpression {
           RequestCondition(
             s"""#$namePlaceholder IN ${attributeValues.mapKeys(k => s":$k").keys.mkString("(", ",", ")")}""",
             attributeName.attributeNames(s"#$prefix"),
-            Some(attributeValues)
+            attributeValues
           )
         }
     }
@@ -168,7 +168,11 @@ object ConditionExpression {
       override def apply(t: AttributeExists): State[Int, RequestCondition] =
         State.inspect { cpt =>
           val prefix = s"attributeExists$cpt"
-          RequestCondition(s"attribute_exists(#${t.key.placeholder(prefix)})", t.key.attributeNames(s"#$prefix"), None)
+          RequestCondition(
+            s"attribute_exists(#${t.key.placeholder(prefix)})",
+            t.key.attributeNames(s"#$prefix"),
+            DynamoObject.empty
+          )
         }
     }
 
@@ -180,7 +184,7 @@ object ConditionExpression {
           RequestCondition(
             s"attribute_not_exists(#${t.key.placeholder(prefix)})",
             t.key.attributeNames(s"#$prefix"),
-            None
+            DynamoObject.empty
           )
         }
     }
@@ -194,7 +198,7 @@ object ConditionExpression {
           RequestCondition(
             s"contains(#${t.key.placeholder(prefix)}, :$valuePlaceholder)",
             t.key.attributeNames(s"#$prefix"),
-            Some(DynamoObject(valuePlaceholder -> DynamoValue.fromString(t.value)))
+            DynamoObject(valuePlaceholder -> DynamoValue.fromString(t.value))
           )
         }
     }
@@ -216,7 +220,7 @@ object ConditionExpression {
           RequestCondition(
             s"begins_with(#${b.key.placeholder(prefix)}, :$valuePlaceholder)",
             b.key.attributeNames(s"#$prefix"),
-            Some(DynamoObject(valuePlaceholder -> b.v))
+            DynamoObject(valuePlaceholder -> b.v)
           )
         }
     }
@@ -232,9 +236,7 @@ object ConditionExpression {
           RequestCondition(
             s"#${b.key.placeholder(prefix)} BETWEEN :$lowerPh and :$upperPh",
             b.key.attributeNames(s"#$prefix"),
-            Some(
-              DynamoObject(lowerPh -> b.lo, upperPh -> b.hi)
-            )
+            DynamoObject(lowerPh -> b.lo, upperPh -> b.hi)
           )
         }
     }
@@ -248,7 +250,7 @@ object ConditionExpression {
           RequestCondition(
             s"#${k.key.placeholder(prefix)} ${k.operator.op} :$valuePlaceholder",
             k.key.attributeNames(s"#$prefix"),
-            Some(DynamoObject(valuePlaceholder -> k.v))
+            DynamoObject(valuePlaceholder -> k.v)
           )
         }
     }
@@ -276,7 +278,7 @@ object ConditionExpression {
     } yield RequestCondition(
       s"(${l.expression} $combininingOperator ${r.expression})",
       l.attributeNames ++ r.attributeNames,
-      l.dynamoValues.flatMap(xs => r.dynamoValues.map(xs <> _)) orElse l.dynamoValues orElse r.dynamoValues
+      l.dynamoValues <> r.dynamoValues
     )
 }
 

--- a/scanamo/src/main/scala/org/scanamo/query/QueryableKeyCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/query/QueryableKeyCondition.scala
@@ -32,7 +32,7 @@ object QueryableKeyCondition {
         RequestCondition(
           s"#K = :${t.key.placeholder("")}",
           Map("#K" -> t.key.placeholder("")),
-          Some(DynamoObject(t.key.placeholder("") -> t.v))
+          DynamoObject(t.key.placeholder("") -> t.v)
         )
     }
 
@@ -43,10 +43,8 @@ object QueryableKeyCondition {
         RequestCondition(
           s"#K = :${t.hashCondition.key.placeholder("")} AND ${t.rangeCondition.keyConditionExpression("R")}",
           Map("#K" -> t.hashCondition.key.placeholder("")) ++ t.rangeCondition.key.attributeNames("#R"),
-          Some(
-            DynamoObject(t.hashCondition.key.placeholder("") -> t.hashCondition.v) <> DynamoObject(
-              t.rangeCondition.attributes.toSeq: _*
-            )
+          DynamoObject(t.hashCondition.key.placeholder("") -> t.hashCondition.v) <> DynamoObject(
+            t.rangeCondition.attributes.toSeq: _*
           )
         )
     }
@@ -64,7 +62,7 @@ object QueryableKeyCondition {
         RequestCondition(
           charWithKey.map { case (char, key) => s"$char = :$key" }.mkString(" AND "),
           charWithKey.toMap,
-          Some(m)
+          m
         )
       }
     }

--- a/scanamo/src/main/scala/org/scanamo/request/AttributeNamesAndValues.scala
+++ b/scanamo/src/main/scala/org/scanamo/request/AttributeNamesAndValues.scala
@@ -1,0 +1,16 @@
+package org.scanamo.request
+
+import cats.Monoid
+import org.scanamo.DynamoObject
+
+case class AttributeNamesAndValues(names: Map[String, String], values: DynamoObject)
+
+object AttributeNamesAndValues {
+  val Empty = AttributeNamesAndValues(Map.empty, DynamoObject.empty)
+
+  /** Technically, this isn't a Monoid - it's not strictly associative (combining `Map`s can arbitrarily annihilate
+    * different keys), making it just a 'unital magma'... practically though, the difference shouldn't be a problem.
+    */
+  implicit val m: Monoid[AttributeNamesAndValues] =
+    Monoid.instance(Empty, (x, y) => AttributeNamesAndValues(x.names ++ y.names, x.values <> y.values))
+}

--- a/scanamo/src/main/scala/org/scanamo/request/ScanamoRequest.scala
+++ b/scanamo/src/main/scala/org/scanamo/request/ScanamoRequest.scala
@@ -16,8 +16,9 @@
 
 package org.scanamo.request
 
+import cats.implicits.*
 import org.scanamo.query.{ Condition, Query }
-import org.scanamo.update.UpdateExpression
+import org.scanamo.update.{ UpdateAndCondition, UpdateExpression }
 import org.scanamo.{ DeleteReturn, DynamoObject, DynamoValue, PutReturn }
 
 case class ScanamoPutRequest(
@@ -37,12 +38,19 @@ case class ScanamoDeleteRequest(
 case class ScanamoUpdateRequest(
   tableName: String,
   key: DynamoObject,
-  updateExpression: String,
-  attributeNames: Map[String, String],
-  dynamoValues: DynamoObject,
-  addEmptyList: Boolean,
-  condition: Option[RequestCondition]
-)
+  updateAndCondition: UpdateAndCondition
+) {
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def updateExpression: String = updateAndCondition.update.expression
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def attributeNames: Map[String, String] = updateAndCondition.update.attributes.names
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def dynamoValues: DynamoObject = updateAndCondition.update.attributes.values
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def addEmptyList: Boolean = updateAndCondition.update.addEmptyList
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def condition: Option[RequestCondition] = updateAndCondition.condition
+}
 
 case class ScanamoScanRequest(
   tableName: String,
@@ -70,9 +78,19 @@ object ScanamoQueryOptions {
 
 case class RequestCondition(
   expression: String,
-  attributeNames: Map[String, String],
-  dynamoValues: DynamoObject
-)
+  attributes: AttributeNamesAndValues
+) {
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def this(
+    expression: String,
+    attributeNames: Map[String, String],
+    dynamoValues: Option[DynamoObject]
+  ) = this(expression, AttributeNamesAndValues(attributeNames, dynamoValues.orEmpty))
+  @deprecated("Use `attributes.names` - see https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def attributeNames: Map[String, String] = attributes.names
+  @deprecated("Use `attributes.values` - see https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def dynamoValues: Option[DynamoObject] = Some(attributes.values)
+}
 
 case class TransactPutItem(
   tableName: String,
@@ -83,9 +101,20 @@ case class TransactPutItem(
 case class TransactUpdateItem(
   tableName: String,
   key: DynamoObject,
-  updateExpression: UpdateExpression,
-  condition: Option[RequestCondition]
-)
+  updateAndCondition: UpdateAndCondition
+) {
+  @deprecated("See https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def this(
+    tableName: String,
+    key: DynamoObject,
+    updateExpression: UpdateExpression,
+    condition: Option[RequestCondition]
+  ) = this(tableName, key, UpdateAndCondition(updateExpression, condition))
+  @deprecated("Use `updateAndCondition.update` - see https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def updateExpression: UpdateExpression = updateAndCondition.update
+  @deprecated("Use `updateAndCondition.condition` - see https://github.com/scanamo/scanamo/pull/1796", "3.0.0")
+  def condition: Option[RequestCondition] = updateAndCondition.condition
+}
 
 case class TransactDeleteItem(
   tableName: String,

--- a/scanamo/src/main/scala/org/scanamo/request/ScanamoRequest.scala
+++ b/scanamo/src/main/scala/org/scanamo/request/ScanamoRequest.scala
@@ -71,7 +71,7 @@ object ScanamoQueryOptions {
 case class RequestCondition(
   expression: String,
   attributeNames: Map[String, String],
-  dynamoValues: Option[DynamoObject]
+  dynamoValues: DynamoObject
 )
 
 case class TransactPutItem(

--- a/scanamo/src/main/scala/org/scanamo/update/UpdateAndCondition.scala
+++ b/scanamo/src/main/scala/org/scanamo/update/UpdateAndCondition.scala
@@ -1,0 +1,8 @@
+package org.scanamo.update
+
+import cats.implicits.*
+import org.scanamo.request.{ AttributeNamesAndValues, RequestCondition }
+
+case class UpdateAndCondition(update: UpdateExpression, condition: Option[RequestCondition] = None) {
+  val attributes: AttributeNamesAndValues = update.attributes |+| condition.map(_.attributes).orEmpty
+}

--- a/scanamo/src/test/scala/org/scanamo/request/RequestConditionTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/request/RequestConditionTest.scala
@@ -1,0 +1,18 @@
+package org.scanamo.request
+
+import org.scalatest.OptionValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scanamo.DynamoObject
+
+import scala.annotation.nowarn
+
+class RequestConditionTest extends AnyFunSpec with Matchers with OptionValues {
+  it("can try to support legacy code using the deprecated optional requestCondition.dynamoValues") {
+    val condition = RequestCondition("", AttributeNamesAndValues(Map.empty, DynamoObject.empty))
+
+    @nowarn("cat=deprecation")
+    val dynamoValues: Option[DynamoObject] = condition.dynamoValues // for legacy clients
+    dynamoValues.value shouldBe condition.attributes.values
+  }
+}

--- a/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/update/UpdateExpressionTest.scala
@@ -46,11 +46,11 @@ class UpdateExpressionTest extends AnyFunSpec with Matchers with org.scalatestpl
   val stringList = DynamoFormat[List[String]]
 
   it("should have all value placeholders in the expression") {
-    check((ue: UpdateExpression) => ue.attributeValues.keys.forall(s => ue.expression.contains(s)))
+    check((ue: UpdateExpression) => ue.attributes.values.keys.forall(s => ue.expression.contains(s)))
   }
 
   it("should have all name placeholders in the expression") {
-    check((ue: UpdateExpression) => ue.attributeNames.keys.forall(s => ue.expression.contains(s)))
+    check((ue: UpdateExpression) => ue.attributes.names.keys.forall(s => ue.expression.contains(s)))
   }
 
   it("append/prepend should wrap scalar values in a list") {


### PR DESCRIPTION
* **`RequestCondition` dynamo values become non-optional**: instead they can just be `DynamoObject.empty`
* **New class `AttributeNamesAndValues`**: we often combine the different sources of attribute names/values in a request (eg, 'update' and 'condition') and there's no point in repeatedly writing code where names are combined, and then _values_ are combined - we always want to aggregate both at the same time, now supported with `AttributeNamesAndValues`
* **New class `UpdateAndCondition`**: combines `UpdateExpression` & `Option[Condition]` - models the payload of both normal `UpdateItem` & transactional `Update` requests.
* Using the [lambda syntax for Single Abstract Method (SAM) types](https://www.scala-lang.org/news/2.12.0/#lambda-syntax-for-sam-types) in the implementation of many typeclass instances of `ConditionExpression` and `QueryableKeyCondition` (eg `QueryableKeyCondition[KeyEquals[V]]`) makes the implementations much shorter.

The 'values' on `RequestCondition` have been optional since `RequestCondition` was introduced with https://github.com/scanamo/scanamo/pull/31 in May 2016 - back then they were `attributeValues: Option[Map[String, AttributeValue]]`), later becoming `dynamoValues: Option[DynamoObject]` with https://github.com/scanamo/scanamo/pull/400 in May 2019.

The values are probably 'optional' because there are certain DynamoDB condition expression functions (like `attribute_exists()`) that _don't_ take a value, so it was _reasonable_ for implementations like `ConditionExpression[AttributeExists]` to create instances of `RequestCondition` where `dynamoValues` was `None`:

https://github.com/scanamo/scanamo/blob/93ab1e7e8292c79283b556e00389017beb8559c0/scanamo/src/main/scala/org/scanamo/query/ConditionExpression.scala#L180-L184

However, if we make `dynamoValues` non-optional, we can just supply `DynamoObject.empty` rather than `None`- and this allows us to simplify so much logic around combining the attribute values that come from different sources (eg as conditions are combined). Note that Cats [`Monoid`](https://typelevel.org/cats/typeclasses/monoid.html) typeclass can provide useful functionality like [`.orEmpty`](https://typelevel.org/cats/api/cats/syntax/OptionOps.html#orEmpty(implicitA:cats.Monoid[A]):A) that helps with this.

## Compatibility

### Classes with field changes

* **`ScanamoUpdateRequest`**: `updateExpression`, `attributeNames`, `dynamoValues`, `addEmptyList`, `condition` are all replaced by `UpdateAndCondition`
* **`TransactUpdateItem`**: `updateExpression`, `condition` are replaced by `UpdateAndCondition`
* **`RequestCondition`**: `attributeNames`, `dynamoValues` are replaced by `AttributeNamesAndValues`

### Affected code using Scanamo

Scanamo doesn't have a clear divide between internal code and external API, but `org.scanamo.request.RequestCondition` is not _explicitly_ part of the public API - it's not mentioned in the documentation at [www.scanamo.org/conditional-operations](https://www.scanamo.org/conditional-operations) for instance. Changing the type of `RequestCondition.dynamoValues` doesn't feel like it should break any user-code - it certainly didn't require any changes to Scanamo's tests, for instance.

However, doing a [search on GitHub](https://github.com/search?q=org.scanamo.request.RequestCondition+NOT+repo%3Ascanamo%2Fscanamo+NOT+is%3Afork&type=code) finds recent code in [github.com/nationalarchives](https://github.com/nationalarchives) that will break on this change - both call `requestCondition.dynamoValues.flatMap()`:

* https://github.com/nationalarchives/dr2-ingest/blob/9954492b605973b80f707be2fc5bb88981cc3889/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/Utils.scala#L138
* https://github.com/nationalarchives/da-aws-clients/blob/f46ad91eaca46f9ba293763f3da75e3ddd070c1f/dynamodb/src/main/scala/uk/gov/nationalarchives/DADynamoDBClient.scala#L248

### Support for legacy code that calls removed methods

For all 3 classes where fields have been removed with a better implementation, read-only _deprecated_ versions of those fields are now provided - so, for instance, you _can_ call `requestCondition.dynamoValues.flatMap()`, but `dynamoValues` will be deprecated.

Additionally, for each of `TransactUpdateItem` & `RequestCondition`, an [auxiliary constructor](https://docs.scala-lang.org/scala3/book/domain-modeling-tools.html#auxiliary-constructors) has been added which maintains the original constructor signature as a deprecated constructor. This wasn't done for `ScanamoUpdateRequest` as re-creating the `UpdateExpression` from the legacy arguments seemed Too Hard.

These deprecated methods will be left in the code for at least a year after this change is released - but they will deleted eventually!

