### PR TITLE
Replicating limit fix to scanM too

### DIFF
--- a/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
+++ b/scanamo/src/main/scala/org/scanamo/DynamoResultStream.scala
@@ -70,7 +70,7 @@ private[scanamo] trait DynamoResultStream[Req, Res] {
         if (results.isEmpty)
           FreeT.liftT(M.empty)
         else {
-          val l1 = limit(req).fold(pageSize)(l => Math.min(pageSize, l - results.length))
+          val l1 = limit(req).fold(pageSize)(l => Math.min(pageSize, l - scannedCount(res).getOrElse(0)))
           lastEvaluatedKey(res)
             .filterNot(_ => l1 <= 0)
             .foldLeft(FreeT.pure[ScanamoOpsA, M, List[Either[DynamoReadError, T]]](results))((res, k) =>


### PR DESCRIPTION
Replicating the fix that @regiskuckaertz did in #996, that doesn't apply to `scanPaginatedM` and similar [as it's been noted here](https://github.com/scanamo/scanamo/issues/987#issuecomment-1798237666)