### PR TITLE
ZIO: Support Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: >
           sbt ++${{ matrix.scala-version }}
           startDynamodbLocal
-          scanamo/test catsEffect/test joda/test pekko/test
+          scanamo/test catsEffect/test joda/test pekko/test zio/test
           dynamodbLocalTestCleanup
           stopDynamodbLocal
       - name: cleanup

--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val zio = (project in file("zio"))
   .settings(
     name := "scanamo-zio",
     commonSettings,
-    crossScalaVersions := scala2xVersions,
+    crossScalaVersions := allCrossVersions,
     publishingSettings,
     libraryDependencies ++= List(
       awsDynamoDB,

--- a/zio/src/main/scala/org/scanamo/ScanamoZio.scala
+++ b/zio/src/main/scala/org/scanamo/ScanamoZio.scala
@@ -29,11 +29,11 @@ class ScanamoZio private (client: DynamoDbAsyncClient)
 
 object ScanamoZio {
   type DIO[+A] = IO[DynamoDbException, A]
+  type DStream[+A] = Stream[DynamoDbException, A]
 
   def apply(client: DynamoDbAsyncClient): ScanamoZio = new ScanamoZio(client)
 
-  val ToStream: IO[DynamoDbException, *] ~> Stream[DynamoDbException, *] =
-    new (IO[DynamoDbException, *] ~> Stream[DynamoDbException, *]) {
-      def apply[A](fa: IO[DynamoDbException, A]): Stream[DynamoDbException, A] = ZStream.fromEffect(fa)
-    }
+  val ToStream: DIO ~> DStream = new (DIO ~> DStream) {
+    def apply[A](fa: DIO[A]): DStream[A] = ZStream.fromEffect(fa)
+  }
 }

--- a/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
+++ b/zio/src/test/scala/org/scanamo/ScanamoZioSpec.scala
@@ -7,7 +7,6 @@ import org.scanamo.fixtures.*
 import org.scanamo.generic.auto.*
 import org.scanamo.ops.ScanamoOps
 import org.scanamo.query.*
-import org.scanamo.syntax.*
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.*
 import zio.Runtime.default.*
@@ -15,6 +14,8 @@ import zio.stream.interop.catz.*
 import zio.stream.{ Sink, Stream }
 
 class ScanamoZioSpec extends AnyFunSpec with Matchers {
+  import org.scanamo.syntax.* // here for Scala 3, otherwise we get `===` from org.scalactic.TripleEqualsSupport
+
   val client = LocalDynamoDB.client()
   val zio = ScanamoZio(client)
 


### PR DESCRIPTION
_This is very similar to PR https://github.com/scanamo/scanamo/pull/1805, which added Scala 3 support to Scanamo's **Pekko** subproject._

Scala 3 support was added to Scanamo with https://github.com/scanamo/scanamo/pull/1577 / https://github.com/scanamo/scanamo/pull/1596 in November 2022, but as mentioned in that 2nd PR, we only enabled Scala 3 support for Scanamo subprojects where it was nice & easy to do so - amongst others, that excluded ZIO (originally added to Scanamo with https://github.com/scanamo/scanamo/pull/262 in October 2018).

* Scala 3 cross-compilation enabled for the ZIO project
* ZIO tests enabled under the Scala 3 CI builds
* [Fixed compilation error in `ScanamoZio`](https://github.com/scanamo/scanamo/pull/1806#discussion_r1733285974) relating to Scala 3's syntax for wildcard arguments in types
* [Fix compilation error in `ScanamoZioSpec`](https://github.com/scanamo/scanamo/pull/1806#discussion_r1733291228) due to changed implicit precedence in Scala 3 which led to the wrong `===` method being selected - using one from `TripleEqualsSupport` in Scalactic rather than our own Scanamo one. 