### PR TITLE
Use `guardian/setup-scala` to cope with Ubuntu changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup JDK
-        uses: actions/setup-java@v4
+      - uses: guardian/setup-scala@v1
         with:
-          distribution: 'corretto'
-          java-version: ${{ matrix.java-version }}
-          cache: sbt
+            major-java-version: ${{ matrix.java-version }}
       - name: lint
         run: >
           sbt ++${{ matrix.scala-version }}
@@ -55,5 +52,6 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
+      - uses: guardian/setup-scala@v1
       - name: test docs
         run: sbt +doc


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10636 removed `sbt` from the `ubuntu-latest` image - hence the need for https://github.com/sbt/setup-sbt - or, as we use at the Guardian,  https://github.com/guardian/setup-scala which combines [`setup-java`](https://github.com/actions/setup-java) & [`setup-sbt`](https://github.com/sbt/setup-sbt) with good defaults for us.

To use `guardian/setup-scala` with Scanamo, I needed to update it with this PR to support the way the Scanamo CI build uses GitHub runner matrix to vary the `java` version:

* https://github.com/guardian/setup-scala/pull/1
