### PR TITLE
Update AWS SDK as a demo for Scala.io!

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,7 @@ lazy val root = (project in file("."))
     stopDynamoDBLocal / aggregate := false
   )
 
-val awsDynamoDB = "software.amazon.awssdk" % "dynamodb" % "2.26.31"
+val awsDynamoDB = "software.amazon.awssdk" % "dynamodb" % "2.29.6"
 
 lazy val scanamo = (project in file("scanamo"))
   .settings(


### PR DESCRIPTION
Normally I'd let Scala Steward do this, but this allows us to demo [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow).