### PR TITLE
Extend AWS SDK builders to ease `Option`-setting

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
+++ b/scanamo/src/main/scala/org/scanamo/ScanamoFree.scala
@@ -16,6 +16,7 @@
 
 package org.scanamo
 
+import cats.implicits.*
 import cats.{ Monad, MonoidK }
 import org.scanamo.DynamoResultStream.{ QueryResponseStream, ScanResponseStream }
 import org.scanamo.ops.ScanamoOps.Results.*
@@ -70,7 +71,7 @@ object ScanamoFree {
           batch,
           item =>
             WriteRequest.builder
-              .putRequest(PutRequest.builder.item(f.write(item).asObject.getOrElse(DynamoObject.empty).toJavaMap).build)
+              .putRequest(PutRequest.builder.item(f.write(item).asObject.orEmpty.toJavaMap).build)
               .build
         )
       }

--- a/scanamo/src/main/scala/org/scanamo/internal/aws/sdkv2/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/internal/aws/sdkv2/package.scala
@@ -1,0 +1,11 @@
+package org.scanamo.internal.aws
+
+import software.amazon.awssdk.utils.builder.Buildable
+
+package object sdkv2 {
+  implicit class RichBuilder[B <: Buildable](builder: B) {
+    def setOpt[V](opt: Option[V])(f: B => V => B): B = opt.foldLeft(builder) { (b, v) =>
+      f(b)(v)
+    }
+  }
+}

--- a/scanamo/src/main/scala/org/scanamo/ops/package.scala
+++ b/scanamo/src/main/scala/org/scanamo/ops/package.scala
@@ -16,9 +16,9 @@
 
 package org.scanamo
 
-import cats.data.NonEmptyList
 import cats.free.{ Free, FreeT }
 import cats.implicits.*
+import org.scanamo.internal.aws.sdkv2.*
 import org.scanamo.request.*
 import software.amazon.awssdk.services.dynamodb.model.*
 
@@ -30,118 +30,73 @@ package object ops {
     import collection.JavaConverters.*
 
     def scan(req: ScanamoScanRequest): ScanRequest = {
-      def queryRefinement[T](
-        o: ScanamoScanRequest => Option[T]
-      )(rt: (ScanRequest.Builder, T) => ScanRequest.Builder): ScanRequest.Builder => ScanRequest.Builder = { qr =>
-        o(req).foldLeft(qr)(rt)
-      }
+      val filterCondition: Option[RequestCondition] = req.options.filter.map(_.apply.runEmptyA.value)
 
-      NonEmptyList
-        .of(
-          queryRefinement(_.index)(_.indexName(_)),
-          queryRefinement(_.options.limit)(_.limit(_)),
-          queryRefinement(_.options.exclusiveStartKey)((r, k) => r.exclusiveStartKey(k.toJavaMap)),
-          queryRefinement(_.options.filter) { (r, f) =>
-            val requestCondition = f.apply.runEmptyA.value
-            val attributes = requestCondition.attributes
-            val builder =
-              r.filterExpression(requestCondition.expression).expressionAttributeNames(attributes.names.asJava)
-            attributes.values.toExpressionAttributeValues.foldLeft(builder)(_ expressionAttributeValues _)
-          }
-        )
-        .reduceLeft(_.compose(_))(
-          ScanRequest.builder.tableName(req.tableName).consistentRead(req.options.consistent)
-        )
+      ScanRequest.builder
+        .tableName(req.tableName)
+        .setOpt(req.index)(_.indexName)
+        .consistentRead(req.options.consistent)
+        .setOpt(req.options.limit)(b => b.limit(_))
+        .setOpt(req.options.exclusiveStartKey.map(_.toJavaMap))(_.exclusiveStartKey)
+        .setOpt(filterCondition) { b => condition =>
+          b.filterExpression(condition.expression)
+            .expressionAttributeNames(condition.attributes.names.asJava)
+            .setOpt(condition.attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
+        }
         .build
     }
 
     def query(req: ScanamoQueryRequest): QueryRequest = {
-      def queryRefinement[T](
-        f: ScanamoQueryRequest => Option[T]
-      )(g: (QueryRequest.Builder, T) => QueryRequest.Builder): QueryRequest.Builder => QueryRequest.Builder = { qr =>
-        f(req).foldLeft(qr)(g)
-      }
-
       val queryCondition: RequestCondition = req.query.apply
-      val requestCondition: Option[RequestCondition] = req.options.filter.map(_.apply.runEmptyA.value)
+      val filterCondition: Option[RequestCondition] = req.options.filter.map(_.apply.runEmptyA.value)
+      val attributes = queryCondition.attributes |+| filterCondition.map(_.attributes).orEmpty
 
-      val requestBuilder = NonEmptyList
-        .of(
-          queryRefinement(_.index)(_ indexName _),
-          queryRefinement(_.options.limit)(_ limit _),
-          queryRefinement(_.options.exclusiveStartKey.map(_.toJavaMap))(_ exclusiveStartKey _)
-        )
-        .reduceLeft(_ compose _)(
-          QueryRequest.builder
-            .tableName(req.tableName)
-            .consistentRead(req.options.consistent)
-            .scanIndexForward(req.options.ascending)
-            .keyConditionExpression(queryCondition.expression)
-        )
-
-      requestCondition.fold {
-        val requestWithCondition = requestBuilder.expressionAttributeNames(queryCondition.attributes.names.asJava)
-        queryCondition.attributes.values.toExpressionAttributeValues
-          .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
-      } { condition =>
-        val attributes = queryCondition.attributes |+| condition.attributes
-
-        val requestWithCondition = requestBuilder
-          .filterExpression(condition.expression)
-          .expressionAttributeNames(attributes.names.asJava)
-        attributes.values.toExpressionAttributeValues.foldLeft(requestWithCondition)(_ expressionAttributeValues _)
-      }.build
-    }
-
-    def put(req: ScanamoPutRequest): PutItemRequest = {
-      val request = PutItemRequest.builder
+      QueryRequest.builder
         .tableName(req.tableName)
-        .item(req.item.asObject.getOrElse(DynamoObject.empty).toJavaMap)
-        .returnValues(req.ret.asDynamoValue)
-
-      req.condition
-        .fold(request) { condition =>
-          val requestWithCondition = request
-            .conditionExpression(condition.expression)
-            .expressionAttributeNames(condition.attributes.names.asJava)
-
-          condition.attributes.values.toExpressionAttributeValues
-            .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
-        }
+        .setOpt(req.index)(_.indexName)
+        .consistentRead(req.options.consistent)
+        .setOpt(req.options.limit)(b => b.limit(_))
+        .setOpt(req.options.exclusiveStartKey.map(_.toJavaMap))(_.exclusiveStartKey)
+        .setOpt(filterCondition.map(_.expression))(_.filterExpression)
+        .expressionAttributeNames(attributes.names.asJava)
+        .setOpt(attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
+        .scanIndexForward(req.options.ascending)
+        .keyConditionExpression(queryCondition.expression)
         .build
     }
 
-    def delete(req: ScanamoDeleteRequest): DeleteItemRequest = {
-      val request = DeleteItemRequest.builder
-        .tableName(req.tableName)
-        .key(req.key.toJavaMap)
-        .returnValues(req.ret.asDynamoValue)
+    def put(req: ScanamoPutRequest): PutItemRequest = PutItemRequest.builder
+      .tableName(req.tableName)
+      .item(req.item.asObject.orEmpty.toJavaMap)
+      .returnValues(req.ret.asDynamoValue)
+      .setOpt(req.condition) { b => condition =>
+        b.conditionExpression(condition.expression)
+          .expressionAttributeNames(condition.attributes.names.asJava)
+          .setOpt(condition.attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
+      }
+      .build
 
-      req.condition
-        .fold(request) { condition =>
-          val requestWithCondition = request
-            .conditionExpression(condition.expression)
-            .expressionAttributeNames(condition.attributes.names.asJava)
-
-          condition.attributes.values.toExpressionAttributeValues
-            .foldLeft(requestWithCondition)(_ expressionAttributeValues _)
-        }
-        .build
-    }
+    def delete(req: ScanamoDeleteRequest): DeleteItemRequest = DeleteItemRequest.builder
+      .tableName(req.tableName)
+      .key(req.key.toJavaMap)
+      .returnValues(req.ret.asDynamoValue)
+      .setOpt(req.condition) { b => condition =>
+        b.conditionExpression(condition.expression)
+          .expressionAttributeNames(condition.attributes.names.asJava)
+          .setOpt(condition.attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
+      }
+      .build
 
     def update(req: ScanamoUpdateRequest): UpdateItemRequest = {
-      val request = UpdateItemRequest.builder
+      val attributes = req.updateAndCondition.attributes
+      UpdateItemRequest.builder
         .tableName(req.tableName)
         .key(req.key.toJavaMap)
-        .updateExpression(req.updateAndCondition.update.expression)
         .returnValues(ReturnValue.ALL_NEW)
-        .expressionAttributeNames(req.updateAndCondition.attributes.names.asJava)
-
-      val requestWithCondition =
-        req.updateAndCondition.condition.fold(request)(condition => request.conditionExpression(condition.expression))
-
-      req.updateAndCondition.attributes.values.toExpressionAttributeValues
-        .fold(requestWithCondition)(requestWithCondition.expressionAttributeValues)
+        .updateExpression(req.updateAndCondition.update.expression)
+        .setOpt(req.updateAndCondition.condition.map(_.expression))(_.conditionExpression)
+        .expressionAttributeNames(attributes.names.asJava)
+        .setOpt(attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
         .build
     }
 
@@ -150,53 +105,55 @@ package object ops {
         TransactWriteItem.builder
           .put(
             software.amazon.awssdk.services.dynamodb.model.Put.builder
-              .item(item.item.asObject.getOrElse(DynamoObject.empty).toJavaMap)
               .tableName(item.tableName)
+              .item(item.item.asObject.orEmpty.toJavaMap)
               .build
           )
           .build
       }
 
       val updateItems = req.updateItems.map { item =>
-        val update = software.amazon.awssdk.services.dynamodb.model.Update.builder
-          .tableName(item.tableName)
-          .updateExpression(item.updateAndCondition.update.expression)
-          .expressionAttributeNames(item.updateAndCondition.update.attributes.names.asJava)
-          .key(item.key.toJavaMap)
-
-        val updateWithAvs = item.updateAndCondition.update.attributes.values.toExpressionAttributeValues
-          .fold(update)(avs => update.expressionAttributeValues(avs))
+        val attributes = item.updateAndCondition.update.attributes
+        TransactWriteItem.builder
+          .update(
+            software.amazon.awssdk.services.dynamodb.model.Update.builder
+              .tableName(item.tableName)
+              .key(item.key.toJavaMap)
+              .updateExpression(item.updateAndCondition.update.expression)
+              .expressionAttributeNames(attributes.names.asJava)
+              .setOpt(attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
+              .build
+          )
           .build
-
-        TransactWriteItem.builder.update(updateWithAvs).build
       }
       val deleteItems = req.deleteItems.map { item =>
         TransactWriteItem.builder
           .delete(
             software.amazon.awssdk.services.dynamodb.model.Delete.builder
-              .key(item.key.toJavaMap)
               .tableName(item.tableName)
+              .key(item.key.toJavaMap)
               .build
           )
           .build
       }
 
       val conditionChecks = req.conditionCheck.map { item =>
-        val check = software.amazon.awssdk.services.dynamodb.model.ConditionCheck.builder
-          .key(item.key.toJavaMap)
-          .tableName(item.tableName)
-          .conditionExpression(item.condition.expression)
-          .expressionAttributeNames(item.condition.attributes.names.asJava)
-
-        val checkWithAvs = item.condition.attributes.values.toExpressionAttributeValues
-          .foldLeft(check)(_ expressionAttributeValues _)
+        val attributes = item.condition.attributes
+        TransactWriteItem.builder
+          .conditionCheck(
+            software.amazon.awssdk.services.dynamodb.model.ConditionCheck.builder
+              .tableName(item.tableName)
+              .key(item.key.toJavaMap)
+              .expressionAttributeNames(attributes.names.asJava)
+              .setOpt(attributes.values.toExpressionAttributeValues)(_.expressionAttributeValues)
+              .conditionExpression(item.condition.expression)
+              .build
+          )
           .build
-
-        TransactWriteItem.builder.conditionCheck(checkWithAvs).build
       }
 
       TransactWriteItemsRequest.builder
-        .transactItems((putItems ++ updateItems ++ deleteItems ++ conditionChecks): _*)
+        .transactItems(putItems ++ updateItems ++ deleteItems ++ conditionChecks: _*)
         .build
     }
   }


### PR DESCRIPTION
Scanamo's own Scala-based models of DynamoDB requests use [Scala's idiomatic approach to optional values](https://alvinalexander.com/scala/using-scala-option-some-none-idiom-function-java-null/) - use `Option` - but this repeatedly gives us a fiddly job when coping with the [fluent nature of the AWS SDK for Java](https://aws.amazon.com/blogs/developer/fluent-client-builders/), which chains methods on builders. We want to pretend that the builders aren't mutable (because if they were written in Scala, they wouldn't be mutable), and using the default methods on Option, the most concise way to do that for a builder is using `optionValue.foldLeft(builder)(builder.setter)` - which is _reasonably_ concise, but you'll notice that we're repeating `builder` twice, and it's not possible to chain together invocations of this - although it _produces_ an instance of builder, it doesn't _start_ from an instance of builder, so: no chaining.

This change introduces a `setOpt` extension method on all AWS SDK `Buildable`s:

https://github.com/scanamo/scanamo/blob/79370f2d09ad941d5fe25075ea8437498cb06db2/scanamo/src/main/scala/org/scanamo/internal/aws/sdkv2/package.scala#L6-L8

This provides a more concise optional-invocation of the builder's setter methods, while supporting the same fluent chaining that native builder setter methods use. `f: B => (V => B)` is used because [partial application](https://docs.scala-lang.org/tour/multiple-parameter-lists.html#partial-application) of the builder setter method in many cases allows us to use a single underscore rather than two - ie `.setOpt(req.index)(_.indexName)` rather than `.setOpt(req.index)(_ indexName _)` which we'd use if we had `f: (B, V) => B`.

Because the builder type `B` is a type-parameter, it's also more flexible than the `queryRefinement()` method that was duplicated in `scan(req: ScanamoScanRequest)` & `query(req: ScanamoQueryRequest)` until now:

https://github.com/scanamo/scanamo/blob/dcc4b4bf35904a0a4b6324525ef3ffd834db27e1/scanamo/src/main/scala/org/scanamo/ops/package.scala#L33-L37

...those can now be replaced with the single `setOpt()` implementation.

The result is code that's more readable, with a good reduction in line-count! ✨ 

<img width="220" alt="image" src="https://github.com/user-attachments/assets/b6d43565-8301-42a8-9ab9-c2368f0f6ba3">

# Inspecting the diff

This diff is best inspected in split configuration, with whitespace changes ignored: https://github.com/scanamo/scanamo/pull/1799/files?diff=split&w=1

I've gone through and visually inspected to check that all setting-of-fields has been copied over - of course, we hope that the tests would have caught it if any field setting _had_ been lost.
