### PR TITLE
Add list-appending support to transactional `Update`s

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -141,11 +141,7 @@ package object ops {
         req.updateAndCondition.condition.fold(request)(condition => request.conditionExpression(condition.expression))
 
       req.updateAndCondition.attributes.values.toExpressionAttributeValues
-        .fold(requestWithCondition) { avs =>
-          if (req.updateAndCondition.update.addEmptyList)
-            avs.put(":emptyList", DynamoValue.EmptyList)
-          requestWithCondition.expressionAttributeValues(avs)
-        }
+        .fold(requestWithCondition)(requestWithCondition.expressionAttributeValues)
         .build
     }
 

--- a/scanamo/src/test/scala/org/scanamo/TableTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/TableTest.scala
@@ -142,7 +142,6 @@ class TableTest extends AnyFunSpec with Matchers with NonImplicitAssertions {
   }
 
   it("Appending or prepending creates the list if it does not yet exist:") {
-
     LocalDynamoDB.withRandomTable(client)("name" -> S) { t =>
       val characters = Table[Character](t)
       val operations = for {


### PR DESCRIPTION
This change makes list-appending support for `Update`s embedded in *transactions* consistent with the support in normal `UpdateItemRequest`s.

The injection of the necessary `:emptyList` attribute has moved from `update(req: ScanamoUpdateRequest): UpdateItemRequest` into the code of `UpdateExpression`, where it can be used for both transactional and non-transactional code.

# Context

DynamoDB update operations let you append to existing list attributes with the [`list_append()`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.SET.UpdatingListElements) function - however, if you're attempting to execute an update-append on an attribute that is not yet populated (eg the item does not even _exist_ yet), DynamoDB will return [this error](https://github.com/scanamo/scanamo/actions/runs/10456684309/job/28954565536#step:7:399):

```
The provided expression refers to an attribute that does not exist in the item
```

To get friendlier behaviour, in January 2017 Scanamo PR https://github.com/scanamo/scanamo/pull/80 (commit 75814f97637089844d072b2d3c785cdca535e9c1) provided an `if_not_exists()` check on the attribute, which effectively provides an empty list to append to if the attribute does not already exist. This code now lives inside the `LeafUpdateExpression` trait.

Initially the test for this functionality was a doctest, but was moved to a regular test (named _"Appending or prepending creates the list if it does not yet exist:"_) in TableTest.scala with https://github.com/scanamo/scanamo/pull/770.