### PR TITLE
Example fix for memory issue

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -298,7 +298,7 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
     that match {
       case other: DynamoObject =>
         // Pure FP approach: pattern match on types without extracting fields
-        // This avoids calling the case class's auto-generated equals() which causes recursion
+        // This avoids triggering the expensive internalToMap conversion when comparing objects of the same concrete type
         (self, other) match {
           case (_: Empty.type, _: Empty.type) =>
             true

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -302,6 +302,14 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
         (self, other) match {
           case (_: Empty.type, _: Empty.type) =>
             true
+          case (_: Empty.type, other: Strict) =>
+            other.xs.isEmpty
+          case (self: Strict, _: Empty.type) =>
+            self.xs.isEmpty
+          case (_: Empty.type, other: Pure) =>
+            other.xs.isEmpty
+          case (self: Pure, _: Empty.type) =>
+            self.xs.isEmpty
           case (self: Strict, other: Strict) =>
             // Access fields after matching to avoid case class equals recursion
             self.xs == other.xs

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -323,12 +323,7 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
     }
 
   final override def hashCode(): Int =
-    self match {
-      case _: Empty.type => 0
-      case self: Strict => self.xs.hashCode()
-      case self: Pure => self.xs.hashCode()
-      case _ => internalToMap.hashCode
-    }
+    internalToMap.hashCode()
 }
 
 object DynamoObject {
@@ -339,7 +334,7 @@ object DynamoObject {
     // Lazy memoization - only computed if internalToMap is actually needed (e.g., mixed-type comparison)
     // This is a safety net for the rare case where Strict is compared to Concat or other mixed types
     @transient private[this] lazy val _internalToMap: Map[String, DynamoValue] =
-      unsafeToScalaMap(xs).view.mapValues(DynamoValue.fromAttributeValue).toMap
+      unsafeToScalaMap(xs).map { case (k, v) => (k, DynamoValue.fromAttributeValue(v)) }
 
     final def internalToMap: Map[String, DynamoValue] = _internalToMap
   }

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -313,7 +313,7 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
           case (_: Empty.type, other: Concat) =>
             other.xs.isEmpty && other.ys.isEmpty
           case (self: Concat, _: Empty.type) =>
-            self.xs.isEmpty && other.ys.isEmpty
+            self.xs.isEmpty && self.ys.isEmpty
           case (self: Strict, other: Strict) =>
             // Access fields after matching to avoid case class equals recursion
             self.xs == other.xs

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -297,8 +297,8 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
   final override def equals(that: Any): Boolean =
     that match {
       case other: DynamoObject =>
-        // Pure FP approach: pattern match on types without extracting fields
-        // This avoids triggering the expensive internalToMap conversion when comparing objects of the same concrete type
+        // Having all these explicit cases is a performance optimization to avoid, if possible,
+        // falling into the final case which calls the expensive internalToMap on both sides.
         (self, other) match {
           case (_: Empty.type, _: Empty.type) =>
             true
@@ -315,7 +315,6 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
           case (self: Concat, _: Empty.type) =>
             self.xs.isEmpty && self.ys.isEmpty
           case (self: Strict, other: Strict) =>
-            // Access fields after matching to avoid case class equals recursion
             self.xs == other.xs
           case (self: Pure, other: Pure) =>
             self.xs == other.xs

--- a/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoObject.scala
@@ -310,11 +310,17 @@ sealed abstract class DynamoObject extends Product with Serializable { self =>
             other.xs.isEmpty
           case (self: Pure, _: Empty.type) =>
             self.xs.isEmpty
+          case (_: Empty.type, other: Concat) =>
+            other.xs.isEmpty && other.ys.isEmpty
+          case (self: Concat, _: Empty.type) =>
+            self.xs.isEmpty && other.ys.isEmpty
           case (self: Strict, other: Strict) =>
             // Access fields after matching to avoid case class equals recursion
             self.xs == other.xs
           case (self: Pure, other: Pure) =>
             self.xs == other.xs
+          case (self: Concat, other: Concat) =>
+            self.xs == other.xs && self.ys == other.ys
           case _ =>
             // Fall back for mixed types (e.g., Strict vs Concat)
             internalToMap == other.internalToMap

--- a/scanamo/src/test/scala/org/scanamo/DynamoObjectPerformanceTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/DynamoObjectPerformanceTest.scala
@@ -20,7 +20,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
-import java.util.{HashMap => JHashMap}
+import java.util.{ HashMap => JHashMap }
 
 class DynamoObjectPerformanceTest extends AnyFunSpec with Matchers {
 
@@ -126,4 +126,3 @@ class DynamoObjectPerformanceTest extends AnyFunSpec with Matchers {
     }
   }
 }
-

--- a/scanamo/src/test/scala/org/scanamo/DynamoObjectPerformanceTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/DynamoObjectPerformanceTest.scala
@@ -49,7 +49,7 @@ class DynamoObjectPerformanceTest extends AnyFunSpec with Matchers {
       // In the buggy version, this causes internalToMap to be called repeatedly
 
       // Access fields many times to amplify the problem
-      val iterations = 50000
+      val iterations = 500000
 
       val startTime = System.nanoTime()
 

--- a/scanamo/src/test/scala/org/scanamo/DynamoObjectPerformanceTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/DynamoObjectPerformanceTest.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Scanamo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scanamo
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+
+import java.util.{HashMap => JHashMap}
+
+class DynamoObjectPerformanceTest extends AnyFunSpec with Matchers {
+
+  describe("DynamoObject field access performance") {
+    it("should not cause excessive memory allocation when accessing fields from Strict representation") {
+      // Create a Strict DynamoObject that simulates data coming from DynamoDB
+      // This mimics what happens when you query a secondary index with 20 attributes
+      val javaMap = new JHashMap[String, AttributeValue]()
+
+      // Simulate 20 attributes like in the user's case
+      (1 to 20).foreach { i =>
+        javaMap.put(s"field$i", AttributeValue.builder.s(s"value$i").build)
+      }
+
+      // Add some nested objects to make it more realistic
+      val nestedMap = new JHashMap[String, AttributeValue]()
+      nestedMap.put("nestedField1", AttributeValue.builder.s("nestedValue1").build)
+      nestedMap.put("nestedField2", AttributeValue.builder.n("42").build)
+      javaMap.put("nested", AttributeValue.builder.m(nestedMap).build)
+
+      // Create DynamoObject - this will wrap in Strict
+      val dynamoObject = DynamoObject(javaMap)
+
+      // Simulate what happens during case class derivation:
+      // Each field access triggers pattern matching which calls equals()
+      // In the buggy version, this causes internalToMap to be called repeatedly
+
+      // Access fields many times to amplify the problem
+      val iterations = 50000
+
+      val startTime = System.nanoTime()
+
+      (1 to iterations).foreach { _ =>
+        // Access all 20 fields - this is what Derivation.decodeField does
+        (1 to 20).foreach { i =>
+          val fieldValue = dynamoObject(s"field$i")
+          fieldValue shouldBe defined
+        }
+
+        // Access nested field
+        val nestedValue = dynamoObject("nested")
+        nestedValue shouldBe defined
+      }
+
+      val endTime = System.nanoTime()
+      val durationMs = (endTime - startTime) / 1000000
+
+      println(s"Field access test completed in ${durationMs}ms for ${iterations} iterations")
+      println(s"Average time per iteration: ${durationMs.toDouble / iterations}ms")
+
+      // The test should complete, but when profiled, the buggy version will show:
+      // - Heavy allocation in Strict.internalToMap
+      // - unsafeToScalaMap being called repeatedly
+      // - DynamoValue.fromAttributeValue being called for all fields repeatedly
+
+      // With the fix, these allocations should be minimal since equals() will
+      // compare Java maps directly without conversion
+    }
+
+    it("should demonstrate the equals performance issue") {
+      // This test explicitly shows that equals() is the problem
+      val javaMap1 = new JHashMap[String, AttributeValue]()
+      val javaMap2 = new JHashMap[String, AttributeValue]()
+
+      // Create identical maps with 20 fields
+      (1 to 20).foreach { i =>
+        val av = AttributeValue.builder.s(s"value$i").build
+        javaMap1.put(s"field$i", av)
+        javaMap2.put(s"field$i", av)
+      }
+
+      val obj1 = DynamoObject(javaMap1)
+      val obj2 = DynamoObject(javaMap2)
+
+      // Compare them many times
+      val iterations = 100000
+
+      val startTime = System.nanoTime()
+
+      var equalCount = 0
+      (1 to iterations).foreach { _ =>
+        if (obj1 == obj2) equalCount += 1
+      }
+
+      val endTime = System.nanoTime()
+      val durationMs = (endTime - startTime) / 1000000
+
+      println(s"Equals test completed in ${durationMs}ms for ${iterations} iterations")
+      println(s"Average time per comparison: ${durationMs.toDouble / iterations}ms")
+      println(s"Objects were equal ${equalCount} times")
+
+      equalCount shouldBe iterations
+
+      // In the buggy version, profiling will show:
+      // - internalToMap being called twice per comparison (once for each object)
+      // - Full conversion of Java map to Scala map each time
+      // - Heavy allocation in unsafeToScalaMap and mapValues
+
+      // With the fix:
+      // - equals() will directly compare the Java maps (xs == ys)
+      // - No conversion, just Java HashMap.equals()
+      // - Dramatically less allocation and faster execution
+    }
+  }
+}
+

--- a/scanamo/src/test/scala/org/scanamo/DynamoValueTest.scala
+++ b/scanamo/src/test/scala/org/scanamo/DynamoValueTest.scala
@@ -19,6 +19,10 @@ class DynamoObjectTest extends Properties("DynamoValue") with DynamoValueInstanc
   property("associativity") = forAll { (x: DynamoObject, y: DynamoObject, z: DynamoObject) =>
     (x <> y) <> z == x <> (y <> z)
   }
+
+  property("equals/hashCode contract") = forAll { (x: DynamoObject, y: DynamoObject) =>
+    if (x == y) x.hashCode == y.hashCode else true
+  }
 }
 
 private[scanamo] trait DynamoValueInstances extends DynamoObjectInstances with DynamoArrayInstances {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "5.0.1-SNAPSHOT"
+ThisBuild / version := "5.0.3-SNAPSHOT"


### PR DESCRIPTION
This is _an example_ of how we might fix #1829 by changing the `equals` method inside `Strict` so that it doesn't inadvertently trigger the creation of a map, which was causing huge memory and performance problems for me.

I suspect this needs a tweak or two by someone with a better understanding of Scanamo than I have.

The profile flame graph revealed that a ton of time and memory was spent in:

```
Derivation ... readObject(...)
   Derivation ... decodeField(...)
      DynamoObject.apply(s: String)  <-- Getting an attribute, so happening for every field, and doing a pattern match on subtype
         DynamoObject.equals             <-- Triggered by the pattern match 
            DynamoObject$String.internalToMap  <-- Happens every time for the Strict subtype, so I think creating two maps for every field access!!!
```

I've changed the equals so it only uses internalToMap when comparing different subtypes of DynamoObject.  Also, the Strict's `internalToMap`, once computed, need never be computed again, so it's memoized.

All tests pass, but this needs careful review by someone who understands Scanamo better than me.

I've included a throw-away test that I used to process 500K objects and profile to see that the memory allocation was down (~9GB to ~60MB!).  I'm not sure if there's a good way to make a memory-related test which can be committed to main.