### PR TITLE
Compile `refined` module under Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: >
           sbt ++${{ matrix.scala-version }}
           startDynamodbLocal
-          scanamo/test catsEffect/test joda/test pekko/test zio/test
+          test
           dynamodbLocalTestCleanup
           stopDynamodbLocal
       - name: cleanup

--- a/build.sbt
+++ b/build.sbt
@@ -139,11 +139,11 @@ lazy val refined = (project in file("refined"))
     commonSettings,
     publishingSettings,
     name := "scanamo-refined",
-    crossScalaVersions := scala2xVersions
+    crossScalaVersions := allCrossVersions
   )
   .settings(
     libraryDependencies ++= Seq(
-      "eu.timepit"    %% "refined"   % "0.11.1",
+      "eu.timepit"    %% "refined"   % "0.11.2",
       scalaTest
     )
   )


### PR DESCRIPTION
Support for `refined` was added to Scanamo with https://github.com/scanamo/scanamo/pull/182 in January 2018, but unfortunately upgrading the module to compile with Scala 3 does not work, as the tests [don't compile](https://github.com/scanamo/scanamo/actions/runs/10560310173/job/29253513792?pr=1804#step:7:487):

```
[error] -- [E007] Type Mismatch Error: /home/runner/work/scanamo/scanamo/refined/src/test/scala/org/scanamo/refined/RefinedDynamoFormatSpec.scala:19:29 
[error] 19 |    valueRead shouldBe Right(10: PosInt)
[error]    |                             ^^
[error]    |                           Found:    (10 : Int)
[error]    |                           Required: RefinedDynamoFormatSpec.this.PosInt
```

This appears to be due to https://github.com/fthomas/refined/issues/932 - implementing `refined`s macros in Scala 3 doesn't seem to be simple, and also `refineMV` has been removed, [without clear documentation on alternatives](https://github.com/fthomas/refined/issues/932#issuecomment-1291771535).

These problems with `refined` under Scala 3 do make me consider whether Scanamo's `refined` module should be removed, allowing me to simplify Scanamo's build, and reduce maintenance burden.