### PR TITLE
Pekko: Support Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: >
           sbt ++${{ matrix.scala-version }}
           startDynamodbLocal
-          scanamo/test catsEffect/test joda/test
+          scanamo/test catsEffect/test joda/test pekko/test
           dynamodbLocalTestCleanup
           stopDynamodbLocal
       - name: cleanup

--- a/build.sbt
+++ b/build.sbt
@@ -229,7 +229,7 @@ lazy val zio = (project in file("zio"))
 lazy val pekko = (project in file("pekko"))
   .settings(
     commonSettings,
-    crossScalaVersions := scala2xVersions,
+    crossScalaVersions := allCrossVersions,
     publishingSettings,
     name := "scanamo-pekko"
   )

--- a/pekko/src/test/scala/org/scanamo/ScanamoPekkoSpec.scala
+++ b/pekko/src/test/scala/org/scanamo/ScanamoPekkoSpec.scala
@@ -11,12 +11,13 @@ import org.scanamo.fixtures.*
 import org.scanamo.generic.auto.*
 import org.scanamo.ops.ScanamoOps
 import org.scanamo.query.*
-import org.scanamo.syntax.*
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.*
 
 import scala.concurrent.ExecutionContext
 
 class ScanamoPekkoSpec extends AnyFunSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
+  import org.scanamo.syntax.* // here for Scala 3, otherwise we get `===` from org.scalactic.TripleEqualsSupport
+
   implicit val system: ActorSystem = ActorSystem("scanamo-pekko")
 
   implicit val executor: ExecutionContext = system.dispatcher


### PR DESCRIPTION
Scala 3 support was added to Scanamo with https://github.com/scanamo/scanamo/pull/1577 / https://github.com/scanamo/scanamo/pull/1596 in November 2022, but as mentioned in that 2nd PR, we only enabled Scala 3 support for Scanamo subprojects where it was nice & easy to do so - amongst others, that excluded Alpakka (the predecessor to Pekko, originally added to Scanamo with https://github.com/scanamo/scanamo/pull/151 in October 2017).

When Pekko was added to Scanamo (porting the Alpakka support) with https://github.com/scanamo/scanamo/pull/1660 in September 2023, it retained the constraint of not supporting Scala 3 - we're fixing that here.

* Scala 3 cross-compilation enabled for the Pekko project
* Pekko tests enabled under the Scala 3 CI builds
* [Fixed compilation error in `ScanamoPekko`](https://github.com/scanamo/scanamo/pull/1805/files#r1731496767) relating to Scala 3's syntax for wildcard arguments in types - we can switch to the `Pekko[A]` type alias for `Source[A, NotUsed]` and avoid specifying the unwanted type parameters anyhow. 
* [Fix compilation error in `ScanamoPekkoSpec`](https://github.com/scanamo/scanamo/pull/1805/files#r1731491275) due to changed implicit precedence in Scala 3 which led to the wrong `===` method being selected - using one from `TripleEqualsSupport` in Scalactic rather than our own Scanamo one. 